### PR TITLE
test structure for symptom status manager

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -227,7 +227,7 @@ impl Default for Params {
             probability_mild_given_infect: 0.0,
             infect_to_mild_mu: 0.0,
             infect_to_mild_sigma: 0.0,
-            probability_severe_given_mild: 0.1,
+            probability_severe_given_mild: 0.0,
             mild_to_severe_mu: 0.0,
             mild_to_severe_sigma: 0.0,
             mild_to_resolved_mu: 0.0,

--- a/src/symptom_status_manager.rs
+++ b/src/symptom_status_manager.rs
@@ -152,8 +152,8 @@ mod test {
         next_status: SymptomStatus,
         expected_proportion: f64,
     ) {
-        // We start with 1 person and simulate infecting them 5000 times, we should see that the proportion of time
-        // that they have transition from their current symptom status to their next symtpom status is close to the expected probability provided.
+        // We perform 5000 simulations with 1 person per simulation to check that the proportion of persons
+        // who transition from their current symptom status to their next symptom status is close to the expected probability.
         // We use a large number of simulations since the outcome is stochastic.
         let num_sims = 5000;
         let count = Rc::new(RefCell::new(0usize));
@@ -244,9 +244,9 @@ mod test {
         expected_mu: f64,
         expected_sigma: f64,
     ) {
-        // We start with 1 person and simulate infecting them 5000 times, we should see that the distribution of duration is equivalent
-        // to the expected distribution provided. We use a large number of simulations since the outcome is stochastic and we want to
-        // get a good estimate of the distribution.
+        // We run 5000 simulations with 1 person per simulation and get the duration of the delay between the specified symptom statuses.
+        // We calculate across simulations the mean of these delays and compare to the mean of the expected distribution.
+        // We need to run many simulations to get a precise estimate of the mean.
         let num_sims = 5000;
         let durations = Rc::new(RefCell::new(Vec::new()));
         for seed in 0..num_sims {
@@ -345,7 +345,7 @@ mod test {
 
     #[test]
     #[allow(clippy::cast_precision_loss)]
-    fn test_proportion_infected_mild() {
+    fn test_proportion_infected_to_mild() {
         test_proportion(SymptomStatus::NoSymptoms, SymptomStatus::Mild, 0.3);
     }
 
@@ -366,17 +366,17 @@ mod test {
 
     #[test]
     fn test_proportion_severe_to_resolved() {
-        test_proportion(SymptomStatus::Severe, SymptomStatus::Resolved, 0.5);
+        test_proportion(SymptomStatus::Severe, SymptomStatus::Resolved, 0.3);
     }
 
     #[test]
     fn test_proportion_critical_to_dead() {
-        test_proportion(SymptomStatus::Critical, SymptomStatus::Dead, 0.5);
+        test_proportion(SymptomStatus::Critical, SymptomStatus::Dead, 0.3);
     }
 
     #[test]
     fn test_proportion_critical_to_resolved() {
-        test_proportion(SymptomStatus::Critical, SymptomStatus::Resolved, 0.5);
+        test_proportion(SymptomStatus::Critical, SymptomStatus::Resolved, 0.3);
     }
 
     #[test]


### PR DESCRIPTION
This PR implements tests for the `symptom_status_manager` module. Currently, two generic tests are written to test the transition probabilities between symptom statuses, and to test the duration of time an individual is in the symptom status states. These generic tests can directly test all transitions and durations by specifying transition (current status -> next status) and the parameters defining the transition. An important note for the duration tests is that they should be KS tests but currently only compare the means.  `rand_distr` does not implement a `cdf` method for distributions. A reasonable approach maybe to use `statrs` distributions which does implement a `cdf` method to compare distributions.