### PR TITLE
Implementing deaths 

### DIFF
--- a/input/input.json
+++ b/input/input.json
@@ -10,7 +10,7 @@
         },
         "infectiousness_rate_fn": {"Constant": {
                 "rate": 1.0,
-                "duration": 10.0
+                "duration": 5.0
             }
         },
         "probability_mild_given_infect": 0.7,

--- a/input/input.json
+++ b/input/input.json
@@ -10,7 +10,7 @@
         },
         "infectiousness_rate_fn": {"Constant": {
                 "rate": 1.0,
-                "duration": 5.0
+                "duration": 10.0
             }
         },
         "probability_mild_given_infect": 0.7,

--- a/scripts/plot_outputs.py
+++ b/scripts/plot_outputs.py
@@ -35,3 +35,17 @@ plt.xlabel("Day")
 plt.ylabel("Number of people")
 plt.tight_layout()
 plt.show()
+
+# Symptom curves
+symp_plot = person_property_report.group_by(["t", "symptom_status"]).agg(
+    pl.col("count").sum()
+)
+
+plt.figure(figsize=(10, 6))
+sns.lineplot(
+    data=symp_plot.to_pandas(), x="t", y="count", hue="symptom_status"
+)
+plt.xlabel("Day")
+plt.ylabel("Number of people")
+plt.tight_layout()
+plt.show()

--- a/src/death.rs
+++ b/src/death.rs
@@ -14,7 +14,7 @@ pub trait ContextDeathExt: PluginContext + ContextEntitiesExt {
 
     /// Adds a plan for the given person if and only if that person is
     /// alive when the plan comes due.
-    fn add_plan_for_person(
+    fn add_plan_if_alive(
         &mut self,
         person_id: PersonId,
         time: f64,
@@ -33,6 +33,8 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
     context.subscribe_to_event(
         move |context, event: PropertyChangeEvent<Person, SymptomStatus>| {
             if event.current == SymptomStatus::Dead {
+                // When the person's symptom status changes to Dead, we set their Alive property to false and remove them from all settings.
+                // If the person is currently infectious, we also immediately transition them to recovered.
                 context.set_property::<Person, Alive>(event.entity_id, Alive(false));
                 context.remove_person_from_settings(event.entity_id);
                 if context.get_property::<Person, InfectionStatus>(event.entity_id)
@@ -48,6 +50,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
 
 #[cfg(test)]
 mod test {
+    use core::panic;
     use std::{cell::RefCell, rc::Rc};
 
     use ixa::{ExecutionPhase, prelude::*};
@@ -135,24 +138,11 @@ mod test {
         let person_id: PersonId = context.add_entity((Age(30),)).unwrap();
         symptom_status_manager::init(&mut context).unwrap();
         init(&mut context).unwrap();
-        // We schedule the person to be set to dead at time 0.0,
+        // We set the person to be dead,
         // and then we check their alive status both before and after the death event is processed.
-        context.add_plan_with_phase(
-            0.0,
-            move |context| {
-                assert!(context.is_alive(person_id));
-                context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
-            },
-            ExecutionPhase::First,
-        );
-        context.add_plan_with_phase(
-            0.0,
-            move |context| {
-                assert!(!context.is_alive(person_id));
-            },
-            ExecutionPhase::Last,
-        );
+        context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
         context.execute();
+        assert!(!context.is_alive(person_id));
     }
 
     #[test]
@@ -165,36 +155,24 @@ mod test {
         set_homogeneous_mixing_itinerary(&mut context, person_id).unwrap();
         symptom_status_manager::init(&mut context).unwrap();
         init(&mut context).unwrap();
-        // We schedule the person to be set to dead at time 0.0,
+        // We set the person to be dead
         // and then we check that they are removed from the homogeneous mixing setting after the death event is processed.
-        context.add_plan_with_phase(
-            0.0,
-            move |context| {
-                assert!(context.is_alive(person_id));
-                assert!(
-                    context
-                        .get_setting_members(&SettingId::new(HomogeneousMixing, 0))
-                        .unwrap()
-                        .contains(&person_id)
-                );
-                context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
-            },
-            ExecutionPhase::First,
+        assert!(context.is_alive(person_id));
+        assert!(
+            context
+                .get_setting_members(&SettingId::new(HomogeneousMixing, 0))
+                .unwrap()
+                .contains(&person_id)
         );
-        context.add_plan_with_phase(
-            0.0,
-            move |context| {
-                assert!(!context.is_alive(person_id));
-                assert!(
-                    !context
-                        .get_setting_members(&SettingId::new(HomogeneousMixing, 0))
-                        .unwrap()
-                        .contains(&person_id)
-                );
-            },
-            ExecutionPhase::Last,
-        );
+        context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
         context.execute();
+        assert!(!context.is_alive(person_id));
+        assert!(
+            !context
+                .get_setting_members(&SettingId::new(HomogeneousMixing, 0))
+                .unwrap()
+                .contains(&person_id)
+        );
     }
 
     #[test]
@@ -207,34 +185,26 @@ mod test {
         infection_propagation_loop::init(&mut context).unwrap();
         symptom_status_manager::init(&mut context).unwrap();
         init(&mut context).unwrap();
-        // We schedule the person to be set to dead at time 0.0,
-        // and then we check that their infection status does not change to recovered after the death event is processed.
-        context.add_plan_with_phase(
-            0.0,
-            move |context| {
-                assert!(context.is_alive(person_id));
-                context.infect_person(person_id, None, None, None);
-                context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
-            },
-            ExecutionPhase::First,
-        );
-        context.subscribe_to_event::<PropertyChangeEvent<Person, InfectionStatus>>(
-            move |context, event| {
-                if event.current == InfectionStatus::Recovered {
-                    match context.get_property::<Person, InfectionData>(event.entity_id) {
-                        InfectionData::Recovered {
-                            infection_time,
-                            recovery_time,
-                        } => {
-                            assert_eq!(infection_time, recovery_time);
-                        }
-                        InfectionData::Susceptible => {}
-                        InfectionData::Infectious { .. } => {}
-                    }
-                }
-            },
-        );
+        // We set the person to be infectious and then immediately set them to dead
+        // and then we check that their infection status changes to recovered after the death event is processed.
+        assert!(context.is_alive(person_id));
+        context.infect_person(person_id, None, None, None);
+        context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
         context.execute();
+        match context.get_property::<Person, InfectionData>(person_id) {
+            InfectionData::Recovered {
+                infection_time,
+                recovery_time,
+            } => {
+                assert_eq!(infection_time, recovery_time);
+            }
+            InfectionData::Susceptible => {
+                panic!("Person should not be susceptible after being infected and then dying")
+            }
+            InfectionData::Infectious { .. } => {
+                panic!("Person should not be infectious after being infected and then dying")
+            }
+        }
     }
 
     #[test]

--- a/src/death.rs
+++ b/src/death.rs
@@ -1,0 +1,288 @@
+use ixa::{Context, IxaError, plan::PlanId, prelude::*};
+
+use crate::{
+    infectiousness_manager::{InfectionContextExt, InfectionStatus},
+    population_loader::{Alive, Person, PersonId},
+    settings::ContextSettingExt,
+    symptom_status_manager::SymptomStatus,
+};
+
+pub trait ContextDeathExt: PluginContext + ContextEntitiesExt {
+    fn is_alive(&self, person_id: PersonId) -> bool {
+        self.get_property::<Person, Alive>(person_id).0
+    }
+
+    /// Adds a plan for the given person if and only if that person is
+    /// alive when the plan comes due.
+    fn add_plan_for_person(
+        &mut self,
+        person_id: PersonId,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+    ) -> PlanId {
+        self.add_plan(time, move |context| {
+            // Only execute callback if the person is still alive.
+            if context.is_alive(person_id) {
+                callback(context)
+            }
+        })
+    }
+}
+impl ContextDeathExt for Context {}
+pub fn init(context: &mut Context) -> Result<(), IxaError> {
+    context.subscribe_to_event(
+        move |context, event: PropertyChangeEvent<Person, SymptomStatus>| {
+            if event.current == SymptomStatus::Dead {
+                context.set_property::<Person, Alive>(event.entity_id, Alive(false));
+                context.remove_person_from_settings(event.entity_id);
+                if context.get_property::<Person, InfectionStatus>(event.entity_id)
+                    == InfectionStatus::Infectious
+                {
+                    context.recover_person(event.entity_id);
+                }
+            }
+        },
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::{cell::RefCell, rc::Rc};
+
+    use ixa::{ExecutionPhase, prelude::*};
+
+    use ixa::HashMap;
+
+    use super::init;
+    use crate::death::ContextDeathExt;
+    use crate::infectiousness_manager::{InfectionData, InfectionStatus};
+    use crate::population_loader::PersonId;
+    use crate::symptom_status_manager::{self, SymptomStatus};
+    use crate::{Age, infection_propagation_loop};
+    use crate::{
+        define_setting_category,
+        infectiousness_manager::InfectionContextExt,
+        parameters::{CoreSettingsTypes, GlobalParams, Params, RateFnType},
+        population_loader::Person,
+        settings::{ContextSettingExt, ItineraryEntry, SettingId, SettingProperties},
+    };
+
+    define_setting_category!(HomogeneousMixing);
+
+    fn set_homogeneous_mixing_itinerary(
+        context: &mut Context,
+        person_id: PersonId,
+    ) -> Result<(), IxaError> {
+        let itinerary = vec![ItineraryEntry::new(
+            SettingId::new(HomogeneousMixing, 0),
+            1.0,
+        )];
+        context.add_itinerary(person_id, itinerary)
+    }
+
+    fn setup_context(seed: u64, rate: f64, alpha: f64, duration: f64) -> Context {
+        let mut context = Context::new();
+
+        let parameters = Params {
+            seed,
+            max_time: 100.0,
+            infectiousness_rate_fn: RateFnType::Constant { rate, duration },
+            settings_properties: HashMap::from_iter(
+                [
+                    (CoreSettingsTypes::Home, SettingProperties { alpha: 0.5 }),
+                    (
+                        CoreSettingsTypes::Workplace,
+                        SettingProperties { alpha: 0.5 },
+                    ),
+                    (
+                        CoreSettingsTypes::CensusTract,
+                        SettingProperties {
+                            alpha: 0.5,
+                            // Itinerary is specified in the `set_homogeneous_mixing_itinerary` function
+                            // so we do not need to set it here.
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+            ),
+            itinerary_ratios: HashMap::from_iter([
+                (CoreSettingsTypes::Home, 1.0),
+                (CoreSettingsTypes::Workplace, 1.0),
+                (CoreSettingsTypes::CensusTract, 0.0),
+            ]),
+            ..Default::default()
+        };
+        context.init_random(parameters.seed);
+        context
+            .set_global_property_value(GlobalParams, parameters)
+            .unwrap();
+
+        // We also set up a homogenous mixing itinerary so that when we don't call `settings::init`,
+        // we still have people in settings.
+        context
+            .register_setting_category(&HomogeneousMixing, SettingProperties { alpha }, 1.0)
+            .unwrap();
+        context
+    }
+
+    #[test]
+    fn test_alive_property_set_to_false_on_death() {
+        // This test verifies that when a person's symptom status is set to Dead, their Alive property is set to false.
+        // It uses the ContextDeathExt trait to check the alive status of the person before and after setting them to dead.
+        let mut context = setup_context(0, 5.0, 0.5, 10.0);
+        let person_id: PersonId = context.add_entity((Age(30),)).unwrap();
+        symptom_status_manager::init(&mut context).unwrap();
+        init(&mut context).unwrap();
+        // We schedule the person to be set to dead at time 0.0,
+        // and then we check their alive status both before and after the death event is processed.
+        context.add_plan_with_phase(
+            0.0,
+            move |context| {
+                assert!(context.is_alive(person_id));
+                context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
+            },
+            ExecutionPhase::First,
+        );
+        context.add_plan_with_phase(
+            0.0,
+            move |context| {
+                assert!(!context.is_alive(person_id));
+            },
+            ExecutionPhase::Last,
+        );
+        context.execute();
+    }
+
+    #[test]
+    fn test_setting_removal_on_death() {
+        // This test verifies that when a person dies, they are removed from all settings they were a part of.
+        // We create a person, add them to a homogeneous mixing setting, and then set them
+        // to dead. We check that they are removed from the setting after death.
+        let mut context = setup_context(0, 5.0, 0.5, 10.0);
+        let person_id: PersonId = context.add_entity((Age(30),)).unwrap();
+        set_homogeneous_mixing_itinerary(&mut context, person_id).unwrap();
+        symptom_status_manager::init(&mut context).unwrap();
+        init(&mut context).unwrap();
+        // We schedule the person to be set to dead at time 0.0,
+        // and then we check that they are removed from the homogeneous mixing setting after the death event is processed.
+        context.add_plan_with_phase(
+            0.0,
+            move |context| {
+                assert!(context.is_alive(person_id));
+                assert!(
+                    context
+                        .get_setting_members(&SettingId::new(HomogeneousMixing, 0))
+                        .unwrap()
+                        .contains(&person_id)
+                );
+                context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
+            },
+            ExecutionPhase::First,
+        );
+        context.add_plan_with_phase(
+            0.0,
+            move |context| {
+                assert!(!context.is_alive(person_id));
+                assert!(
+                    !context
+                        .get_setting_members(&SettingId::new(HomogeneousMixing, 0))
+                        .unwrap()
+                        .contains(&person_id)
+                );
+            },
+            ExecutionPhase::Last,
+        );
+        context.execute();
+    }
+
+    #[test]
+    fn test_dead_person_recovers_immediately() {
+        // This test verifies that when a person is dies while infectious, they immediately transition to a recovered state.
+        // This test also verifies that the plan to recovered created from the infection event does not execute.
+        // We create a person, infect them, set them to dead, and then check they are recovered and that they do not recover twice.
+        let mut context = setup_context(0, 5.0, 0.5, 10.0);
+        let person_id: PersonId = context.add_entity((Age(30),)).unwrap();
+        infection_propagation_loop::init(&mut context).unwrap();
+        symptom_status_manager::init(&mut context).unwrap();
+        init(&mut context).unwrap();
+        // We schedule the person to be set to dead at time 0.0,
+        // and then we check that their infection status does not change to recovered after the death event is processed.
+        context.add_plan_with_phase(
+            0.0,
+            move |context| {
+                assert!(context.is_alive(person_id));
+                context.infect_person(person_id, None, None, None);
+                context.set_property::<Person, SymptomStatus>(person_id, SymptomStatus::Dead);
+            },
+            ExecutionPhase::First,
+        );
+        context.subscribe_to_event::<PropertyChangeEvent<Person, InfectionStatus>>(
+            move |context, event| {
+                if event.current == InfectionStatus::Recovered {
+                    match context.get_property::<Person, InfectionData>(event.entity_id) {
+                        InfectionData::Recovered {
+                            infection_time,
+                            recovery_time,
+                        } => {
+                            assert_eq!(infection_time, recovery_time);
+                        }
+                        InfectionData::Susceptible => {}
+                        InfectionData::Infectious { .. } => {}
+                    }
+                }
+            },
+        );
+        context.execute();
+    }
+
+    #[test]
+    fn test_no_infection_when_dead() {
+        // This test verifies that when a person is dead, they cannot infect others.
+        // We create an infectious person and a susceptible person, set the infectious person to dead,
+        // and then check that the susceptible person does not become infected over the course of the simulation
+        let num_sims: u64 = 1000;
+        let rate = 5.0;
+        let alpha = 0.42;
+        let duration = 10.0;
+
+        let num_infected = Rc::new(RefCell::new(0usize));
+        for seed in 0..num_sims {
+            let num_infected_clone = Rc::clone(&num_infected);
+            let mut context = setup_context(seed, rate, alpha, duration);
+
+            context.add_plan_with_phase(10.0, ixa::Context::shutdown, ExecutionPhase::Last);
+            // Add our susceptible fellow and set their itinerary.
+            let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+            set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
+
+            // Add our infectious fellow and set their itinerary
+            let infectious_person: PersonId = context.add_entity((Age(30),)).unwrap();
+            set_homogeneous_mixing_itinerary(&mut context, infectious_person).unwrap();
+
+            // Initialize the infection propagation loop, symptom status manager, and death modules,
+            // and then infect the infectious person and set them to dead.
+            infection_propagation_loop::init(&mut context).unwrap();
+            symptom_status_manager::init(&mut context).unwrap();
+            init(&mut context).unwrap();
+            context.infect_person(infectious_person, None, None, None);
+            context.set_property::<Person, SymptomStatus>(infectious_person, SymptomStatus::Dead);
+
+            // Add a watcher if the other person is infected.
+            context.subscribe_to_event::<PropertyChangeEvent<Person, InfectionStatus>>(
+                move |context, event| {
+                    if event.current == InfectionStatus::Infectious
+                        && event.entity_id != infectious_person
+                    {
+                        *num_infected_clone.borrow_mut() += 1;
+                        context.set_property(event.entity_id, InfectionData::Susceptible);
+                    }
+                },
+            );
+            context.execute();
+        }
+        // assert the susceptible person was never infected across all simulations
+        assert_eq!(*num_infected.borrow(), 0);
+    }
+}

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -1,5 +1,6 @@
 use ixa::prelude::*;
 
+use crate::death::ContextDeathExt;
 use crate::infectiousness_manager::{
     Forecast, InfectionContextExt, InfectionStatus, evaluate_forecast, get_forecast,
     infection_attempt,
@@ -17,7 +18,7 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
         forecasted_total_infectiousness,
     }) = get_forecast(context, person)
     {
-        context.add_plan(next_time, move |context| {
+        context.add_plan_for_person(person, next_time, move |context| {
             let _span = open_span("evaluate and schedule next forecast");
             if evaluate_forecast(context, person, forecasted_total_infectiousness) {
                 let _ = infection_attempt(context, person);
@@ -31,7 +32,7 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
 fn schedule_recovery(context: &mut Context, person: PersonId) {
     let infection_duration = context.get_person_rate_fn(person).infection_duration();
     let recovery_time = context.get_current_time() + infection_duration;
-    context.add_plan(recovery_time, move |context| {
+    context.add_plan_for_person(person, recovery_time, move |context| {
         increment_named_count("recovery");
         trace!("Person {person} has recovered at {recovery_time}");
         context.recover_person(person);

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -18,7 +18,7 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
         forecasted_total_infectiousness,
     }) = get_forecast(context, person)
     {
-        context.add_plan_for_person(person, next_time, move |context| {
+        context.add_plan_if_alive(person, next_time, move |context| {
             let _span = open_span("evaluate and schedule next forecast");
             if evaluate_forecast(context, person, forecasted_total_infectiousness) {
                 let _ = infection_attempt(context, person);
@@ -32,7 +32,7 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
 fn schedule_recovery(context: &mut Context, person: PersonId) {
     let infection_duration = context.get_person_rate_fn(person).infection_duration();
     let recovery_time = context.get_current_time() + infection_duration;
-    context.add_plan_for_person(person, recovery_time, move |context| {
+    context.add_plan_if_alive(person, recovery_time, move |context| {
         increment_named_count("recovery");
         trace!("Person {person} has recovered at {recovery_time}");
         context.recover_person(person);

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -3,6 +3,7 @@ use rand_distr::Exp;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    death::ContextDeathExt,
     population_loader::PersonId,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, ScaledRateFn},
     settings::ContextSettingExt,
@@ -111,6 +112,10 @@ pub struct Forecast {
 /// Forecast of the next expected infection time, and the expected rate of
 /// infection at that time.
 pub fn get_forecast(context: &Context, person_id: PersonId) -> Option<Forecast> {
+    if !context.is_alive(person_id) {
+        trace!("Person {person_id} is dead. No forecast will be generated.");
+        return None;
+    }
     // Get the person's individual infectiousness
     let rate_fn = context.get_person_rate_fn(person_id);
     // This scales infectiousness by the maximum possible infectiousness across all settings
@@ -140,6 +145,10 @@ pub fn evaluate_forecast(
     person_id: PersonId,
     forecasted_total_infectiousness: f64,
 ) -> bool {
+    if !context.is_alive(person_id) {
+        trace!("Person {person_id} is dead. Forecast will be automatically rejected.");
+        return false;
+    }
     let rate_fn = context.get_person_rate_fn(person_id);
 
     let total_multiplier = calc_total_infectiousness_multiplier(context, person_id);
@@ -170,7 +179,7 @@ pub fn evaluate_forecast(
     true
 }
 
-pub trait InfectionContextExt: PluginContext + InfectiousnessRateExt {
+pub trait InfectionContextExt: PluginContext + InfectiousnessRateExt + ContextDeathExt {
     // This function should be called from the main loop whenever
     // someone is first infected. It assigns all their properties needed to
     // calculate intrinsic infectiousness
@@ -228,7 +237,7 @@ mod test {
         Age, define_setting_category,
         infectiousness_manager::{InfectionData, InfectionStatus},
         parameters::{GlobalParams, Params},
-        population_loader::{Person, PersonId},
+        population_loader::{Alive, Person, PersonId},
         rate_fns::{InfectiousnessRateExt, load_rate_fns},
         settings::{ContextSettingExt, ItineraryEntry, SettingId, SettingProperties},
     };
@@ -359,6 +368,40 @@ mod test {
         let f = get_forecast(&context, p1).expect("Forecast should be returned");
         // The expected rate is 2.0, because intrinsic is 1.0 and there are 2 contacts.
         assert_almost_eq!(f.forecasted_total_infectiousness, 2.0, 0.0);
+    }
+
+    #[test]
+    fn test_get_forecast_returns_none_for_dead_person() {
+        let mut context = setup_context();
+        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
+        context.infect_person(p1, None, None, None);
+
+        // Mark person as dead
+        context.set_property::<Person, Alive>(p1, Alive(false));
+
+        // Forecast should return None for dead person
+        assert!(get_forecast(&context, p1).is_none());
+    }
+
+    #[test]
+    fn test_evaluate_forecast_returns_false_for_dead_person() {
+        let mut context = setup_context();
+        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
+        context.infect_person(p1, None, None, None);
+
+        let forecasted_infectiousness = 1.0;
+
+        // Mark person as dead
+        context.set_property::<Person, Alive>(p1, Alive(false));
+
+        // Evaluate should return false for dead person
+        assert!(!evaluate_forecast(
+            &mut context,
+            p1,
+            forecasted_infectiousness
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod death;
 pub mod infection_importation;
 pub mod infection_propagation_loop;
 pub mod infectiousness_manager;

--- a/src/model.rs
+++ b/src/model.rs
@@ -23,6 +23,7 @@ pub fn initialize_model(context: &mut Context, seed: u64, max_time: f64) -> Resu
     symptom_status_manager::init(context)?;
     infection_propagation_loop::init(context)?;
     infection_importation::init(context)?;
+    death::init(context)?;
     reports::init(context)?;
 
     Ok(())

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,7 @@ use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
     infection_importation, infection_propagation_loop, population_loader, reports, settings,
-    symptom_status_manager,
+    symptom_status_manager, death
 };
 
 pub fn initialize_model(context: &mut Context, seed: u64, max_time: f64) -> Result<(), IxaError> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,8 @@
 use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
-    infection_importation, infection_propagation_loop, population_loader, reports, settings,
-    symptom_status_manager, death
+    death, infection_importation, infection_propagation_loop, population_loader, reports, settings,
+    symptom_status_manager,
 };
 
 pub fn initialize_model(context: &mut Context, seed: u64, max_time: f64) -> Result<(), IxaError> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -208,6 +208,12 @@ impl SettingDataContainer {
             .or_default()
             .insert(person_id);
     }
+
+    fn remove_member(&mut self, person_id: PersonId, setting_identifier: (TypeId, usize)) {
+        if let Some(members) = self.all_members.get_mut(&setting_identifier) {
+            members.swap_remove(&person_id);
+        }
+    }
 }
 
 #[macro_export]
@@ -260,6 +266,25 @@ trait ContextSettingInternalExt: PluginContext + ContextRandomExt {
 
     fn get_itinerary_internal(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
         self.get_data(SettingDataPlugin).get_itinerary(person_id)
+    }
+
+    fn remove_person_from_settings_internal(&mut self, person_id: PersonId) {
+        // We remove the person from setting membership but don't remove their itinerary because
+        // we want to preserve the itinerary for future interventions and reporting.
+        let container = self.get_data_mut(SettingDataPlugin);
+        let setting_identifiers: Vec<_> = container
+            .get_itinerary(person_id)
+            .map(|itinerary| {
+                itinerary
+                    .iter()
+                    .map(|entry| entry.setting.get_tuple_id())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for setting_identifier in setting_identifiers {
+            container.remove_member(person_id, setting_identifier);
+        }
     }
 }
 impl ContextSettingInternalExt for Context {}
@@ -369,7 +394,6 @@ pub trait ContextSettingExt:
         let container = self.get_data_mut(SettingDataPlugin);
 
         // Clean up settings that from previous itinerary, if there is one
-
         if container.itineraries.contains_key(&person_id) {
             return Err(IxaError::from("Person already has an itinerary."));
         }
@@ -471,6 +495,10 @@ pub trait ContextSettingExt:
 
     fn sample_setting_members(&self, setting: &dyn AnySettingId) -> Option<PersonId> {
         self.sample_setting_members_internal(setting)
+    }
+
+    fn remove_person_from_settings(&mut self, person_id: PersonId) {
+        self.remove_person_from_settings_internal(person_id);
     }
 }
 impl ContextSettingExt for Context {}
@@ -1049,6 +1077,28 @@ mod test {
             ),
             Ok(_) => panic!("Expected an error. Instead, validation passed with no errors."),
         }
+    }
+
+    #[test]
+    fn test_remove_person_from_settings() {
+        let mut context = Context::new();
+        context
+            .register_setting_category(&Home, SettingProperties { alpha: 0.1 }, 1.0)
+            .unwrap();
+        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let itinerary = vec![ItineraryEntry::new(SettingId::new(Home, 1), 1.0)];
+        context.add_itinerary(person, itinerary).unwrap();
+
+        let members = context
+            .get_setting_members(&SettingId::new(Home, 1))
+            .unwrap();
+        assert_eq!(members.len(), 1);
+
+        context.remove_person_from_settings(person);
+        let members_after_removal = context
+            .get_setting_members(&SettingId::new(Home, 1))
+            .unwrap();
+        assert_eq!(members_after_removal.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
This PR implements the effects of a dead symptom status. This involves disallowing future plans that are scheduled to happen for dead individuals and removing them from setting membership.

## Changes

- A death module was created with event subscription to listen for dead symtpom status progression. 
- Upon death the `alive` person property is set to false, they are removed from setting membership, and if they are infectious when they die, the directly transition to the recovered infection status. 
- A death context extension was created with the method to ergonomically check the alive status. This context extension includes a lightweight wrapper on `add_plan` called `add_plan_if_alive` that checks if the person is alive before executing the callback.
- An additional method was added to the settings context extension to remove the person from setting membership. Their itineraries are maintained in case additional analysis on a dead person's itinerary is required.
- Tests were add to the death module to ensure all functionality of death occurs how we expect.
- Checks were add to multiple places in the `infection_manager` and `infection_propagation_loop` modules to check if the person is alive before proceeding

## Open Question
Should the `add_plan_if_alive` be used for all plans? Even those in the symptom status manager that execute before a person dies?

## Additional Resource
A design document for deaths in models can be found [here](https://cdc.sharepoint.com/:w:/r/teams/CenterforForecastingandOutbreakAnalytics/Shared%20Documents/General/02%20-%20Predict/Analytics%20Response%20Branch/Community%20Mitigation%20%26%20Economic%20Impacts/Projects/2026-ixa-epi-covid/phase-2/Deaths%20in%20ixa-epi-covid.docx?d=w14e3f7bbd96642cb82e34ec3975b015f&csf=1&web=1&e=r5lDB6)