### PR TITLE
feat: FIPSCode-based synthetic population parsing, ASPR-compatible population loading and synth pop generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 **/profiling.json
 
+# IDE and Platform
+.vscode
+.idea
+.DS_Store
+
 # Data
 *.csv
 *.tsv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  python: python3.12
+
 repos:
 #####
 # Basic file cleanliness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -85,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -135,6 +152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +171,15 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "cast"
@@ -159,6 +194,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -167,12 +204,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -210,6 +241,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -253,25 +294,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -341,6 +397,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +458,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -411,6 +492,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dtor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,34 +518,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "dyn-eq"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
-
-[[package]]
-name = "dyn-hash"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdab65db9274e0168143841eb8f864a0a21f8b1b8d2ba6812bbe6024346e99e"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -468,31 +536,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fern"
@@ -508,6 +559,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -526,6 +587,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -548,10 +619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -604,12 +677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest",
 ]
 
 [[package]]
@@ -661,6 +734,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,7 +750,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -694,11 +776,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixa"
-version = "2.0.0-beta2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b1a44faf128a2d85abcd24a8d8f530b04cbcda6b60dfdca9adb36134fabb4f"
+version = "2.0.0-beta2.1"
+source = "git+https://github.com/CDCgov/ixa?branch=main#5ee076a5f4a215b9521258814285344eae507548"
 dependencies = [
- "anyhow",
  "approx",
  "bincode",
  "bytesize",
@@ -716,15 +796,14 @@ dependencies = [
  "log4rs",
  "ouroboros",
  "paste",
- "progress_bar",
  "rand",
  "rustc-hash",
- "rustyline",
  "seq-macro",
  "serde",
  "serde_derive",
  "serde_json",
- "shlex",
+ "smallbox",
+ "smallvec",
  "sysinfo",
  "thiserror",
  "wasm-bindgen",
@@ -735,8 +814,7 @@ dependencies = [
 [[package]]
 name = "ixa-derive"
 version = "2.0.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2377d465cd9978c98d2b6e51722ed70d2da5aef31d0e97a83bbaf638ad75497"
+source = "git+https://github.com/CDCgov/ixa?branch=main#5ee076a5f4a215b9521258814285344eae507548"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -751,28 +829,27 @@ dependencies = [
  "anyhow",
  "clap",
  "criterion",
- "dyn-clone",
- "dyn-eq",
- "dyn-hash",
- "indexmap",
  "ixa",
- "ixa-fips",
+ "memchr",
+ "once_cell",
+ "ouroboros",
  "rand_distr",
  "serde",
  "serde_json",
- "strum 0.28.0",
- "strum_macros 0.28.0",
+ "strum",
  "tempfile",
  "thiserror",
+ "zip",
 ]
 
 [[package]]
-name = "ixa-fips"
-version = "0.1.4"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27968562c813a4c3be4f09030468afecfb3058eea2653d49313262a78b8e196a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "strum 0.27.2",
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -790,6 +867,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
@@ -843,37 +926,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mock_instant"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "ntapi"
@@ -883,6 +964,12 @@ checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -962,6 +1049,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1091,18 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -1040,15 +1155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "progress_bar"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78e216a48ed863994dcc1357367f097d5a1875fc5bcf233875f32c1d442c734"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,16 +1174,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
 
 [[package]]
 name = "rand"
@@ -1192,7 +1288,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1200,28 +1296,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rustyline"
-version = "17.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
-dependencies = [
- "bitflags",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "home",
- "libc",
- "log",
- "memchr",
- "nix",
- "radix_trie",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "ryu"
@@ -1294,10 +1368,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallbox"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aca054fd9f8c2ebe8557a2433f307e038c0716124efd045daa0388afa5172189"
 
 [[package]]
 name = "smallvec"
@@ -1319,29 +1427,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -1355,6 +1445,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1391,7 +1487,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1421,8 +1517,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "js-sys",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinytemplate"
@@ -1465,6 +1581,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,12 +1603,6 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1645,7 +1767,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1795,62 +1917,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1861,102 +1932,6 @@ checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2088,7 +2063,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zip"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+dependencies = [
+ "aes",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.2",
+ "hmac",
+ "indexmap",
+ "lzma-rust2",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,6 @@ dependencies = [
 name = "ixa-epi-covid"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "criterion",
  "ixa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,18 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0.102"
-dyn-clone = "1.0.20"
-dyn-eq = "0.1.3"
-dyn-hash = "1.0.0"
-indexmap = "2.13.0"
 clap = { version = "4", features = ["derive"] }
-ixa = { version = "2.0.0-beta2", default-features = false, features = ["logging", "debugger", "progress_bar"] }
-ixa-fips = "0.1.4"
+ixa = { git = "https://github.com/CDCgov/ixa", branch = "main", default-features = false, features = ["logging"] }
 rand_distr = "0.5.1"
 serde = "1.0.217"
 serde_json = "1.0.139"
 tempfile = "3.25.0"
 thiserror = "2.0.18"
-strum = "0.28.0"
-strum_macros = "0.28.0"
+memchr = "2.7.6"
+zip = { version = "8.5" }
+once_cell = { version = "1" }
+ouroboros = { version = "0.18.5" }
+strum = { version = "0.28.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -33,8 +31,21 @@ name = "infection_loop"
 harness = false
 
 [features]
+default = ["profiling", "aspr_archive"]
+
 profiling = ["ixa/profiling"]
 bench_old_settings = []
+
+# Runs tests that assume the existence of ASPR Synthetic Population files from ZIP archives
+aspr_tests = ["aspr_dataset_tests", "aspr_zip_tests"]
+# Just (unzipped) dataset tests
+aspr_dataset_tests = ["aspr_archive"]
+# Just zipped dataset tests
+aspr_zip_tests = ["aspr_archive"]
+
+# Historical compatibility feature; archive-backed ASPR loading is now always enabled.
+# Keep this: We will want this feature gate again when we backport the code to `ixa-fips`.
+aspr_archive = []
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ harness = false
 default = ["profiling", "pop_reader_archive"]
 
 profiling = ["ixa/profiling"]
-bench_old_settings = []
 
 # Runs tests that assume the existence of ASPR Synthetic Population files from ZIP archives
 pop_reader_tests = ["pop_reader_dataset_tests", "pop_reader_zip_tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ name = "epimodel"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1.0.102"
 clap = { version = "4", features = ["derive"] }
 ixa = { git = "https://github.com/CDCgov/ixa", branch = "main", default-features = false, features = ["logging"] }
 rand_distr = "0.5.1"
@@ -31,21 +30,21 @@ name = "infection_loop"
 harness = false
 
 [features]
-default = ["profiling", "aspr_archive"]
+default = ["profiling", "pop_reader_archive"]
 
 profiling = ["ixa/profiling"]
 bench_old_settings = []
 
 # Runs tests that assume the existence of ASPR Synthetic Population files from ZIP archives
-aspr_tests = ["aspr_dataset_tests", "aspr_zip_tests"]
+pop_reader_tests = ["pop_reader_dataset_tests", "pop_reader_zip_tests"]
 # Just (unzipped) dataset tests
-aspr_dataset_tests = ["aspr_archive"]
+pop_reader_dataset_tests = ["pop_reader_archive"]
 # Just zipped dataset tests
-aspr_zip_tests = ["aspr_archive"]
+pop_reader_zip_tests = ["pop_reader_archive"]
 
 # Historical compatibility feature; archive-backed ASPR loading is now always enabled.
 # Keep this: We will want this feature gate again when we backport the code to `ixa-fips`.
-aspr_archive = []
+pop_reader_archive = []
 
 [profile.release]
 opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ SIZE ?= 1000
 
 # Normalize SIZE to use underscores (e.g., 1000 -> 1_000, 1000000 -> 1_000_000)
 NORMALIZED_SIZE := $(shell python3 -c "print(f'{int(\"$(SIZE)\".replace(\"_\",\"\")):_}')")
+CLEAN_STATE_PATTERN := $(if $(filter command line environment environment override,$(origin STATE)),$(STATE),*)
+CLEAN_SIZE_PATTERN := $(if $(filter command line environment environment override,$(origin SIZE)),$(NORMALIZED_SIZE),*)
 
-.PHONY: all uv-sync synthetic-population run profile
+.PHONY: all uv-sync synthetic-population test-syn-pop clean-synthetic-population run profile
 all: uv-sync
 
 # Initialize the uv environment for Python scripts
@@ -14,6 +16,15 @@ uv-sync:
 # Generate a synthetic population (configure with STATE and SIZE)
 synthetic-population:
 	uv run scripts/create_synthetic_population.py --state $(STATE) --size $(NORMALIZED_SIZE)
+
+# Run synthetic population generator tests
+test-syn-pop:
+	uv run pytest scripts/test_create_synthetic_population.py
+
+# Remove generated synthetic population CSVs. Optionally narrow with STATE and/or SIZE.
+clean-synthetic-population:
+	rm -f input/synth_pop_people_$(CLEAN_STATE_PATTERN)_$(CLEAN_SIZE_PATTERN).csv
+	rm -f input/synth_pop_region_$(CLEAN_STATE_PATTERN)_$(CLEAN_SIZE_PATTERN).csv
 
 input/synth_pop_people_%.csv:
 	uv run scripts/create_synthetic_population.py --state $(shell echo "$*" | sed 's/_.*//')  --size $(shell echo "$*" | sed 's/^[A-Z]*_//')

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cargo run -- -c input/input.json -o output
 
 ### Synthetic Population
 
-The model requires a synthetic population CSV. A small test file is included at `input/people_test.csv`. To generate larger populations, first install R dependencies and set up a [Census Bureau API key](https://api.census.gov/data/key_signup.html) in `.env` as `CENSUS_API_KEY`:
+The model requires an ASPR-compatible synthetic population CSV. A small test file is included at `input/people_test.csv`. To generate larger populations, first install R dependencies and set up a [Census Bureau API key](https://api.census.gov/data/key_signup.html) in `.env` as `CENSUS_API_KEY`:
 
 ```bash
 make setup-r

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cargo run -- -c input/input.json -o output
 
 ### Synthetic Population
 
-The model requires an ASPR-compatible synthetic population CSV. A small test file is included at `input/people_test.csv`. To generate larger populations, first install R dependencies and set up a [Census Bureau API key](https://api.census.gov/data/key_signup.html) in `.env` as `CENSUS_API_KEY`:
+The model requires a compatible synthetic population CSV in the person-record format supported by `pop_reader`. A small test file is included at `input/people_test.csv`. To generate larger populations, first install R dependencies and set up a [Census Bureau API key](https://api.census.gov/data/key_signup.html) in `.env` as `CENSUS_API_KEY`:
 
 ```bash
 make setup-r

--- a/benches/infection_loop.rs
+++ b/benches/infection_loop.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
 
-use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use epimodel::parameters::{GlobalParams, Params, RateFnType, SettingProperties};
 use epimodel::settings::SettingCategory;
 use epimodel::symptom_status_manager::SymptomDelayDistLogNormParams;
-use epimodel::{initialize_model, ContextParametersExt};
-use ixa::prelude::*;
+use epimodel::{ContextParametersExt, initialize_model};
 use ixa::HashMap;
+use ixa::prelude::*;
 
 type SettingType = SettingCategory;
 

--- a/benches/infection_loop.rs
+++ b/benches/infection_loop.rs
@@ -1,36 +1,20 @@
 use std::path::{Path, PathBuf};
 
-use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
-#[cfg(feature = "bench_old_settings")]
-use epimodel::parameters::{CoreSettingsTypes, GlobalParams, Params, RateFnType};
-#[cfg(not(feature = "bench_old_settings"))]
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use epimodel::parameters::{GlobalParams, Params, RateFnType, SettingProperties};
-#[cfg(not(feature = "bench_old_settings"))]
 use epimodel::settings::SettingCategory;
-#[cfg(feature = "bench_old_settings")]
-use epimodel::settings::SettingProperties;
 use epimodel::symptom_status_manager::SymptomDelayDistLogNormParams;
-use epimodel::{ContextParametersExt, initialize_model};
-use ixa::HashMap;
+use epimodel::{initialize_model, ContextParametersExt};
 use ixa::prelude::*;
+use ixa::HashMap;
 
-#[cfg(feature = "bench_old_settings")]
-type SettingType = CoreSettingsTypes;
-#[cfg(not(feature = "bench_old_settings"))]
 type SettingType = SettingCategory;
+
 fn make_params(synth_file: PathBuf) -> Params {
     let delay = SymptomDelayDistLogNormParams {
         mu: 0.1,
         sigma: 0.1,
     };
-    #[cfg(feature = "bench_old_settings")]
-    let settings = [
-        (SettingType::Home, 0.3, 0.3),
-        (SettingType::Workplace, 0.2, 0.3),
-        (SettingType::School, 0.2, 0.1),
-        (SettingType::CensusTract, 0.01, 0.3),
-    ];
-    #[cfg(not(feature = "bench_old_settings"))]
     let settings = [
         (SettingType::Home, 0.3, 0.3),
         (SettingType::Work, 0.2, 0.3),

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -6,4 +6,18 @@ When the simulation is instantiated, all individuals are created in the suscepti
 Seeded infections are allowed to vary in their remaining duration of infection at time 0.0. This is implemented using negative simulation time feature of `ixa`, where individuals to be seeded as infectious sample their infection duration elapsed at time 0.0 to be uniformly distributed from 0 to 100% of their assigned infection duration. Note that the process of seeding infections is distinct from the importation of novel infections from outside the community, discussed in more detail in the [importation module](importation.md). Even though both approaches allow for infectious individuals who arise external to the transmission model, imported cases begin their infection upon importation and still have their whole duration of infection ahead of them.
 
 ## Synthetic populations
-A synthetic population is a structured `.csv` file which defines the population that will be simulated. Each row corresponds to an individual with the properties defined by the columns of the file: `age`, `homeId`, `schoolId`, `workplaceId`. `age` corresponds to the age of the individual. `homeId`, `schoolId`, and `workplaceId` corresponds to the home, school and workplace setting an individual belongs to. An individual must belong to a home setting, but does not need to belong to a school or workplace (this is indicated by an empty entry). An individual's community or census tract group is derived from the individual's `homeId`. The implementation in `population_loader.rs` adds all people to the model, assigns the age person property and setting itinerary to each individual. For this model, the entries for all setting IDs should be represented by 17 character structured numeric values. The first 11 characters of the string contain information about the state, county, and census tract following the FIPS format, and the remaining 6 characters define the group.
+A synthetic population is a structured `.csv` file which defines the population that will be simulated. Each row corresponds to an individual with the properties defined by the columns of the file: `age`, `homeId`, `schoolId`, `workplaceId`. `age` corresponds to the age of the individual. `homeId`, `schoolId`, and `workplaceId` correspond to the home, school, and workplace settings an individual belongs to. An individual must belong to a home setting, but does not need to belong to a school or workplace (this is indicated by an empty entry). An individual's community or census tract group is derived from the individual's `homeId`. The implementation in `population_loader.rs` adds all people to the model, assigns the age person property and setting itinerary to each individual.
+
+The model now expects ASPR-compatible setting identifiers. The geographic prefix remains fixed-width, but the observed ASPR data sometimes uses one extra decimal digit in the sequential suffix when the sequence value exceeds the originally documented width:
+
+- `homeId`: 11-digit tract + within-tract id
+  - published ASPR description: 4-digit suffix
+  - observed data accepted by the parser: 4 or 5 digits
+- `schoolId`:
+  - public school: 11-digit tract + within-tract id
+    - published ASPR description: 3-digit suffix
+    - observed data accepted by the parser: 3 or 4 digits
+  - private school: 5-digit county + `xprvx` + 4-digit within-county id
+- `workplaceId`: 11-digit tract + 5-digit within-tract id
+
+These values are parsed into `ixa-fips::FIPSCode` values, and the model's `Community` setting is derived from the tract-level prefix of `homeId`.

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -8,7 +8,9 @@ Seeded infections are allowed to vary in their remaining duration of infection a
 ## Synthetic populations
 A synthetic population is a structured `.csv` file which defines the population that will be simulated. Each row corresponds to an individual with the properties defined by the columns of the file: `age`, `homeId`, `schoolId`, `workplaceId`. `age` corresponds to the age of the individual. `homeId`, `schoolId`, and `workplaceId` correspond to the home, school, and workplace settings an individual belongs to. An individual must belong to a home setting, but does not need to belong to a school or workplace (this is indicated by an empty entry). An individual's community or census tract group is derived from the individual's `homeId`. The implementation in `population_loader.rs` adds all people to the model, assigns the age person property and setting itinerary to each individual.
 
-The model now expects ASPR-compatible setting identifiers. The geographic prefix remains fixed-width, but the observed ASPR data sometimes uses one extra decimal digit in the sequential suffix when the sequence value exceeds the originally documented width:
+The model now expects setting identifiers compatible with the population record format handled by `pop_reader`. The
+geographic prefix remains fixed-width, but the observed data in commonly used datasets sometimes uses one extra decimal
+digit in the sequential suffix when the sequence value exceeds the originally documented width:
 
 - `homeId`: 11-digit tract + within-tract id
   - published ASPR description: 4-digit suffix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "matplotlib>=3.10.8",
     "numpy>=2.3.4",
     "pandas>=3.0.0",
+    "pandas-stubs~=3.0.0",
     "pyarrow>=23.0.0",
     "pygris>=0.2.1",
     "pytest>=9.0.2",

--- a/scripts/create_synthetic_population.py
+++ b/scripts/create_synthetic_population.py
@@ -24,6 +24,7 @@ DEFAULT_PUMS_DATA_YEAR = 2023
 
 CROSSWALK_FILE = "2020_Census_Tract_to_2020_PUMA.csv"
 CROSSWALK_URL = "https://www2.census.gov/geo/docs/maps-data/data/rel2020/2020_Census_Tract_to_2020_PUMA.txt"
+FIPS_CODE_ID_MAX = 32_767
 
 
 def parse_args(argv=None):
@@ -212,14 +213,49 @@ def load_tracts(state_synth, year_synth):
     return tracts_gdf
 
 
+def assign_within_group_sequence(df, group_col, seq_col):
+    df = df.copy()
+    df[seq_col] = df.groupby(group_col).cumcount() + 1
+    return df
+
+
 def create_places(tracts_gdf, n, id_col, rng):
     sample = tracts_gdf.sample(
         n=n, replace=True, random_state=rng.integers(2**31)
     ).reset_index(drop=True)
+    sample = sample.copy()
+    sample["tract_id"] = sample["GEOID"]
+    sample = assign_within_group_sequence(
+        sample, "tract_id", "place_seq_within_tract"
+    )
+
+    max_place_seq_by_tract = sample.groupby("tract_id")[
+        "place_seq_within_tract"
+    ].max()
+    overflowed = max_place_seq_by_tract[
+        max_place_seq_by_tract > FIPS_CODE_ID_MAX
+    ]
+    if not overflowed.empty:
+        tract_id = overflowed.index[0]
+        max_seq = int(overflowed.iloc[0])
+        setting_type = (
+            "school"
+            if id_col == "school_id"
+            else "workplace" if id_col == "workplace_id" else id_col
+        )
+        raise ValueError(
+            f"{setting_type} sequence overflow for tract {tract_id}: "
+            f"maximum sequence {max_seq} exceeds FIPSCode limit {FIPS_CODE_ID_MAX}"
+        )
+
+    min_width = 3 if id_col == "school_id" else 5
+    place_ids = sample["tract_id"] + sample[
+        "place_seq_within_tract"
+    ].astype(str).str.zfill(min_width)
+
     return pd.DataFrame(
         {
-            id_col: sample["GEOID"]
-            + (sample.index + 1).astype(str).str.zfill(6),
+            id_col: place_ids,
             "lat": sample["lat"].values,
             "lon": sample["lon"].values,
             "enrolled": 0,
@@ -311,8 +347,37 @@ def assign_geography(synth_pop_df, tracts_by_puma, tracts_gdf, rng):
     )
     house_puma_df = house_puma_df.drop(columns=["tracts"])
 
+    missing_tracts = house_puma_df[house_puma_df["tract_id"].isna()]
+    if not missing_tracts.empty:
+        missing_pumas = missing_tracts["puma_id"].drop_duplicates().tolist()
+        raise ValueError(
+            "Could not assign tract_id for sampled households in PUMAs: "
+            f"{missing_pumas}"
+        )
+
+    house_puma_df = assign_within_group_sequence(
+        house_puma_df, "tract_id", "home_seq_within_tract"
+    )
+    max_home_seq_by_tract = house_puma_df.groupby("tract_id")[
+        "home_seq_within_tract"
+    ].max()
+    overflowed = max_home_seq_by_tract[max_home_seq_by_tract > FIPS_CODE_ID_MAX]
+    if not overflowed.empty:
+        tract_id = overflowed.index[0]
+        max_seq = int(overflowed.iloc[0])
+        raise ValueError(
+            f"home sequence overflow for tract {tract_id}: "
+            f"maximum sequence {max_seq} exceeds FIPSCode limit {FIPS_CODE_ID_MAX}"
+        )
+
+    house_puma_df["home_id"] = house_puma_df["tract_id"] + house_puma_df[
+        "home_seq_within_tract"
+    ].astype(str).str.zfill(4)
+
     synth_pop_region_df = synth_pop_df.merge(
-        house_puma_df[["house_number", "STATE", "PUMA", "tract_id"]],
+        house_puma_df[
+            ["house_number", "STATE", "PUMA", "tract_id", "home_id"]
+        ],
         on=["house_number", "STATE", "PUMA"],
         how="left",
     )
@@ -330,10 +395,6 @@ def assign_geography(synth_pop_df, tracts_by_puma, tracts_gdf, rng):
         how="left",
         suffixes=("", "_tract"),
     )
-
-    synth_pop_region_df["home_id"] = synth_pop_region_df["tract_id"].astype(
-        str
-    ) + synth_pop_region_df["house_number"].apply(lambda x: f"{x:06d}")
 
     return synth_pop_region_df
 

--- a/scripts/create_synthetic_population.py
+++ b/scripts/create_synthetic_population.py
@@ -241,7 +241,9 @@ def create_places(tracts_gdf, n, id_col, rng):
         setting_type = (
             "school"
             if id_col == "school_id"
-            else "workplace" if id_col == "workplace_id" else id_col
+            else "workplace"
+            if id_col == "workplace_id"
+            else id_col
         )
         raise ValueError(
             f"{setting_type} sequence overflow for tract {tract_id}: "
@@ -249,9 +251,9 @@ def create_places(tracts_gdf, n, id_col, rng):
         )
 
     min_width = 3 if id_col == "school_id" else 5
-    place_ids = sample["tract_id"] + sample[
-        "place_seq_within_tract"
-    ].astype(str).str.zfill(min_width)
+    place_ids = sample["tract_id"] + sample["place_seq_within_tract"].astype(
+        str
+    ).str.zfill(min_width)
 
     return pd.DataFrame(
         {
@@ -361,7 +363,9 @@ def assign_geography(synth_pop_df, tracts_by_puma, tracts_gdf, rng):
     max_home_seq_by_tract = house_puma_df.groupby("tract_id")[
         "home_seq_within_tract"
     ].max()
-    overflowed = max_home_seq_by_tract[max_home_seq_by_tract > FIPS_CODE_ID_MAX]
+    overflowed = max_home_seq_by_tract[
+        max_home_seq_by_tract > FIPS_CODE_ID_MAX
+    ]
     if not overflowed.empty:
         tract_id = overflowed.index[0]
         max_seq = int(overflowed.iloc[0])

--- a/scripts/test_create_synthetic_population.py
+++ b/scripts/test_create_synthetic_population.py
@@ -313,7 +313,9 @@ class TestAssignGeography:
             }
         )
 
-        geo_df = assign_geography(synth_pop_df, tracts_by_puma, tracts_gdf, rng)
+        geo_df = assign_geography(
+            synth_pop_df, tracts_by_puma, tracts_gdf, rng
+        )
         households = (
             geo_df[["house_number", "home_id"]]
             .drop_duplicates()

--- a/scripts/test_create_synthetic_population.py
+++ b/scripts/test_create_synthetic_population.py
@@ -201,6 +201,67 @@ class TestCreatePlaces:
         df = create_places(tracts_gdf, 3, "school_id", rng)
         assert df["lat"].notna().all() and df["lon"].notna().all()
 
+    def test_school_ids_reset_within_tract(self, tracts_gdf, rng):
+        sampled = tracts_gdf.iloc[[0, 1, 0, 1]].copy().reset_index(drop=True)
+        with patch.object(
+            gpd.GeoDataFrame,
+            "sample",
+            autospec=True,
+            return_value=sampled,
+        ):
+            df = create_places(tracts_gdf, 4, "school_id", rng)
+
+        assert df["school_id"].tolist() == [
+            "56001000100001",
+            "56001000200001",
+            "56001000100002",
+            "56001000200002",
+        ]
+
+    def test_workplace_ids_reset_within_tract(self, tracts_gdf, rng):
+        sampled = tracts_gdf.iloc[[0, 1, 0, 1]].copy().reset_index(drop=True)
+        with patch.object(
+            gpd.GeoDataFrame,
+            "sample",
+            autospec=True,
+            return_value=sampled,
+        ):
+            df = create_places(tracts_gdf, 4, "workplace_id", rng)
+
+        assert df["workplace_id"].tolist() == [
+            "5600100010000001",
+            "5600100020000001",
+            "5600100010000002",
+            "5600100020000002",
+        ]
+
+    @pytest.mark.parametrize(
+        ("id_col", "setting_type"),
+        [("school_id", "school"), ("workplace_id", "workplace")],
+    )
+    def test_place_id_overflow_raises(
+        self, tracts_gdf, rng, id_col, setting_type
+    ):
+        sampled = (
+            tracts_gdf.iloc[np.zeros(32_768, dtype=int)]
+            .copy()
+            .reset_index(drop=True)
+        )
+        with patch.object(
+            gpd.GeoDataFrame,
+            "sample",
+            autospec=True,
+            return_value=sampled,
+        ):
+            with pytest.raises(
+                ValueError,
+                match=(
+                    rf"{setting_type} sequence overflow for tract 56001000100: "
+                    r"maximum sequence 32768 exceeds FIPSCode limit 32767"
+                ),
+            ):
+                create_places(tracts_gdf, 32_768, id_col, rng)
+
 
 class TestSamplePopulation:
     def test_produces_at_least_target(self, household_pums, sample_pums, rng):
@@ -229,6 +290,63 @@ class TestAssignGeography:
         assert "home_id" in geo_df.columns
         assert "tract_id" in geo_df.columns
         assert geo_df["home_id"].notna().all()
+
+    def test_home_ids_reset_within_tract_and_households_share_home(
+        self, tracts_gdf, rng
+    ):
+        synth_pop_df = pd.DataFrame(
+            {
+                "person_id": [1, 2, 3, 4, 5],
+                "house_number": [1, 1, 2, 3, 3],
+                "STATE": ["56"] * 5,
+                "PUMA": ["00100", "00100", "00200", "00300", "00300"],
+            }
+        )
+        tracts_by_puma = pd.DataFrame(
+            {
+                "puma_id": ["5600100", "5600200", "5600300"],
+                "tracts": [
+                    ["56001000100"],
+                    ["56001000200"],
+                    ["56001000100"],
+                ],
+            }
+        )
+
+        geo_df = assign_geography(synth_pop_df, tracts_by_puma, tracts_gdf, rng)
+        households = (
+            geo_df[["house_number", "home_id"]]
+            .drop_duplicates()
+            .sort_values("house_number")
+        )
+
+        assert households["home_id"].tolist() == [
+            "560010001000001",
+            "560010002000001",
+            "560010001000002",
+        ]
+        assert geo_df.groupby("house_number")["home_id"].nunique().eq(1).all()
+
+    def test_home_id_overflow_raises(self, tracts_gdf, rng):
+        synth_pop_df = pd.DataFrame(
+            {
+                "house_number": np.arange(1, 32_769),
+                "STATE": ["56"] * 32_768,
+                "PUMA": ["00100"] * 32_768,
+            }
+        )
+        tracts_by_puma = pd.DataFrame(
+            {"puma_id": ["5600100"], "tracts": [["56001000100"]]}
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"home sequence overflow for tract 56001000100: "
+                r"maximum sequence 32768 exceeds FIPSCode limit 32767"
+            ),
+        ):
+            assign_geography(synth_pop_df, tracts_by_puma, tracts_gdf, rng)
 
 
 class TestBuildOutputs:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use ixa::IxaError;
 use thiserror::Error;
 
-use crate::pop_reader::errors::ASPRError;
+use crate::pop_reader::errors::PopulationReaderError;
 
 #[derive(Error, Debug)]
 pub enum ModelError {
@@ -21,5 +21,5 @@ pub enum ModelError {
     IxaCsvError(#[from] ixa::csv::Error),
 
     #[error(transparent)]
-    ASPRError(#[from] ASPRError),
+    PopulationReaderError(#[from] PopulationReaderError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 use ixa::IxaError;
 use thiserror::Error;
 
+use crate::pop_reader::errors::ASPRError;
+
 #[derive(Error, Debug)]
 pub enum ModelError {
     #[error("Model Error: {0}")]
@@ -17,4 +19,7 @@ pub enum ModelError {
 
     #[error(transparent)]
     IxaCsvError(#[from] ixa::csv::Error),
+
+    #[error(transparent)]
+    ASPRError(#[from] ASPRError),
 }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -73,7 +73,7 @@ mod test {
 
     use crate::Age;
     use crate::pop_reader::{
-        ASPRSettingCategory, FIPSCode,
+        PopulationReaderSettingCategory, FIPSCode,
         parser::{parse_fips_home_id, parse_fips_workplace_id},
     };
     use crate::infection_propagation_loop::InfectionRng;
@@ -104,7 +104,7 @@ mod test {
             home_id.state_code(),
             home_id.county_code(),
             home_id.census_tract_code(),
-            ASPRSettingCategory::CensusTract.into(),
+            PopulationReaderSettingCategory::CensusTract.encode(),
         )
             .unwrap()
         )

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -72,10 +72,14 @@ mod test {
     use ixa::{HashMap, assert_almost_eq};
 
     use crate::Age;
+    use crate::pop_reader::{
+        ASPRSettingCategory, FIPSCode,
+        parser::{parse_fips_home_id, parse_fips_workplace_id},
+    };
     use crate::infection_propagation_loop::InfectionRng;
     use crate::infectiousness_manager::InfectionData;
     use crate::population_loader::PersonId;
-    use crate::settings::{ContextSettingExt, SettingCategory};
+    use crate::settings::{ContextSettingExt, SettingCategory, SettingCode};
     use crate::{
         infection_propagation_loop::{
             InfectionStatus, init, schedule_next_forecasted_infection, schedule_recovery,
@@ -85,12 +89,33 @@ mod test {
         population_loader::Person,
         rate_fns::{InfectiousnessRateExt, load_rate_fns},
     };
+    
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
+
+    fn make_workplace_id(workplace_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_workplace_id(workplace_id).unwrap().1)
+    }
+
+    fn make_community_id(home_id: &[u8]) -> SettingCode {
+        let home_id = make_home_id(home_id).0;
+        SettingCode(FIPSCode::with_category(
+            home_id.state_code(),
+            home_id.county_code(),
+            home_id.census_tract_code(),
+            ASPRSettingCategory::CensusTract.into(),
+        )
+            .unwrap()
+        )
+    }
 
     fn set_homogeneous_mixing_itinerary(
         context: &mut Context,
         person_id: PersonId,
     ) -> Result<(), crate::error::ModelError> {
-        context.add_person_to_settings(person_id, None, None, None, Some(0))?;
+        let community_code = make_community_id(b"160379602000001");
+        context.add_person_to_settings(person_id, None, None, None, Some(community_code))?;
         context.initialize_setting_size()?;
         Ok(())
     }
@@ -398,17 +423,21 @@ mod test {
                 let person_censustract: PersonId = context.add_entity((Age(30),)).unwrap();
                 let person_workplace: PersonId = context.add_entity((Age(30),)).unwrap();
 
+                let home_code = make_home_id(b"160379602000001");
+                let community_code = make_community_id(b"160379602000001");
+                let workplace_code = make_workplace_id(b"1603796020000220");
+
                 context
-                    .add_person_to_settings(person_home, Some(0), None, None, None)
+                    .add_person_to_settings(person_home, Some(home_code), None, None, None)
                     .unwrap();
                 context
-                    .add_person_to_settings(person_workplace, None, Some(0), None, None)
+                    .add_person_to_settings(person_workplace, None, Some(workplace_code), None, None)
                     .unwrap();
                 context
-                    .add_person_to_settings(person_censustract, None, None, None, Some(0))
+                    .add_person_to_settings(person_censustract, None, None, None, Some(community_code))
                     .unwrap();
                 context
-                    .add_person_to_settings(infectious_person, Some(0), Some(0), None, Some(0))
+                    .add_person_to_settings(infectious_person, Some(home_code), Some(workplace_code), None, Some(community_code))
                     .unwrap();
                 context.initialize_setting_size().unwrap();
 

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -72,12 +72,12 @@ mod test {
     use ixa::{HashMap, assert_almost_eq};
 
     use crate::Age;
-    use crate::pop_reader::{
-        PopulationReaderSettingCategory, FIPSCode,
-        parser::{parse_fips_home_id, parse_fips_workplace_id},
-    };
     use crate::infection_propagation_loop::InfectionRng;
     use crate::infectiousness_manager::InfectionData;
+    use crate::pop_reader::{
+        FIPSCode, PopulationReaderSettingCategory,
+        parser::{parse_fips_home_id, parse_fips_workplace_id},
+    };
     use crate::population_loader::PersonId;
     use crate::settings::{ContextSettingExt, SettingCategory, SettingCode};
     use crate::{
@@ -89,7 +89,7 @@ mod test {
         population_loader::Person,
         rate_fns::{InfectiousnessRateExt, load_rate_fns},
     };
-    
+
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)
     }
@@ -100,13 +100,14 @@ mod test {
 
     fn make_community_id(home_id: &[u8]) -> SettingCode {
         let home_id = make_home_id(home_id).0;
-        SettingCode(FIPSCode::with_category(
-            home_id.state_code(),
-            home_id.county_code(),
-            home_id.census_tract_code(),
-            PopulationReaderSettingCategory::CensusTract.encode(),
-        )
-            .unwrap()
+        SettingCode(
+            FIPSCode::with_category(
+                home_id.state_code(),
+                home_id.county_code(),
+                home_id.census_tract_code(),
+                PopulationReaderSettingCategory::CensusTract.encode(),
+            )
+            .unwrap(),
         )
     }
 
@@ -431,13 +432,31 @@ mod test {
                     .add_person_to_settings(person_home, Some(home_code), None, None, None)
                     .unwrap();
                 context
-                    .add_person_to_settings(person_workplace, None, Some(workplace_code), None, None)
+                    .add_person_to_settings(
+                        person_workplace,
+                        None,
+                        Some(workplace_code),
+                        None,
+                        None,
+                    )
                     .unwrap();
                 context
-                    .add_person_to_settings(person_censustract, None, None, None, Some(community_code))
+                    .add_person_to_settings(
+                        person_censustract,
+                        None,
+                        None,
+                        None,
+                        Some(community_code),
+                    )
                     .unwrap();
                 context
-                    .add_person_to_settings(infectious_person, Some(home_code), Some(workplace_code), None, Some(community_code))
+                    .add_person_to_settings(
+                        infectious_person,
+                        Some(home_code),
+                        Some(workplace_code),
+                        None,
+                        Some(community_code),
+                    )
                     .unwrap();
                 context.initialize_setting_size().unwrap();
 

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -217,6 +217,7 @@ mod test {
     };
     use crate::{
         Age,
+        pop_reader::{ASPRSettingCategory, FIPSCode, parser::parse_fips_home_id},
         infectiousness_manager::{InfectionData, InfectionStatus},
         parameters::{GlobalParams, Params, SettingProperties},
         population_loader::{Person, PersonId},
@@ -225,11 +226,29 @@ mod test {
     };
     use ixa::{HashMap, assert_almost_eq, prelude::*};
 
+
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
+    
+    fn make_community_id(home_id: &[u8]) -> SettingCode {
+        let home_id = make_home_id(home_id).0;
+        SettingCode(FIPSCode::with_category(
+            home_id.state_code(),
+            home_id.county_code(),
+            home_id.census_tract_code(),
+            ASPRSettingCategory::CensusTract.into(),
+        )
+            .unwrap()
+        )
+    }
+
     fn set_homogeneous_mixing_itinerary(
         context: &mut Context,
         person_id: PersonId,
     ) -> Result<(), crate::error::ModelError> {
-        context.add_person_to_settings(person_id, None, None, None, Some(0))?;
+        let community_code = make_community_id(b"160379602000001");
+        context.add_person_to_settings(person_id, None, None, None, Some(community_code))?;
         context.initialize_setting_size()?;
         Ok(())
     }
@@ -395,7 +414,7 @@ mod test {
         let index: PersonId = context.add_entity((Age(30),)).unwrap();
         let contact: PersonId = context.add_entity((Age(30),)).unwrap();
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(0), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000001"), SettingCategory::Home))
             .unwrap();
         let infection_setting_id = Some(home_id);
         context.infect_person(contact, Some(index), infection_setting_id);

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -217,7 +217,7 @@ mod test {
     };
     use crate::{
         Age,
-        pop_reader::{ASPRSettingCategory, FIPSCode, parser::parse_fips_home_id},
+        pop_reader::{PopulationReaderSettingCategory, FIPSCode, parser::parse_fips_home_id},
         infectiousness_manager::{InfectionData, InfectionStatus},
         parameters::{GlobalParams, Params, SettingProperties},
         population_loader::{Person, PersonId},
@@ -237,7 +237,7 @@ mod test {
             home_id.state_code(),
             home_id.county_code(),
             home_id.census_tract_code(),
-            ASPRSettingCategory::CensusTract.into(),
+            PopulationReaderSettingCategory::CensusTract.encode(),
         )
             .unwrap()
         )

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -217,29 +217,29 @@ mod test {
     };
     use crate::{
         Age,
-        pop_reader::{PopulationReaderSettingCategory, FIPSCode, parser::parse_fips_home_id},
         infectiousness_manager::{InfectionData, InfectionStatus},
         parameters::{GlobalParams, Params, SettingProperties},
+        pop_reader::{FIPSCode, PopulationReaderSettingCategory, parser::parse_fips_home_id},
         population_loader::{Person, PersonId},
         rate_fns::{InfectiousnessRateExt, load_rate_fns},
         settings::{ContextSettingExt, Setting, SettingCategory, SettingCode},
     };
     use ixa::{HashMap, assert_almost_eq, prelude::*};
 
-
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)
     }
-    
+
     fn make_community_id(home_id: &[u8]) -> SettingCode {
         let home_id = make_home_id(home_id).0;
-        SettingCode(FIPSCode::with_category(
-            home_id.state_code(),
-            home_id.county_code(),
-            home_id.census_tract_code(),
-            PopulationReaderSettingCategory::CensusTract.encode(),
-        )
-            .unwrap()
+        SettingCode(
+            FIPSCode::with_category(
+                home_id.state_code(),
+                home_id.county_code(),
+                home_id.census_tract_code(),
+                PopulationReaderSettingCategory::CensusTract.encode(),
+            )
+            .unwrap(),
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@ pub mod infectiousness_manager;
 pub mod model;
 pub mod natural_history_parameter_manager;
 pub mod parameters;
+pub mod pop_reader;
 pub mod population_loader;
 pub mod rate_fns;
 pub mod reports;
 pub mod settings;
 pub mod symptom_status_manager;
-pub mod pop_reader;
 
 pub use model::initialize_model;
 pub use parameters::ContextParametersExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod rate_fns;
 pub mod reports;
 pub mod settings;
 pub mod symptom_status_manager;
+pub mod pop_reader;
 
 pub use model::initialize_model;
 pub use parameters::ContextParametersExt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,5 +30,4 @@ fn main() {
 
     // Write the profiling data and context's execution statistics to a JSON file.
     context.write_profiling_data();
-    ixa::profiling::print_profiling_data();
 }

--- a/src/pop_reader/archive.rs
+++ b/src/pop_reader/archive.rs
@@ -1,6 +1,24 @@
 /*!
 This module provides facilities to read CSV files in the supported person record format.
 
+The CSV format is as follows:
+
+```csv
+age,homeId,schoolId,workplaceId
+33,56000000300000001,,
+37,56000000300000001,,56000000500000017
+8,56000000300000001,56000000400000001,
+5,56000000300000001,56000000400000001,
+```
+
+The first line is a header, and the remaining lines contain the data. The `age` field is required.
+The `homeId` field may be required by the model and is always present in the datasets we use, but
+the `pop_reader::archive` module does not enforce this. The `schoolId` and `workplaceId` fields
+are optional. The fields are separated by commas without spaces and are unquoted. The ID fields
+must be in the format described in the [`pop_reader`] module-level documentation. The record format
+is parsed by [`PersonRecordIterator::next()`], which itself calls out to parselets for each field,
+while `EXPECTED_FIELD_COUNT` defines the number of fields in each record.
+
 Throughout this module, source data files are addressed using two paths:
 
 - the **data path**, configured with [`set_data_path`] and retrieved with [`get_data_path`]
@@ -500,6 +518,10 @@ fn parse_optional_field<T>(
     Ok(Some(value))
 }
 
+/// An iterator-like structure that produces the fields of a line of CSV data.
+///
+/// This type emits an error message if the row has a number of fields different from
+/// `EXPECTED_FIELD_COUNT`.
 struct FieldCursor<'a> {
     rest: &'a [u8],
     line_number: usize,

--- a/src/pop_reader/archive.rs
+++ b/src/pop_reader/archive.rs
@@ -1,9 +1,9 @@
 /*!
-This module provides facilities to read CSV files in the ASPR person record format.
+This module provides facilities to read CSV files in the supported person record format.
 
 Throughout this module, source data files are addressed using two paths:
 
-- the **data path**, configured with [`set_aspr_data_path`] and retrieved with [`get_aspr_data_path`]
+- the **data path**, configured with [`set_data_path`] and retrieved with [`get_data_path`]
 - the **file path**, which is always interpreted relative to that data path
 
 The data path can have one of two forms:
@@ -16,40 +16,32 @@ The same file path is interpreted differently depending on which kind of data pa
 - if the data path is a directory, the final source file is `data_path.join(file_path)`
 - if the data path is a zip archive, the file path is the name of the file inside the archive
 
-For example, when reading the ASPR synthetic population dataset itself, if the file path is
-`all_states/ak.csv`, then:
+For example, when reading a dataset, if the file path is `all_states/ak.csv`, then:
 
 - with data path `/path/to/ASPR_Synthetic_Population`, the source file is
   `/path/to/ASPR_Synthetic_Population/all_states/ak.csv`
 - with data path `/path/to/ASPR_Synthetic_Population.zip`, the source file is the archive member
   named `all_states/ak.csv`
 
-Set and get the ASPR data path with the `set_aspr_data_path` and `get_aspr_data_path` functions:
+Set and get the data path with the `set_data_path` and `get_data_path` functions:
 
 ```rust,ignore
-let current_path = get_aspr_data_path();
-println!("The current ASPR data path: {:?}", current_path);
+let current_path = get_data_path();
+println!("The current data path: {:?}", current_path);
 
-set_aspr_data_path(PathBuf::from("../CDC/data/ASPR_Synthetic_Population.zip"));
-let new_path = get_aspr_data_path();
-println!("The new ASPR data path: {:?}", new_path);
+set_data_path(PathBuf::from("../CDC/data/ASPR_Synthetic_Population.zip"));
+let new_path = get_data_path();
+println!("The new data path: {:?}", new_path);
 ```
 
-For ASPR-specific conveniences such as [`ALL_STATES_DIR`], [`CBSA_ALL_DIR`],
-[`CBSA_ONLY_RESIDENTS_DIR`], [`NON_CBSA_RESIDENTS_DIR`], and [`MULTI_STATE_DIR`], the assumption is
-that the data path is either:
-
-- `path/to/root/of/unzipped/aspr/dataset`
-- `path/to/ASPR_Synthetic_Population.zip`
-
 You can iterate over the records in a CSV file by passing a file path relative to the configured
-data path to [`ASPRRecordIterator::from_path`]:
+data path to [`PersonRecordIterator::from_path`]:
 
 ```ignore
-# use ixa_aspr::archive::{CBSA_ALL_DIR, ASPRRecordIterator};
+# use crate::pop_reader::archive::PersonRecordIterator;
 # use std::path::PathBuf;
-let file_path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
-let records = ASPRRecordIterator::from_path(file_path);
+let file_path = PathBuf::from("cbsa_all_work_school_household").join("AK/Ketchikan AK.csv");
+let records = PersonRecordIterator::from_path(file_path);
 // Do something with the records...
 ```
 
@@ -57,25 +49,16 @@ If the data path is the root of an unzipped dataset, that file path refers to
 `cbsa_all_work_school_household/AK/Ketchikan AK.csv` under that directory. If the data path is a zip
 archive, the same file path refers to the archive member with that name.
 
-The [`ASPRRecordIterator::state_population`] convenience method reads the file whose file path is
-`all_states/{state}.csv` relative to the configured data path. This is an ASPR-specific convenience
-and therefore assumes the data path points at either the root of the unzipped ASPR synthetic
-population dataset or the corresponding zip archive.
-
-```ignore
-# use ixa_aspr::archive::{ASPRRecordIterator};
-# use ixa_fips::USState;
-let records = ASPRRecordIterator::state_population(USState::AK);
-// Do something with the records...
-```
-
 You can get a list of CSV file paths in a given subdirectory with [`iter_csv_files`]. The returned
 paths are always relative to the configured data path, so they can be passed directly to
-[`ASPRRecordIterator::from_path`] or [`ASPRRecordIterator::from_file_iterator`]:
+[`PersonRecordIterator::from_path`] or [`PersonRecordIterator::from_file_iterator`]:
 
 ```ignore
-# use ixa_aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
-let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
+# use crate::pop_reader::archive::PersonRecordIterator;
+# use crate::pop_reader::archive::iter_csv_files;
+let records = PersonRecordIterator::from_file_iterator(
+    iter_csv_files("all_states").unwrap(),
+);
 // Do something with the records...
 ```
 */
@@ -92,60 +75,43 @@ use ouroboros::self_referencing;
 use zip::{read::ZipFile, ZipArchive};
 
 use super::{
-    errors::{ASPRError, FIPSParserError},
+    errors::{PopulationReaderError, FIPSParserError},
     parser::{
         parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id, parse_integer,
     },
-    states::USState,
-    ASPRPersonRecord,
+    PersonRecord,
 };
 
 /// The size of the buffer used to read lines from source data files in the expected format. This is
 /// chosen to be large enough to keep rebuffering to a minimum, which in turn minimizes the
 /// probability that a line spans a buffer window boundary and thus has to be copied to scratch
 /// memory for processing.
-const ASPR_READER_CAPACITY: usize = 256 * 1024;
-/// The number of fields in each ASPR record: age, homeId, schoolId, workplaceId.
-const ASPR_EXPECTED_FIELD_COUNT: usize = 4;
+const READER_CAPACITY: usize = 256 * 1024;
+/// The number of fields in each record: age, homeId, schoolId, workplaceId.
+const EXPECTED_FIELD_COUNT: usize = 4;
 
-/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
-/// root, containing one CSV file per state.
-pub const ALL_STATES_DIR: &str = "all_states";
-/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
-/// root, containing CBSA files with all work, school, and household assignments.
-pub const CBSA_ALL_DIR: &str = "cbsa_all_work_school_household";
-/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
-/// root, containing CBSA files restricted to residents.
-pub const CBSA_ONLY_RESIDENTS_DIR: &str = "cbsa_only_residents";
-/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
-/// root, used beneath either CBSA directory for non-CBSA residents.
-pub const NON_CBSA_RESIDENTS_DIR: &str = "non_CBSA_residents";
-/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
-/// root, used beneath either CBSA directory for multi-state areas.
-pub const MULTI_STATE_DIR: &str = "Multi-state";
+/// Default data path. By default this points at the root of a local unzipped dataset.
+const DEFAULT_DATA_PATH: &str = "../CDC/data/ASPR_Synthetic_Population";
+// ToDo: Get the data path from an environment variable.
+static DATA_PATH: Lazy<RwLock<PathBuf>> =
+    Lazy::new(|| RwLock::new(PathBuf::from(DEFAULT_DATA_PATH)));
 
-/// Default ASPR data path. By default this points at the root of a local unzipped ASPR dataset.
-const DEFAULT_ASPR_DATA_PATH: &str = "../CDC/data/ASPR_Synthetic_Population";
-// ToDo: Get the ASPR data path from an environment variable.
-static ASPR_DATA_PATH: Lazy<RwLock<PathBuf>> =
-    Lazy::new(|| RwLock::new(PathBuf::from(DEFAULT_ASPR_DATA_PATH)));
-
-/// Sets the ASPR data path.
+/// Sets the data path.
 ///
 /// The data path may be either a directory containing source files in the expected format or the
 /// path to a zip archive containing such files. File paths accepted elsewhere in this module are
 /// always interpreted relative to this data path.
-pub fn set_aspr_data_path(path: PathBuf) {
-    *ASPR_DATA_PATH.write().unwrap() = path;
+pub fn set_data_path(path: PathBuf) {
+    *DATA_PATH.write().unwrap() = path;
 }
 
-/// Returns the current ASPR data path.
+/// Returns the current data path.
 ///
 /// The returned path is interpreted either as a directory containing source files in the expected
 /// format or as the path to a zip archive containing such files. File paths accepted elsewhere in
 /// this module are always interpreted relative to this data path.
-pub fn get_aspr_data_path() -> PathBuf {
-    ASPR_DATA_PATH.read().unwrap().clone()
+pub fn get_data_path() -> PathBuf {
+    DATA_PATH.read().unwrap().clone()
 }
 
 /// Byte-oriented line reader over a particular source data file.
@@ -157,7 +123,7 @@ struct FileLineSource {
 impl FileLineSource {
     fn from_file(file: File) -> Self {
         Self {
-            reader: BufReader::with_capacity(ASPR_READER_CAPACITY, file),
+            reader: BufReader::with_capacity(READER_CAPACITY, file),
             scratch: Vec::new(),
         }
     }
@@ -180,19 +146,19 @@ struct ZipLineSource {
 impl ZipLineSource {
     /// Constructs a `ZipLineSource` over the lines of the file whose file path is `path` inside the
     /// zip archive at `archive_path`.
-    fn from_path(archive_path: PathBuf, path: PathBuf) -> Result<Self, ASPRError> {
-        let file = File::open(archive_path).map_err(ASPRError::Io)?;
-        let reader = BufReader::with_capacity(ASPR_READER_CAPACITY, file);
-        let mut maybe_error: Option<ASPRError> = None;
+    fn from_path(archive_path: PathBuf, path: PathBuf) -> Result<Self, PopulationReaderError> {
+        let file = File::open(archive_path).map_err(PopulationReaderError::Io)?;
+        let reader = BufReader::with_capacity(READER_CAPACITY, file);
+        let mut maybe_error: Option<PopulationReaderError> = None;
 
         let zip_line_source = ZipLineSourceBuilder {
-            _archive: ZipArchive::new(reader).map_err(ASPRError::ZipError)?,
+            _archive: ZipArchive::new(reader).map_err(PopulationReaderError::ZipError)?,
             scratch: Vec::new(),
             line_reader_builder: |archive: &mut ZipArchive<BufReader<File>>| {
                 match archive.by_name(path.to_str().unwrap()) {
-                    Ok(zipped_file) => Some(BufReader::with_capacity(ASPR_READER_CAPACITY, zipped_file)),
+                    Ok(zipped_file) => Some(BufReader::with_capacity(READER_CAPACITY, zipped_file)),
                     Err(error) => {
-                        maybe_error = Some(ASPRError::ZipError(error));
+                        maybe_error = Some(PopulationReaderError::ZipError(error));
                         None
                     }
                 }
@@ -217,12 +183,12 @@ enum LineIterator {
 
 impl LineIterator {
     /// Returns a line reader over the file whose file path is `file_path` relative to the current
-    /// ASPR data path.
+    /// data path.
     ///
-    /// If the ASPR data path is a directory, the source file is `data_path.join(file_path)`. If the
-    /// ASPR data path is a zip archive, `file_path` is the name of the file inside the archive.
-    fn from_path(file_path: PathBuf) -> Result<Self, ASPRError> {
-        let path = get_aspr_data_path();
+    /// If the data path is a directory, the source file is `data_path.join(file_path)`. If the
+    /// data path is a zip archive, `file_path` is the name of the file inside the archive.
+    fn from_path(file_path: PathBuf) -> Result<Self, PopulationReaderError> {
+        let path = get_data_path();
 
         if path
             .extension()
@@ -231,15 +197,15 @@ impl LineIterator {
         {
             Ok(Self::Zip(ZipLineSource::from_path(path, file_path)?))
         } else {
-            let file = File::open(path.join(file_path)).map_err(ASPRError::Io)?;
+            let file = File::open(path.join(file_path)).map_err(PopulationReaderError::Io)?;
             Ok(Self::File(FileLineSource::from_file(file)))
         }
     }
 
     fn with_next_line<R>(
         &mut self,
-        process_line: impl FnOnce(&[u8]) -> Result<R, ASPRError>,
-    ) -> Result<Option<R>, ASPRError> {
+        process_line: impl FnOnce(&[u8]) -> Result<R, PopulationReaderError>,
+    ) -> Result<Option<R>, PopulationReaderError> {
         match self {
 
             Self::File(source) => {
@@ -268,15 +234,15 @@ impl LineIterator {
 fn with_next_line_from_reader<R, Reader>(
     reader: &mut Reader,
     scratch: &mut Vec<u8>,
-    process_line: impl FnOnce(&[u8]) -> Result<R, ASPRError>,
-) -> Result<Option<R>, ASPRError>
+    process_line: impl FnOnce(&[u8]) -> Result<R, PopulationReaderError>,
+) -> Result<Option<R>, PopulationReaderError>
 where
     Reader: BufRead,
 {
     scratch.clear();
 
     loop {
-        let buf = reader.fill_buf().map_err(ASPRError::Io)?;
+        let buf = reader.fill_buf().map_err(PopulationReaderError::Io)?;
 
         if buf.is_empty() {
             if scratch.is_empty() {
@@ -315,24 +281,24 @@ where
     }
 }
 
-/// Returns an iterator over CSV file paths in the given subdirectory of the current ASPR data path.
+/// Returns an iterator over CSV file paths in the given subdirectory of the current data path.
 ///
-/// `subdirectory` is itself interpreted as a file path relative to the configured ASPR data path. The returned paths
-/// are always relative to the configured ASPR data path as well, regardless of whether the data path is a directory or
+/// `subdirectory` is itself interpreted as a file path relative to the configured data path. The returned paths
+/// are always relative to the configured data path as well, regardless of whether the data path is a directory or
 /// a zip archive.
 pub fn iter_csv_files(
     subdirectory: &'static str,
-) -> Result<std::vec::IntoIter<PathBuf>, ASPRError> {
-    let mut path = get_aspr_data_path();
+) -> Result<std::vec::IntoIter<PathBuf>, PopulationReaderError> {
+    let mut path = get_data_path();
 
     if path
         .extension()
         .and_then(|ext| ext.to_str())
         .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"))
     {
-        let file = File::open(path).map_err(ASPRError::Io)?;
-        let reader = BufReader::with_capacity(ASPR_READER_CAPACITY, file);
-        let archive = ZipArchive::new(reader).map_err(ASPRError::ZipError)?;
+        let file = File::open(path).map_err(PopulationReaderError::Io)?;
+        let reader = BufReader::with_capacity(READER_CAPACITY, file);
+        let archive = ZipArchive::new(reader).map_err(PopulationReaderError::ZipError)?;
 
         let file_names: Vec<PathBuf> = archive
             .file_names()
@@ -343,11 +309,11 @@ pub fn iter_csv_files(
         Ok(file_names.into_iter())
     } else {
         path.push(subdirectory);
-        let entries = path.read_dir().map_err(ASPRError::Io)?;
+        let entries = path.read_dir().map_err(PopulationReaderError::Io)?;
         let mut files = vec![];
 
         for entry in entries {
-            let entry = entry.map_err(ASPRError::Io)?;
+            let entry = entry.map_err(PopulationReaderError::Io)?;
             if entry.path().is_file() {
                 files.push(PathBuf::from(subdirectory).join(entry.file_name()));
             }
@@ -357,25 +323,25 @@ pub fn iter_csv_files(
     }
 }
 
-/// Iterator over ASPR records in a particular data file in the expected ASPR person record format.
+/// Iterator over person records in a particular data file in the supported person record format.
 ///
-/// The constructors on this type interpret file paths relative to the current ASPR data path.
-pub struct ASPRRecordIterator {
+/// The constructors on this type interpret file paths relative to the current data path.
+pub struct PersonRecordIterator {
     line_iter: LineIterator,
     line_number: usize,
     failed: bool,
 }
 
-/// Used internally by `ASPRRecordIterator::from_file_iterator`, FileRecordIterator exists to unify
+/// Used internally by `PersonRecordIterator::from_file_iterator`, FileRecordIterator exists to unify
 /// “many records from a file” and “one file-level error for a failed file” into a single iterator
 /// type that from_file_iterator can flatten lazily.
 enum FileRecordIterator {
-    Records(ASPRRecordIterator),
-    Error(Option<ASPRError>),
+    Records(PersonRecordIterator),
+    Error(Option<PopulationReaderError>),
 }
 
 impl Iterator for FileRecordIterator {
-    type Item = Result<ASPRPersonRecord, ASPRError>;
+    type Item = Result<PersonRecord, PopulationReaderError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -385,31 +351,18 @@ impl Iterator for FileRecordIterator {
     }
 }
 
-impl ASPRRecordIterator {
-    /// Returns an iterator over the records in the file whose file path is `all_states/{state}.csv` relative to the
-    /// current ASPR data path.
-    ///
-    /// This is an ASPR-specific convenience method and assumes the current ASPR data path points at either the root of
-    /// the unzipped ASPR synthetic population dataset or the corresponding zip archive.
-    pub fn state_population(state: USState) -> Result<Self, ASPRError> {
-        let file_name = format!("{}.csv", state.to_static_str().to_lowercase());
-        let mut path = PathBuf::from(ALL_STATES_DIR);
-        path.push(file_name);
-
-        Self::from_path(path)
-    }
-
-    /// Returns an iterator over the records in the file whose file path is `file_path` relative to the current ASPR
+impl PersonRecordIterator {
+    /// Returns an iterator over the records in the file whose file path is `file_path` relative to the current
     /// data path.
     ///
-    /// If the current ASPR data path is a directory, the source file is `data_path.join(file_path)`. If the current
-    /// ASPR data path is a zip archive, `file_path` is the name of the file inside the archive. This function is
+    /// If the current data path is a directory, the source file is `data_path.join(file_path)`. If the current
+    /// data path is a zip archive, `file_path` is the name of the file inside the archive. This function is
     /// intended to be used with [`iter_csv_files`].
-    pub fn from_path(file_path: PathBuf) -> Result<Self, ASPRError> {
+    pub fn from_path(file_path: PathBuf) -> Result<Self, PopulationReaderError> {
         let mut line_iter = LineIterator::from_path(file_path.clone())?;
 
         if line_iter.with_next_line(|_| Ok(()))?.is_none() {
-            return Err(ASPRError::EmptyFile(file_path));
+            return Err(PopulationReaderError::EmptyFile(file_path));
         }
 
         Ok(Self {
@@ -421,21 +374,23 @@ impl ASPRRecordIterator {
 
     /// Returns an iterator over all the rows of all the files in the iterator.
     ///
-    /// Each path yielded by `files` is interpreted as a file path relative to the current ASPR data path. If a file
-    /// cannot be opened as an [`ASPRRecordIterator`], this iterator yields [`ASPRError::FileError`] for that path.
-    /// This function is intended to be used with [`iter_csv_files`]:
+    /// Each path yielded by `files` is interpreted as a file path relative to the current data
+    /// path. If a file cannot be opened as a [`PersonRecordIterator`], this iterator yields
+    /// [`PopulationReaderError::FileError`] for that path. This function is intended to be used
+    /// with [`iter_csv_files`]:
     ///
     /// ```ignore
-    /// # use ixa_aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
-    /// let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
+    /// # use crate::pop_reader::archive::PersonRecordIterator;
+    /// # use crate::pop_reader::archive::iter_csv_files;
+    /// let records = PersonRecordIterator::from_file_iterator(iter_csv_files("all_states").unwrap());
     /// ```
     pub fn from_file_iterator(
         files: impl Iterator<Item = PathBuf>,
-    ) -> impl Iterator<Item = Result<ASPRPersonRecord, ASPRError>> {
+    ) -> impl Iterator<Item = Result<PersonRecord, PopulationReaderError>> {
         files
             .map(|path| match Self::from_path(path.clone()) {
                 Ok(records) => FileRecordIterator::Records(records),
-                Err(source) => FileRecordIterator::Error(Some(ASPRError::FileError {
+                Err(source) => FileRecordIterator::Error(Some(PopulationReaderError::FileError {
                     path,
                     source: Box::new(source),
                 })),
@@ -444,8 +399,8 @@ impl ASPRRecordIterator {
     }
 }
 
-impl Iterator for ASPRRecordIterator {
-    type Item = Result<ASPRPersonRecord, ASPRError>;
+impl Iterator for PersonRecordIterator {
+    type Item = Result<PersonRecord, PopulationReaderError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.failed {
@@ -459,14 +414,14 @@ impl Iterator for ASPRRecordIterator {
 
             let field = fields.next_field()?;
             let age = parse_optional_field(field, parse_integer)
-                .map_err(|source| ASPRError::Parse {
+                .map_err(|source| PopulationReaderError::Parse {
                     field_name: "age",
                     line_number,
                     source,
                 })?
                 .ok_or(
                     // The case of an empty `age` field, which is an error.
-                    ASPRError::Parse {
+                    PopulationReaderError::Parse {
                         field_name: "age",
                         line_number,
                         source: FIPSParserError::InvalidLength {
@@ -477,7 +432,7 @@ impl Iterator for ASPRRecordIterator {
                 )?;
             let age = u8::try_from(age).map_err(
                 // The case of an `age` field that is too large.
-                |_| ASPRError::Parse {
+                |_| PopulationReaderError::Parse {
                     field_name: "age",
                     line_number,
                     source: FIPSParserError::ValueExceedsCapacity {
@@ -488,27 +443,27 @@ impl Iterator for ASPRRecordIterator {
             )?;
 
             let home_id = parse_optional_field(fields.next_field()?, parse_fips_home_id)
-                .map_err(|source| ASPRError::Parse {
+                .map_err(|source| PopulationReaderError::Parse {
                     field_name: "homeId",
                     line_number,
                     source,
                 })?;
 
             let school_id = parse_optional_field(fields.next_field()?, parse_fips_school_id)
-                .map_err(|source| ASPRError::Parse {
+                .map_err(|source| PopulationReaderError::Parse {
                     field_name: "schoolId",
                     line_number,
                     source,
                 })?;
 
             let work_id = parse_optional_field(fields.final_field()?, parse_fips_workplace_id)
-                .map_err(|source| ASPRError::Parse {
+                .map_err(|source| PopulationReaderError::Parse {
                     field_name: "workplaceId",
                     line_number,
                     source,
                 })?;
 
-            Ok(ASPRPersonRecord {
+            Ok(PersonRecord {
                 age,
                 home_id,
                 school_id,
@@ -521,7 +476,7 @@ impl Iterator for ASPRRecordIterator {
             Err(error) => {
                 if !matches!(
                     error,
-                    ASPRError::Parse { .. } | ASPRError::WrongFieldCount { .. }
+                    PopulationReaderError::Parse { .. } | PopulationReaderError::WrongFieldCount { .. }
                 ) {
                     self.failed = true;
                 }
@@ -567,9 +522,9 @@ impl<'a> FieldCursor<'a> {
 
     /// Returns the next comma-delimited field before the final field, and errors if there are
     /// not enough fields.
-    fn next_field(&mut self) -> Result<&'a [u8], ASPRError> {
-        let comma = memchr(b',', self.rest).ok_or(ASPRError::WrongFieldCount {
-            expected: ASPR_EXPECTED_FIELD_COUNT,
+    fn next_field(&mut self) -> Result<&'a [u8], PopulationReaderError> {
+        let comma = memchr(b',', self.rest).ok_or(PopulationReaderError::WrongFieldCount {
+            expected: EXPECTED_FIELD_COUNT,
             found: self.found + 1,
             line_number: self.line_number,
         })?;
@@ -581,11 +536,11 @@ impl<'a> FieldCursor<'a> {
     }
 
     /// Returns the remaining final field and errors if extra commas remain.
-    fn final_field(self) -> Result<&'a [u8], ASPRError> {
+    fn final_field(self) -> Result<&'a [u8], PopulationReaderError> {
         let extra_commas = self.rest.iter().filter(|&&b| b == b',').count();
         if extra_commas != 0 {
-            return Err(ASPRError::WrongFieldCount {
-                expected: ASPR_EXPECTED_FIELD_COUNT,
+            return Err(PopulationReaderError::WrongFieldCount {
+                expected: EXPECTED_FIELD_COUNT,
                 found: self.found + 1 + extra_commas,
                 line_number: self.line_number,
             });
@@ -595,37 +550,37 @@ impl<'a> FieldCursor<'a> {
     }
 }
 
-#[cfg(all(any(feature = "aspr_tests", feature = "aspr_dataset_tests", feature = "aspr_zip_tests"), test))]
+#[cfg(all(any(feature = "pop_reader_tests", feature = "pop_reader_dataset_tests", feature = "pop_reader_zip_tests"), test))]
 mod tests {
-    //! These tests assume the existence of data at the default ASPR data path and, separately, the existence of the
+    //! These tests assume the existence of data at the default data path and, separately, the existence of the
     //! corresponding zip archive beside it.
     use super::*;
     use std::io::Write;
     use tempfile::tempdir;
     use zip::write::SimpleFileOptions;
 
-    // Enforce serial execution of tests because the "zip" tests mutate the process-global ASPR data path.
+    // Enforce serial execution of tests because the "zip" tests mutate the process-global data path.
     static TEST_MUTEX: Lazy<std::sync::Mutex<()>> = Lazy::new(|| std::sync::Mutex::new(()));
 
-    #[cfg(feature = "aspr_zip_tests")]
+    #[cfg(feature = "pop_reader_zip_tests")]
     fn test_zip_data_path() -> PathBuf {
         let dataset_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join(DEFAULT_ASPR_DATA_PATH)
+            .join(DEFAULT_DATA_PATH)
             .with_extension("zip");
         assert!(dataset_path.exists());
         dataset_path
     }
 
-    #[cfg(feature = "aspr_dataset_tests")]
+    #[cfg(feature = "pop_reader_dataset_tests")]
     fn test_data_path() -> PathBuf {
-        let dataset_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_ASPR_DATA_PATH);
+        let dataset_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_DATA_PATH);
         assert!(dataset_path.exists());
         dataset_path
     }
 
     fn count_ok_records(
-        mut records: impl Iterator<Item = Result<ASPRPersonRecord, ASPRError>>,
-    ) -> Result<usize, ASPRError> {
+        mut records: impl Iterator<Item = Result<PersonRecord, PopulationReaderError>>,
+    ) -> Result<usize, PopulationReaderError> {
         records.try_fold(0usize, |count, record| record.map(|_| count + 1))
     }
 
@@ -637,7 +592,7 @@ mod tests {
         std::fs::create_dir(&csv_dir).unwrap();
         std::fs::write(csv_dir.join("people.csv"), b"age,homeId,schoolId,workplaceId\n").unwrap();
 
-        set_aspr_data_path(temp_dir.path().to_path_buf());
+        set_data_path(temp_dir.path().to_path_buf());
 
         let files: Vec<PathBuf> = iter_csv_files("subdir").unwrap().collect();
         assert_eq!(files, vec![PathBuf::from("subdir").join("people.csv")]);
@@ -658,7 +613,7 @@ mod tests {
             .unwrap();
         zip_writer.finish().unwrap();
 
-        set_aspr_data_path(zip_path);
+        set_data_path(zip_path);
 
         let files: Vec<PathBuf> = iter_csv_files("subdir").unwrap().collect();
         assert_eq!(files, vec![PathBuf::from("subdir").join("people.csv")]);
@@ -680,14 +635,14 @@ mod tests {
         )
         .unwrap();
 
-        set_aspr_data_path(temp_dir.path().to_path_buf());
+        set_data_path(temp_dir.path().to_path_buf());
 
-        let mut records = ASPRRecordIterator::from_path(PathBuf::from("people.csv")).unwrap();
+        let mut records = PersonRecordIterator::from_path(PathBuf::from("people.csv")).unwrap();
 
         assert_eq!(records.next().unwrap().unwrap().age, 35);
         assert!(matches!(
             records.next().unwrap(),
-            Err(ASPRError::Parse {
+            Err(PopulationReaderError::Parse {
                 field_name: "age",
                 line_number: 3,
                 ..
@@ -720,15 +675,15 @@ mod tests {
             .unwrap();
         zip_writer.finish().unwrap();
 
-        set_aspr_data_path(zip_path);
+        set_data_path(zip_path);
 
-        let mut records = ASPRRecordIterator::from_path(PathBuf::from("people.csv")).unwrap();
+        let mut records = PersonRecordIterator::from_path(PathBuf::from("people.csv")).unwrap();
 
         assert_eq!(records.next().unwrap().unwrap().age, 40);
         assert!(matches!(
             records.next().unwrap(),
-            Err(ASPRError::WrongFieldCount {
-                expected: ASPR_EXPECTED_FIELD_COUNT,
+            Err(PopulationReaderError::WrongFieldCount {
+                expected: EXPECTED_FIELD_COUNT,
                 found: 3,
                 line_number: 3,
             })
@@ -737,38 +692,29 @@ mod tests {
         assert!(records.next().is_none());
     }
 
-    #[cfg(feature = "aspr_dataset_tests")]
+    #[cfg(feature = "pop_reader_dataset_tests")]
     #[test]
-    fn test_record_iterator_state_population() {
+    fn test_record_iterator_reads_real_directory_backed_file() {
         let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_data_path());
+        set_data_path(test_data_path());
 
-        let records = ASPRRecordIterator::state_population(USState::WY).unwrap();
-        assert_eq!(count_ok_records(records).unwrap(), 583200);
-    }
-
-    #[cfg(feature = "aspr_dataset_tests")]
-    #[test]
-    fn test_record_iterator_from_path() {
-        let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_data_path());
-
-        let path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
-        let records = match ASPRRecordIterator::from_path(path) {
+        let path = PathBuf::from("cbsa_all_work_school_household").join("AK/Ketchikan AK.csv");
+        let records = match PersonRecordIterator::from_path(path) {
             Ok(records) => records,
             Err(error) => panic!("{error:?}"),
         };
+        // This count is specific to the local ASPR-compatible dataset fixture.
         assert_eq!(count_ok_records(records).unwrap(), 14132);
     }
 
-    #[cfg(feature = "aspr_dataset_tests")]
+    #[cfg(feature = "pop_reader_dataset_tests")]
     #[test]
-    fn test_record_iterator_from_files() {
+    fn test_record_iterator_reads_real_directory_backed_files() {
         let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_data_path());
+        set_data_path(test_data_path());
 
-        let all_path = PathBuf::from(CBSA_ALL_DIR);
-        let only_residents_path = PathBuf::from(CBSA_ONLY_RESIDENTS_DIR);
+        let all_path = PathBuf::from("cbsa_all_work_school_household");
+        let only_residents_path = PathBuf::from("cbsa_only_residents");
         let paths = vec![
             all_path.join("AK/Ketchikan AK.csv"),
             all_path.join("TX/Vernon TX.csv"),
@@ -777,61 +723,32 @@ mod tests {
         ]
         .into_iter();
 
-        let records = ASPRRecordIterator::from_file_iterator(paths);
+        let records = PersonRecordIterator::from_file_iterator(paths);
 
+        // This count is specific to the local ASPR-compatible dataset fixture.
         assert_eq!(count_ok_records(records).unwrap(), 57454);
     }
 
-    #[cfg(feature = "aspr_dataset_tests")]
+    #[cfg(feature = "pop_reader_zip_tests")]
     #[test]
-    fn test_state_row_iter() {
+    fn test_record_iterator_reads_real_zip_backed_file() {
         let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_data_path());
+        set_data_path(test_zip_data_path());
 
-        let state = USState::AL;
-        let state_records = ASPRRecordIterator::state_population(state).unwrap();
-
-        for (idx, record) in state_records.enumerate() {
-            if idx == 10 {
-                break;
-            }
-            println!("{}", record.unwrap());
-        }
-    }
-
-    #[cfg(feature = "aspr_zip_tests")]
-    #[test]
-    fn test_zip_record_iterator_state_population() {
-        let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_zip_data_path());
-
-        let records = match ASPRRecordIterator::state_population(USState::WY) {
-            Ok(records) => records,
-            Err(error) => panic!("{error:?}"),
-        };
-
-        assert_eq!(count_ok_records(records).unwrap(), 583200);
-    }
-
-    #[cfg(feature = "aspr_zip_tests")]
-    #[test]
-    fn test_zip_record_iterator_from_path() {
-        let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_zip_data_path());
-
-        let path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
-        let records = ASPRRecordIterator::from_path(path).unwrap();
+        let path = PathBuf::from("cbsa_all_work_school_household").join("AK/Ketchikan AK.csv");
+        let records = PersonRecordIterator::from_path(path).unwrap();
+        // This count is specific to the local ASPR-compatible dataset fixture.
         assert_eq!(count_ok_records(records).unwrap(), 14132);
     }
 
-    #[cfg(feature = "aspr_zip_tests")]
+    #[cfg(feature = "pop_reader_zip_tests")]
     #[test]
-    fn test_zip_record_iterator_from_files() {
+    fn test_record_iterator_reads_real_zip_backed_files() {
         let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_zip_data_path());
+        set_data_path(test_zip_data_path());
 
-        let all_path = PathBuf::from(CBSA_ALL_DIR);
-        let only_residents_path = PathBuf::from(CBSA_ONLY_RESIDENTS_DIR);
+        let all_path = PathBuf::from("cbsa_all_work_school_household");
+        let only_residents_path = PathBuf::from("cbsa_only_residents");
         let paths = vec![
             all_path.join("AK/Ketchikan AK.csv"),
             all_path.join("TX/Vernon TX.csv"),
@@ -840,25 +757,9 @@ mod tests {
         ]
         .into_iter();
 
-        let records = ASPRRecordIterator::from_file_iterator(paths);
+        let records = PersonRecordIterator::from_file_iterator(paths);
 
+        // This count is specific to the local ASPR-compatible dataset fixture.
         assert_eq!(count_ok_records(records).unwrap(), 57454);
-    }
-
-    #[cfg(feature = "aspr_zip_tests")]
-    #[test]
-    fn test_zip_state_row_iter() {
-        let _guard = TEST_MUTEX.lock();
-        set_aspr_data_path(test_zip_data_path());
-
-        let state = USState::AL;
-        let state_records = ASPRRecordIterator::state_population(state).unwrap();
-
-        for (idx, record) in state_records.enumerate() {
-            if idx == 10 {
-                break;
-            }
-            println!("{}", record.unwrap());
-        }
     }
 }

--- a/src/pop_reader/archive.rs
+++ b/src/pop_reader/archive.rs
@@ -72,14 +72,12 @@ use std::{
 use memchr::memchr;
 use once_cell::sync::Lazy;
 use ouroboros::self_referencing;
-use zip::{read::ZipFile, ZipArchive};
+use zip::{ZipArchive, read::ZipFile};
 
 use super::{
-    errors::{PopulationReaderError, FIPSParserError},
-    parser::{
-        parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id, parse_integer,
-    },
     PersonRecord,
+    errors::{FIPSParserError, PopulationReaderError},
+    parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id, parse_integer},
 };
 
 /// The size of the buffer used to read lines from source data files in the expected format. This is
@@ -154,13 +152,13 @@ impl ZipLineSource {
         let zip_line_source = ZipLineSourceBuilder {
             _archive: ZipArchive::new(reader).map_err(PopulationReaderError::ZipError)?,
             scratch: Vec::new(),
-            line_reader_builder: |archive: &mut ZipArchive<BufReader<File>>| {
-                match archive.by_name(path.to_str().unwrap()) {
-                    Ok(zipped_file) => Some(BufReader::with_capacity(READER_CAPACITY, zipped_file)),
-                    Err(error) => {
-                        maybe_error = Some(PopulationReaderError::ZipError(error));
-                        None
-                    }
+            line_reader_builder: |archive: &mut ZipArchive<BufReader<File>>| match archive
+                .by_name(path.to_str().unwrap())
+            {
+                Ok(zipped_file) => Some(BufReader::with_capacity(READER_CAPACITY, zipped_file)),
+                Err(error) => {
+                    maybe_error = Some(PopulationReaderError::ZipError(error));
+                    None
                 }
             },
         }
@@ -176,6 +174,7 @@ impl ZipLineSource {
 // endregion ZipLineSource
 
 /// Interface abstracting over the different ways to iterate over lines in a source data file.
+#[allow(clippy::large_enum_variant)]
 enum LineIterator {
     File(FileLineSource),
     Zip(ZipLineSource),
@@ -207,22 +206,17 @@ impl LineIterator {
         process_line: impl FnOnce(&[u8]) -> Result<R, PopulationReaderError>,
     ) -> Result<Option<R>, PopulationReaderError> {
         match self {
-
             Self::File(source) => {
                 with_next_line_from_reader(&mut source.reader, &mut source.scratch, process_line)
-            },
-
-            Self::Zip(source) => {
-                source.with_mut(|fields| {
-                    let buf_reader = fields.line_reader.as_mut().unwrap();
-                    with_next_line_from_reader(buf_reader, fields.scratch, process_line)
-                })
             }
 
+            Self::Zip(source) => source.with_mut(|fields| {
+                let buf_reader = fields.line_reader.as_mut().unwrap();
+                with_next_line_from_reader(buf_reader, fields.scratch, process_line)
+            }),
         }
     }
 }
-
 
 /// Reads the next line from a buffered reader and processes it using the provided callback
 /// function.
@@ -335,6 +329,7 @@ pub struct PersonRecordIterator {
 /// Used internally by `PersonRecordIterator::from_file_iterator`, FileRecordIterator exists to unify
 /// “many records from a file” and “one file-level error for a failed file” into a single iterator
 /// type that from_file_iterator can flatten lazily.
+#[allow(clippy::large_enum_variant)]
 enum FileRecordIterator {
     Records(PersonRecordIterator),
     Error(Option<PopulationReaderError>),
@@ -387,15 +382,13 @@ impl PersonRecordIterator {
     pub fn from_file_iterator(
         files: impl Iterator<Item = PathBuf>,
     ) -> impl Iterator<Item = Result<PersonRecord, PopulationReaderError>> {
-        files
-            .map(|path| match Self::from_path(path.clone()) {
-                Ok(records) => FileRecordIterator::Records(records),
-                Err(source) => FileRecordIterator::Error(Some(PopulationReaderError::FileError {
-                    path,
-                    source: Box::new(source),
-                })),
-            })
-            .flatten()
+        files.flat_map(|path| match Self::from_path(path.clone()) {
+            Ok(records) => FileRecordIterator::Records(records),
+            Err(source) => FileRecordIterator::Error(Some(PopulationReaderError::FileError {
+                path,
+                source: Box::new(source),
+            })),
+        })
     }
 }
 
@@ -428,7 +421,7 @@ impl Iterator for PersonRecordIterator {
                             expected: 1,
                             found: 0,
                         },
-                    }
+                    },
                 )?;
             let age = u8::try_from(age).map_err(
                 // The case of an `age` field that is too large.
@@ -439,15 +432,16 @@ impl Iterator for PersonRecordIterator {
                         value_prefix: age.to_string(),
                         capacity: u64::from(u8::MAX),
                     },
-                }
+                },
             )?;
 
-            let home_id = parse_optional_field(fields.next_field()?, parse_fips_home_id)
-                .map_err(|source| PopulationReaderError::Parse {
+            let home_id = parse_optional_field(fields.next_field()?, parse_fips_home_id).map_err(
+                |source| PopulationReaderError::Parse {
                     field_name: "homeId",
                     line_number,
                     source,
-                })?;
+                },
+            )?;
 
             let school_id = parse_optional_field(fields.next_field()?, parse_fips_school_id)
                 .map_err(|source| PopulationReaderError::Parse {
@@ -476,7 +470,8 @@ impl Iterator for PersonRecordIterator {
             Err(error) => {
                 if !matches!(
                     error,
-                    PopulationReaderError::Parse { .. } | PopulationReaderError::WrongFieldCount { .. }
+                    PopulationReaderError::Parse { .. }
+                        | PopulationReaderError::WrongFieldCount { .. }
                 ) {
                     self.failed = true;
                 }
@@ -550,7 +545,14 @@ impl<'a> FieldCursor<'a> {
     }
 }
 
-#[cfg(all(any(feature = "pop_reader_tests", feature = "pop_reader_dataset_tests", feature = "pop_reader_zip_tests"), test))]
+#[cfg(all(
+    any(
+        feature = "pop_reader_tests",
+        feature = "pop_reader_dataset_tests",
+        feature = "pop_reader_zip_tests"
+    ),
+    test
+))]
 mod tests {
     //! These tests assume the existence of data at the default data path and, separately, the existence of the
     //! corresponding zip archive beside it.
@@ -590,7 +592,11 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let csv_dir = temp_dir.path().join("subdir");
         std::fs::create_dir(&csv_dir).unwrap();
-        std::fs::write(csv_dir.join("people.csv"), b"age,homeId,schoolId,workplaceId\n").unwrap();
+        std::fs::write(
+            csv_dir.join("people.csv"),
+            b"age,homeId,schoolId,workplaceId\n",
+        )
+        .unwrap();
 
         set_data_path(temp_dir.path().to_path_buf());
 

--- a/src/pop_reader/archive.rs
+++ b/src/pop_reader/archive.rs
@@ -1,0 +1,864 @@
+/*!
+This module provides facilities to read CSV files in the ASPR person record format.
+
+Throughout this module, source data files are addressed using two paths:
+
+- the **data path**, configured with [`set_aspr_data_path`] and retrieved with [`get_aspr_data_path`]
+- the **file path**, which is always interpreted relative to that data path
+
+The data path can have one of two forms:
+
+- a path to a directory containing source files in the expected format
+- a path to a zip archive containing such files
+
+The same file path is interpreted differently depending on which kind of data path is configured:
+
+- if the data path is a directory, the final source file is `data_path.join(file_path)`
+- if the data path is a zip archive, the file path is the name of the file inside the archive
+
+For example, when reading the ASPR synthetic population dataset itself, if the file path is
+`all_states/ak.csv`, then:
+
+- with data path `/path/to/ASPR_Synthetic_Population`, the source file is
+  `/path/to/ASPR_Synthetic_Population/all_states/ak.csv`
+- with data path `/path/to/ASPR_Synthetic_Population.zip`, the source file is the archive member
+  named `all_states/ak.csv`
+
+Set and get the ASPR data path with the `set_aspr_data_path` and `get_aspr_data_path` functions:
+
+```rust,ignore
+let current_path = get_aspr_data_path();
+println!("The current ASPR data path: {:?}", current_path);
+
+set_aspr_data_path(PathBuf::from("../CDC/data/ASPR_Synthetic_Population.zip"));
+let new_path = get_aspr_data_path();
+println!("The new ASPR data path: {:?}", new_path);
+```
+
+For ASPR-specific conveniences such as [`ALL_STATES_DIR`], [`CBSA_ALL_DIR`],
+[`CBSA_ONLY_RESIDENTS_DIR`], [`NON_CBSA_RESIDENTS_DIR`], and [`MULTI_STATE_DIR`], the assumption is
+that the data path is either:
+
+- `path/to/root/of/unzipped/aspr/dataset`
+- `path/to/ASPR_Synthetic_Population.zip`
+
+You can iterate over the records in a CSV file by passing a file path relative to the configured
+data path to [`ASPRRecordIterator::from_path`]:
+
+```ignore
+# use ixa_aspr::archive::{CBSA_ALL_DIR, ASPRRecordIterator};
+# use std::path::PathBuf;
+let file_path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
+let records = ASPRRecordIterator::from_path(file_path);
+// Do something with the records...
+```
+
+If the data path is the root of an unzipped dataset, that file path refers to
+`cbsa_all_work_school_household/AK/Ketchikan AK.csv` under that directory. If the data path is a zip
+archive, the same file path refers to the archive member with that name.
+
+The [`ASPRRecordIterator::state_population`] convenience method reads the file whose file path is
+`all_states/{state}.csv` relative to the configured data path. This is an ASPR-specific convenience
+and therefore assumes the data path points at either the root of the unzipped ASPR synthetic
+population dataset or the corresponding zip archive.
+
+```ignore
+# use ixa_aspr::archive::{ASPRRecordIterator};
+# use ixa_fips::USState;
+let records = ASPRRecordIterator::state_population(USState::AK);
+// Do something with the records...
+```
+
+You can get a list of CSV file paths in a given subdirectory with [`iter_csv_files`]. The returned
+paths are always relative to the configured data path, so they can be passed directly to
+[`ASPRRecordIterator::from_path`] or [`ASPRRecordIterator::from_file_iterator`]:
+
+```ignore
+# use ixa_aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
+let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
+// Do something with the records...
+```
+*/
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+    sync::RwLock,
+};
+
+use memchr::memchr;
+use once_cell::sync::Lazy;
+use ouroboros::self_referencing;
+use zip::{read::ZipFile, ZipArchive};
+
+use super::{
+    errors::{ASPRError, FIPSParserError},
+    parser::{
+        parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id, parse_integer,
+    },
+    states::USState,
+    ASPRPersonRecord,
+};
+
+/// The size of the buffer used to read lines from source data files in the expected format. This is
+/// chosen to be large enough to keep rebuffering to a minimum, which in turn minimizes the
+/// probability that a line spans a buffer window boundary and thus has to be copied to scratch
+/// memory for processing.
+const ASPR_READER_CAPACITY: usize = 256 * 1024;
+/// The number of fields in each ASPR record: age, homeId, schoolId, workplaceId.
+const ASPR_EXPECTED_FIELD_COUNT: usize = 4;
+
+/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
+/// root, containing one CSV file per state.
+pub const ALL_STATES_DIR: &str = "all_states";
+/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
+/// root, containing CBSA files with all work, school, and household assignments.
+pub const CBSA_ALL_DIR: &str = "cbsa_all_work_school_household";
+/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
+/// root, containing CBSA files restricted to residents.
+pub const CBSA_ONLY_RESIDENTS_DIR: &str = "cbsa_only_residents";
+/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
+/// root, used beneath either CBSA directory for non-CBSA residents.
+pub const NON_CBSA_RESIDENTS_DIR: &str = "non_CBSA_residents";
+/// ASPR synthetic population dataset directory name, relative to the dataset root or zip archive
+/// root, used beneath either CBSA directory for multi-state areas.
+pub const MULTI_STATE_DIR: &str = "Multi-state";
+
+/// Default ASPR data path. By default this points at the root of a local unzipped ASPR dataset.
+const DEFAULT_ASPR_DATA_PATH: &str = "../CDC/data/ASPR_Synthetic_Population";
+// ToDo: Get the ASPR data path from an environment variable.
+static ASPR_DATA_PATH: Lazy<RwLock<PathBuf>> =
+    Lazy::new(|| RwLock::new(PathBuf::from(DEFAULT_ASPR_DATA_PATH)));
+
+/// Sets the ASPR data path.
+///
+/// The data path may be either a directory containing source files in the expected format or the
+/// path to a zip archive containing such files. File paths accepted elsewhere in this module are
+/// always interpreted relative to this data path.
+pub fn set_aspr_data_path(path: PathBuf) {
+    *ASPR_DATA_PATH.write().unwrap() = path;
+}
+
+/// Returns the current ASPR data path.
+///
+/// The returned path is interpreted either as a directory containing source files in the expected
+/// format or as the path to a zip archive containing such files. File paths accepted elsewhere in
+/// this module are always interpreted relative to this data path.
+pub fn get_aspr_data_path() -> PathBuf {
+    ASPR_DATA_PATH.read().unwrap().clone()
+}
+
+/// Byte-oriented line reader over a particular source data file.
+struct FileLineSource {
+    reader: BufReader<File>,
+    scratch: Vec<u8>,
+}
+
+impl FileLineSource {
+    fn from_file(file: File) -> Self {
+        Self {
+            reader: BufReader::with_capacity(ASPR_READER_CAPACITY, file),
+            scratch: Vec::new(),
+        }
+    }
+}
+
+// region ZipLineSource
+
+/// Byte-oriented line reader over a particular source data file within a zip archive.
+#[self_referencing]
+struct ZipLineSource {
+    _archive: ZipArchive<BufReader<File>>,
+    scratch: Vec<u8>,
+
+    // This option is always `Some` after successful construction.
+    #[borrows(mut _archive)]
+    #[covariant]
+    line_reader: Option<BufReader<ZipFile<'this, BufReader<File>>>>,
+}
+
+impl ZipLineSource {
+    /// Constructs a `ZipLineSource` over the lines of the file whose file path is `path` inside the
+    /// zip archive at `archive_path`.
+    fn from_path(archive_path: PathBuf, path: PathBuf) -> Result<Self, ASPRError> {
+        let file = File::open(archive_path).map_err(ASPRError::Io)?;
+        let reader = BufReader::with_capacity(ASPR_READER_CAPACITY, file);
+        let mut maybe_error: Option<ASPRError> = None;
+
+        let zip_line_source = ZipLineSourceBuilder {
+            _archive: ZipArchive::new(reader).map_err(ASPRError::ZipError)?,
+            scratch: Vec::new(),
+            line_reader_builder: |archive: &mut ZipArchive<BufReader<File>>| {
+                match archive.by_name(path.to_str().unwrap()) {
+                    Ok(zipped_file) => Some(BufReader::with_capacity(ASPR_READER_CAPACITY, zipped_file)),
+                    Err(error) => {
+                        maybe_error = Some(ASPRError::ZipError(error));
+                        None
+                    }
+                }
+            },
+        }
+        .build();
+
+        match maybe_error {
+            Some(error) => Err(error),
+            None => Ok(zip_line_source),
+        }
+    }
+}
+
+// endregion ZipLineSource
+
+/// Interface abstracting over the different ways to iterate over lines in a source data file.
+enum LineIterator {
+    File(FileLineSource),
+    Zip(ZipLineSource),
+}
+
+impl LineIterator {
+    /// Returns a line reader over the file whose file path is `file_path` relative to the current
+    /// ASPR data path.
+    ///
+    /// If the ASPR data path is a directory, the source file is `data_path.join(file_path)`. If the
+    /// ASPR data path is a zip archive, `file_path` is the name of the file inside the archive.
+    fn from_path(file_path: PathBuf) -> Result<Self, ASPRError> {
+        let path = get_aspr_data_path();
+
+        if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"))
+        {
+            Ok(Self::Zip(ZipLineSource::from_path(path, file_path)?))
+        } else {
+            let file = File::open(path.join(file_path)).map_err(ASPRError::Io)?;
+            Ok(Self::File(FileLineSource::from_file(file)))
+        }
+    }
+
+    fn with_next_line<R>(
+        &mut self,
+        process_line: impl FnOnce(&[u8]) -> Result<R, ASPRError>,
+    ) -> Result<Option<R>, ASPRError> {
+        match self {
+
+            Self::File(source) => {
+                with_next_line_from_reader(&mut source.reader, &mut source.scratch, process_line)
+            },
+
+            Self::Zip(source) => {
+                source.with_mut(|fields| {
+                    let buf_reader = fields.line_reader.as_mut().unwrap();
+                    with_next_line_from_reader(buf_reader, fields.scratch, process_line)
+                })
+            }
+
+        }
+    }
+}
+
+
+/// Reads the next line from a buffered reader and processes it using the provided callback
+/// function.
+///
+/// This private helper factors out the common logic of chunking out a slice up to the next newline.
+/// In the case that a line spans the boundary of the buffered window, the line is copied into
+/// `scratch`, and a slice into `scratch` rather than the underlying buffer is provided to the
+/// callback.
+fn with_next_line_from_reader<R, Reader>(
+    reader: &mut Reader,
+    scratch: &mut Vec<u8>,
+    process_line: impl FnOnce(&[u8]) -> Result<R, ASPRError>,
+) -> Result<Option<R>, ASPRError>
+where
+    Reader: BufRead,
+{
+    scratch.clear();
+
+    loop {
+        let buf = reader.fill_buf().map_err(ASPRError::Io)?;
+
+        if buf.is_empty() {
+            if scratch.is_empty() {
+                return Ok(None);
+            }
+
+            let line = scratch.as_slice();
+            let line = line.strip_suffix(b"\r").unwrap_or(line);
+            return process_line(line).map(Some);
+        }
+
+        if let Some(newline_index) = memchr(b'\n', buf) {
+            if scratch.is_empty() {
+                let result = {
+                    let line1 = &buf[..newline_index];
+                    let line = line1.strip_suffix(b"\r").unwrap_or(line1);
+                    process_line(line)
+                };
+                reader.consume(newline_index + 1);
+                return result.map(Some);
+            }
+
+            scratch.extend_from_slice(&buf[..newline_index]);
+            let result = {
+                let line1 = scratch.as_slice();
+                let line = line1.strip_suffix(b"\r").unwrap_or(line1);
+                process_line(line)
+            };
+            reader.consume(newline_index + 1);
+            return result.map(Some);
+        }
+
+        scratch.extend_from_slice(buf);
+        let consumed = buf.len();
+        reader.consume(consumed);
+    }
+}
+
+/// Returns an iterator over CSV file paths in the given subdirectory of the current ASPR data path.
+///
+/// `subdirectory` is itself interpreted as a file path relative to the configured ASPR data path. The returned paths
+/// are always relative to the configured ASPR data path as well, regardless of whether the data path is a directory or
+/// a zip archive.
+pub fn iter_csv_files(
+    subdirectory: &'static str,
+) -> Result<std::vec::IntoIter<PathBuf>, ASPRError> {
+    let mut path = get_aspr_data_path();
+
+    if path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"))
+    {
+        let file = File::open(path).map_err(ASPRError::Io)?;
+        let reader = BufReader::with_capacity(ASPR_READER_CAPACITY, file);
+        let archive = ZipArchive::new(reader).map_err(ASPRError::ZipError)?;
+
+        let file_names: Vec<PathBuf> = archive
+            .file_names()
+            .filter(|name| name.starts_with(subdirectory))
+            .map(PathBuf::from)
+            .collect();
+
+        Ok(file_names.into_iter())
+    } else {
+        path.push(subdirectory);
+        let entries = path.read_dir().map_err(ASPRError::Io)?;
+        let mut files = vec![];
+
+        for entry in entries {
+            let entry = entry.map_err(ASPRError::Io)?;
+            if entry.path().is_file() {
+                files.push(PathBuf::from(subdirectory).join(entry.file_name()));
+            }
+        }
+
+        Ok(files.into_iter())
+    }
+}
+
+/// Iterator over ASPR records in a particular data file in the expected ASPR person record format.
+///
+/// The constructors on this type interpret file paths relative to the current ASPR data path.
+pub struct ASPRRecordIterator {
+    line_iter: LineIterator,
+    line_number: usize,
+    failed: bool,
+}
+
+/// Used internally by `ASPRRecordIterator::from_file_iterator`, FileRecordIterator exists to unify
+/// “many records from a file” and “one file-level error for a failed file” into a single iterator
+/// type that from_file_iterator can flatten lazily.
+enum FileRecordIterator {
+    Records(ASPRRecordIterator),
+    Error(Option<ASPRError>),
+}
+
+impl Iterator for FileRecordIterator {
+    type Item = Result<ASPRPersonRecord, ASPRError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            FileRecordIterator::Records(records) => records.next(),
+            FileRecordIterator::Error(error) => error.take().map(Err),
+        }
+    }
+}
+
+impl ASPRRecordIterator {
+    /// Returns an iterator over the records in the file whose file path is `all_states/{state}.csv` relative to the
+    /// current ASPR data path.
+    ///
+    /// This is an ASPR-specific convenience method and assumes the current ASPR data path points at either the root of
+    /// the unzipped ASPR synthetic population dataset or the corresponding zip archive.
+    pub fn state_population(state: USState) -> Result<Self, ASPRError> {
+        let file_name = format!("{}.csv", state.to_static_str().to_lowercase());
+        let mut path = PathBuf::from(ALL_STATES_DIR);
+        path.push(file_name);
+
+        Self::from_path(path)
+    }
+
+    /// Returns an iterator over the records in the file whose file path is `file_path` relative to the current ASPR
+    /// data path.
+    ///
+    /// If the current ASPR data path is a directory, the source file is `data_path.join(file_path)`. If the current
+    /// ASPR data path is a zip archive, `file_path` is the name of the file inside the archive. This function is
+    /// intended to be used with [`iter_csv_files`].
+    pub fn from_path(file_path: PathBuf) -> Result<Self, ASPRError> {
+        let mut line_iter = LineIterator::from_path(file_path.clone())?;
+
+        if line_iter.with_next_line(|_| Ok(()))?.is_none() {
+            return Err(ASPRError::EmptyFile(file_path));
+        }
+
+        Ok(Self {
+            line_iter,
+            line_number: 1,
+            failed: false,
+        })
+    }
+
+    /// Returns an iterator over all the rows of all the files in the iterator.
+    ///
+    /// Each path yielded by `files` is interpreted as a file path relative to the current ASPR data path. If a file
+    /// cannot be opened as an [`ASPRRecordIterator`], this iterator yields [`ASPRError::FileError`] for that path.
+    /// This function is intended to be used with [`iter_csv_files`]:
+    ///
+    /// ```ignore
+    /// # use ixa_aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
+    /// let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
+    /// ```
+    pub fn from_file_iterator(
+        files: impl Iterator<Item = PathBuf>,
+    ) -> impl Iterator<Item = Result<ASPRPersonRecord, ASPRError>> {
+        files
+            .map(|path| match Self::from_path(path.clone()) {
+                Ok(records) => FileRecordIterator::Records(records),
+                Err(source) => FileRecordIterator::Error(Some(ASPRError::FileError {
+                    path,
+                    source: Box::new(source),
+                })),
+            })
+            .flatten()
+    }
+}
+
+impl Iterator for ASPRRecordIterator {
+    type Item = Result<ASPRPersonRecord, ASPRError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.failed {
+            return None;
+        }
+
+        let result = self.line_iter.with_next_line(|line| {
+            self.line_number += 1;
+            let line_number = self.line_number;
+            let mut fields = FieldCursor::new(line, line_number);
+
+            let field = fields.next_field()?;
+            let age = parse_optional_field(field, parse_integer)
+                .map_err(|source| ASPRError::Parse {
+                    field_name: "age",
+                    line_number,
+                    source,
+                })?
+                .ok_or(
+                    // The case of an empty `age` field, which is an error.
+                    ASPRError::Parse {
+                        field_name: "age",
+                        line_number,
+                        source: FIPSParserError::InvalidLength {
+                            expected: 1,
+                            found: 0,
+                        },
+                    }
+                )?;
+            let age = u8::try_from(age).map_err(
+                // The case of an `age` field that is too large.
+                |_| ASPRError::Parse {
+                    field_name: "age",
+                    line_number,
+                    source: FIPSParserError::ValueExceedsCapacity {
+                        value_prefix: age.to_string(),
+                        capacity: u64::from(u8::MAX),
+                    },
+                }
+            )?;
+
+            let home_id = parse_optional_field(fields.next_field()?, parse_fips_home_id)
+                .map_err(|source| ASPRError::Parse {
+                    field_name: "homeId",
+                    line_number,
+                    source,
+                })?;
+
+            let school_id = parse_optional_field(fields.next_field()?, parse_fips_school_id)
+                .map_err(|source| ASPRError::Parse {
+                    field_name: "schoolId",
+                    line_number,
+                    source,
+                })?;
+
+            let work_id = parse_optional_field(fields.final_field()?, parse_fips_workplace_id)
+                .map_err(|source| ASPRError::Parse {
+                    field_name: "workplaceId",
+                    line_number,
+                    source,
+                })?;
+
+            Ok(ASPRPersonRecord {
+                age,
+                home_id,
+                school_id,
+                work_id,
+            })
+        });
+
+        match result {
+            Ok(record) => record.map(Ok),
+            Err(error) => {
+                if !matches!(
+                    error,
+                    ASPRError::Parse { .. } | ASPRError::WrongFieldCount { .. }
+                ) {
+                    self.failed = true;
+                }
+                Some(Err(error))
+            }
+        }
+    }
+}
+
+fn parse_optional_field<T>(
+    field: &[u8],
+    parser: impl Fn(&[u8]) -> Result<(&[u8], T), (&[u8], FIPSParserError)>,
+) -> Result<Option<T>, FIPSParserError> {
+    if field.is_empty() {
+        return Ok(None);
+    }
+
+    let (rest, value) = parser(field).map_err(|(_, source)| source)?;
+    if !rest.is_empty() {
+        return Err(FIPSParserError::InvalidLength {
+            expected: field.len(),
+            found: field.len() - rest.len(),
+        });
+    }
+
+    Ok(Some(value))
+}
+
+struct FieldCursor<'a> {
+    rest: &'a [u8],
+    line_number: usize,
+    found: usize,
+}
+
+impl<'a> FieldCursor<'a> {
+    fn new(line: &'a [u8], line_number: usize) -> Self {
+        Self {
+            rest: line,
+            line_number,
+            found: 0,
+        }
+    }
+
+    /// Returns the next comma-delimited field before the final field, and errors if there are
+    /// not enough fields.
+    fn next_field(&mut self) -> Result<&'a [u8], ASPRError> {
+        let comma = memchr(b',', self.rest).ok_or(ASPRError::WrongFieldCount {
+            expected: ASPR_EXPECTED_FIELD_COUNT,
+            found: self.found + 1,
+            line_number: self.line_number,
+        })?;
+
+        let field = &self.rest[..comma];
+        self.rest = &self.rest[comma + 1..];
+        self.found += 1;
+        Ok(field)
+    }
+
+    /// Returns the remaining final field and errors if extra commas remain.
+    fn final_field(self) -> Result<&'a [u8], ASPRError> {
+        let extra_commas = self.rest.iter().filter(|&&b| b == b',').count();
+        if extra_commas != 0 {
+            return Err(ASPRError::WrongFieldCount {
+                expected: ASPR_EXPECTED_FIELD_COUNT,
+                found: self.found + 1 + extra_commas,
+                line_number: self.line_number,
+            });
+        }
+
+        Ok(self.rest)
+    }
+}
+
+#[cfg(all(any(feature = "aspr_tests", feature = "aspr_dataset_tests", feature = "aspr_zip_tests"), test))]
+mod tests {
+    //! These tests assume the existence of data at the default ASPR data path and, separately, the existence of the
+    //! corresponding zip archive beside it.
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+    use zip::write::SimpleFileOptions;
+
+    // Enforce serial execution of tests because the "zip" tests mutate the process-global ASPR data path.
+    static TEST_MUTEX: Lazy<std::sync::Mutex<()>> = Lazy::new(|| std::sync::Mutex::new(()));
+
+    #[cfg(feature = "aspr_zip_tests")]
+    fn test_zip_data_path() -> PathBuf {
+        let dataset_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(DEFAULT_ASPR_DATA_PATH)
+            .with_extension("zip");
+        assert!(dataset_path.exists());
+        dataset_path
+    }
+
+    #[cfg(feature = "aspr_dataset_tests")]
+    fn test_data_path() -> PathBuf {
+        let dataset_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_ASPR_DATA_PATH);
+        assert!(dataset_path.exists());
+        dataset_path
+    }
+
+    fn count_ok_records(
+        mut records: impl Iterator<Item = Result<ASPRPersonRecord, ASPRError>>,
+    ) -> Result<usize, ASPRError> {
+        records.try_fold(0usize, |count, record| record.map(|_| count + 1))
+    }
+
+    #[test]
+    fn test_iter_csv_files_returns_paths_relative_to_directory_data_path() {
+        let _guard = TEST_MUTEX.lock();
+        let temp_dir = tempdir().unwrap();
+        let csv_dir = temp_dir.path().join("subdir");
+        std::fs::create_dir(&csv_dir).unwrap();
+        std::fs::write(csv_dir.join("people.csv"), b"age,homeId,schoolId,workplaceId\n").unwrap();
+
+        set_aspr_data_path(temp_dir.path().to_path_buf());
+
+        let files: Vec<PathBuf> = iter_csv_files("subdir").unwrap().collect();
+        assert_eq!(files, vec![PathBuf::from("subdir").join("people.csv")]);
+    }
+
+    #[test]
+    fn test_iter_csv_files_returns_paths_relative_to_zip_data_path() {
+        let _guard = TEST_MUTEX.lock();
+        let temp_dir = tempdir().unwrap();
+        let zip_path = temp_dir.path().join("aspr.zip");
+        let zip_file = File::create(&zip_path).unwrap();
+        let mut zip_writer = zip::ZipWriter::new(zip_file);
+        zip_writer
+            .start_file("subdir/people.csv", SimpleFileOptions::default())
+            .unwrap();
+        zip_writer
+            .write_all(b"age,homeId,schoolId,workplaceId\n")
+            .unwrap();
+        zip_writer.finish().unwrap();
+
+        set_aspr_data_path(zip_path);
+
+        let files: Vec<PathBuf> = iter_csv_files("subdir").unwrap().collect();
+        assert_eq!(files, vec![PathBuf::from("subdir").join("people.csv")]);
+    }
+
+    #[test]
+    fn test_record_iterator_reports_row_errors_and_recovers_for_directory_input() {
+        let _guard = TEST_MUTEX.lock();
+        let temp_dir = tempdir().unwrap();
+        let csv_path = temp_dir.path().join("people.csv");
+        std::fs::write(
+            &csv_path,
+            concat!(
+                "age,homeId,schoolId,workplaceId\n",
+                "35,110010109000024,11001009810157,1100100620201546\n",
+                "oops,110010109000024,11001009810157,1100100620201546\n",
+                "36,110010109000024,11001009810157,1100100620201546\n",
+            ),
+        )
+        .unwrap();
+
+        set_aspr_data_path(temp_dir.path().to_path_buf());
+
+        let mut records = ASPRRecordIterator::from_path(PathBuf::from("people.csv")).unwrap();
+
+        assert_eq!(records.next().unwrap().unwrap().age, 35);
+        assert!(matches!(
+            records.next().unwrap(),
+            Err(ASPRError::Parse {
+                field_name: "age",
+                line_number: 3,
+                ..
+            })
+        ));
+        assert_eq!(records.next().unwrap().unwrap().age, 36);
+        assert!(records.next().is_none());
+    }
+
+    #[test]
+    fn test_record_iterator_reports_row_errors_and_recovers_for_zip_input() {
+        let _guard = TEST_MUTEX.lock();
+        let temp_dir = tempdir().unwrap();
+        let zip_path = temp_dir.path().join("aspr.zip");
+        let zip_file = File::create(&zip_path).unwrap();
+        let mut zip_writer = zip::ZipWriter::new(zip_file);
+        zip_writer
+            .start_file("people.csv", SimpleFileOptions::default())
+            .unwrap();
+        zip_writer
+            .write_all(
+                concat!(
+                    "age,homeId,schoolId,workplaceId\n",
+                    "40,110010109000024,11001009810157,1100100620201546\n",
+                    "41,110010109000024,11001009810157\n",
+                    "42,110010109000024,11001009810157,1100100620201546\n",
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        zip_writer.finish().unwrap();
+
+        set_aspr_data_path(zip_path);
+
+        let mut records = ASPRRecordIterator::from_path(PathBuf::from("people.csv")).unwrap();
+
+        assert_eq!(records.next().unwrap().unwrap().age, 40);
+        assert!(matches!(
+            records.next().unwrap(),
+            Err(ASPRError::WrongFieldCount {
+                expected: ASPR_EXPECTED_FIELD_COUNT,
+                found: 3,
+                line_number: 3,
+            })
+        ));
+        assert_eq!(records.next().unwrap().unwrap().age, 42);
+        assert!(records.next().is_none());
+    }
+
+    #[cfg(feature = "aspr_dataset_tests")]
+    #[test]
+    fn test_record_iterator_state_population() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_data_path());
+
+        let records = ASPRRecordIterator::state_population(USState::WY).unwrap();
+        assert_eq!(count_ok_records(records).unwrap(), 583200);
+    }
+
+    #[cfg(feature = "aspr_dataset_tests")]
+    #[test]
+    fn test_record_iterator_from_path() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_data_path());
+
+        let path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
+        let records = match ASPRRecordIterator::from_path(path) {
+            Ok(records) => records,
+            Err(error) => panic!("{error:?}"),
+        };
+        assert_eq!(count_ok_records(records).unwrap(), 14132);
+    }
+
+    #[cfg(feature = "aspr_dataset_tests")]
+    #[test]
+    fn test_record_iterator_from_files() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_data_path());
+
+        let all_path = PathBuf::from(CBSA_ALL_DIR);
+        let only_residents_path = PathBuf::from(CBSA_ONLY_RESIDENTS_DIR);
+        let paths = vec![
+            all_path.join("AK/Ketchikan AK.csv"),
+            all_path.join("TX/Vernon TX.csv"),
+            only_residents_path.join("AK/Ketchikan AK.csv"),
+            only_residents_path.join("TX/Vernon TX.csv"),
+        ]
+        .into_iter();
+
+        let records = ASPRRecordIterator::from_file_iterator(paths);
+
+        assert_eq!(count_ok_records(records).unwrap(), 57454);
+    }
+
+    #[cfg(feature = "aspr_dataset_tests")]
+    #[test]
+    fn test_state_row_iter() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_data_path());
+
+        let state = USState::AL;
+        let state_records = ASPRRecordIterator::state_population(state).unwrap();
+
+        for (idx, record) in state_records.enumerate() {
+            if idx == 10 {
+                break;
+            }
+            println!("{}", record.unwrap());
+        }
+    }
+
+    #[cfg(feature = "aspr_zip_tests")]
+    #[test]
+    fn test_zip_record_iterator_state_population() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_zip_data_path());
+
+        let records = match ASPRRecordIterator::state_population(USState::WY) {
+            Ok(records) => records,
+            Err(error) => panic!("{error:?}"),
+        };
+
+        assert_eq!(count_ok_records(records).unwrap(), 583200);
+    }
+
+    #[cfg(feature = "aspr_zip_tests")]
+    #[test]
+    fn test_zip_record_iterator_from_path() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_zip_data_path());
+
+        let path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
+        let records = ASPRRecordIterator::from_path(path).unwrap();
+        assert_eq!(count_ok_records(records).unwrap(), 14132);
+    }
+
+    #[cfg(feature = "aspr_zip_tests")]
+    #[test]
+    fn test_zip_record_iterator_from_files() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_zip_data_path());
+
+        let all_path = PathBuf::from(CBSA_ALL_DIR);
+        let only_residents_path = PathBuf::from(CBSA_ONLY_RESIDENTS_DIR);
+        let paths = vec![
+            all_path.join("AK/Ketchikan AK.csv"),
+            all_path.join("TX/Vernon TX.csv"),
+            only_residents_path.join("AK/Ketchikan AK.csv"),
+            only_residents_path.join("TX/Vernon TX.csv"),
+        ]
+        .into_iter();
+
+        let records = ASPRRecordIterator::from_file_iterator(paths);
+
+        assert_eq!(count_ok_records(records).unwrap(), 57454);
+    }
+
+    #[cfg(feature = "aspr_zip_tests")]
+    #[test]
+    fn test_zip_state_row_iter() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(test_zip_data_path());
+
+        let state = USState::AL;
+        let state_records = ASPRRecordIterator::state_population(state).unwrap();
+
+        for (idx, record) in state_records.enumerate() {
+            if idx == 10 {
+                break;
+            }
+            println!("{}", record.unwrap());
+        }
+    }
+}

--- a/src/pop_reader/errors.rs
+++ b/src/pop_reader/errors.rs
@@ -1,0 +1,178 @@
+use std::{io::Error as IoError, path::PathBuf};
+use thiserror::Error;
+
+use super::{CountyCode, DataCode, IdCode, SettingCategoryCode, StateCode, TractCode};
+use zip::result::ZipError;
+
+#[derive(Debug, Error)]
+pub enum ASPRError {
+    #[error("ASPR IO error: {0}")]
+    Io(#[source] IoError),
+    #[error("ASPR file error for {path:?}: {source}")]
+    FileError {
+        path: PathBuf,
+        #[source]
+        source: Box<ASPRError>,
+    },
+    #[error("ASPR parse error in {field_name} on line {line_number}: {source}")]
+    Parse {
+        field_name: &'static str,
+        line_number: usize,
+        #[source]
+        source: FIPSParserError,
+    },
+    #[error(
+        "ASPR wrong field count on line {line_number}: expected {expected}, found {found}"
+    )]
+    WrongFieldCount {
+        expected: usize,
+        found: usize,
+        line_number: usize,
+    },
+    #[error("ASPR data file is empty: {0}")]
+    EmptyFile(PathBuf),
+    #[error("ASPR Zip error: {0}")]
+    ZipError(#[source] ZipError),
+}
+
+
+/// The FIPS parser error type.
+///
+/// We assume the length of the input text is small enough that it's not necessary to attach source
+/// location information, e.g. parsing a string containing a single code.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum FIPSParserError {
+    #[error("invalid digit {found:?} at byte index {at_index}")]
+    InvalidDigit {
+        /// The non-digit character, if it decodes as valid UTF-8.
+        found: Option<char>,
+        /// The index of the non-digit character in the input string.
+        at_index: usize
+    },
+    #[error("expected {expected} digits, found {found}")]
+    InvalidLength {
+        /// The exact digit count required by the parser in this context.
+        expected: usize,
+        /// How many digits were actually available before the input ended.
+        found: usize
+    },
+    #[error("value {value_prefix} exceeds maximum {capacity}")]
+    ValueExceedsCapacity {
+        /// The parsed prefix that exceeds the bit-width constraint
+        value_prefix: String,
+        /// The largest value that can be represented in the requested bit width.
+        capacity: u64
+    },
+    #[error("value {value} is not a valid state code")]
+    InvalidStateCode {
+        /// The parsed numeric value
+        value: StateCode
+    }
+}
+
+/// Similar to how Nom structures its results. We have:
+///   `I`: The input type, i.e. `&str`
+///   `O`: The output type, i.e. `u32`
+///   `E`: The error type returns a tuple of the original input and the error.
+/// A successful result consists of the remaining unparsed input and the parsed value.
+pub type IResult<I, O, E = (I, FIPSParserError)> = Result<(I, O), E>;
+pub type FIPSParseResult<'a, T> = IResult<&'a [u8], T>;
+
+/// We only have one error case, namely when a value is out of range. Instances of `FIPSError` are
+/// constructed with the `FIPSError::from_*_code()` constructor methods in the
+/// `FIPSCode::encode_*()` constructor methods.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Error)]
+#[error("value {value} provided for {parameter_name} is outside valid range of {min}..{max}")]
+pub struct FIPSError {
+    parameter_name: &'static str,
+    value: u64,
+    min: u64,
+    max: u64,
+}
+
+impl FIPSError {
+    #[must_use]
+    pub fn new(parameter_name: &'static str, value: u64, min: u64, max: u64) -> Self {
+        Self {
+            parameter_name,
+            value,
+            min,
+            max,
+        }
+    }
+
+    // Convenience constructors for the code types. These should be kept in sync with the module-level documentation
+    // in `fips_code.rs`.
+
+    /// This one is unique in that it represents an error converting a (presumably valid) [`StateCode`] to a [`USState`]
+    /// variant. We lie a little bit and claim that values in 1..57 are valid when 3, 7, 14, 43, and 52 are not.
+    #[must_use]
+    pub fn from_us_state(value: StateCode) -> Self {
+        Self {
+            parameter_name: "USState Code",
+            value: value as u64,
+            min: 1,
+            max: 57, // 1..57
+        }
+    }
+
+    #[must_use]
+    pub fn from_state_code(value: StateCode) -> Self {
+        Self {
+            parameter_name: "StateCode",
+            value: value as u64,
+            min: 1,
+            max: 100, // Two decimal digits
+        }
+    }
+
+    #[must_use]
+    pub fn from_county_code(value: CountyCode) -> Self {
+        Self {
+            parameter_name: "CountyCode",
+            value: value as u64,
+            min: 0,
+            max: 1000, // Three decimal digits
+        }
+    }
+
+    #[must_use]
+    pub fn from_tract_code(value: TractCode) -> Self {
+        Self {
+            parameter_name: "TractCode",
+            value: value as u64,
+            min: 0,
+            max: 1_000_000, // Six decimal digits
+        }
+    }
+
+    #[must_use]
+    pub fn from_setting_category_code(value: SettingCategoryCode) -> Self {
+        Self {
+            parameter_name: "SettingCategoryCode",
+            value: value as u64,
+            min: 0,
+            max: 16, // 2^4
+        }
+    }
+
+    #[must_use]
+    pub fn from_id_code(value: IdCode) -> Self {
+        Self {
+            parameter_name: "IdCode",
+            value: value as u64,
+            min: 0,
+            max: 32_768, // 2^15
+        }
+    }
+
+    #[must_use]
+    pub fn from_data_code(value: DataCode) -> Self {
+        Self {
+            parameter_name: "DataCode",
+            value: value as u64,
+            min: 0,
+            max: 256, // 2^8
+        }
+    }
+}

--- a/src/pop_reader/errors.rs
+++ b/src/pop_reader/errors.rs
@@ -35,7 +35,6 @@ pub enum PopulationReaderError {
     ZipError(#[source] ZipError),
 }
 
-
 /// The FIPS parser error type.
 ///
 /// We assume the length of the input text is small enough that it's not necessary to attach source
@@ -47,27 +46,27 @@ pub enum FIPSParserError {
         /// The non-digit character, if it decodes as valid UTF-8.
         found: Option<char>,
         /// The index of the non-digit character in the input string.
-        at_index: usize
+        at_index: usize,
     },
     #[error("expected {expected} digits, found {found}")]
     InvalidLength {
         /// The exact digit count required by the parser in this context.
         expected: usize,
         /// How many digits were actually available before the input ended.
-        found: usize
+        found: usize,
     },
     #[error("value {value_prefix} exceeds maximum {capacity}")]
     ValueExceedsCapacity {
         /// The parsed prefix that exceeds the bit-width constraint
         value_prefix: String,
         /// The largest value that can be represented in the requested bit width.
-        capacity: u64
+        capacity: u64,
     },
     #[error("value {value} is not a valid state code")]
     InvalidStateCode {
         /// The parsed numeric value
-        value: StateCode
-    }
+        value: StateCode,
+    },
 }
 
 /// Similar to how Nom structures its results. We have:

--- a/src/pop_reader/errors.rs
+++ b/src/pop_reader/errors.rs
@@ -5,16 +5,16 @@ use super::{CountyCode, DataCode, IdCode, SettingCategoryCode, StateCode, TractC
 use zip::result::ZipError;
 
 #[derive(Debug, Error)]
-pub enum ASPRError {
-    #[error("ASPR IO error: {0}")]
+pub enum PopulationReaderError {
+    #[error("population reader IO error: {0}")]
     Io(#[source] IoError),
-    #[error("ASPR file error for {path:?}: {source}")]
+    #[error("population reader file error for {path:?}: {source}")]
     FileError {
         path: PathBuf,
         #[source]
-        source: Box<ASPRError>,
+        source: Box<PopulationReaderError>,
     },
-    #[error("ASPR parse error in {field_name} on line {line_number}: {source}")]
+    #[error("population reader parse error in {field_name} on line {line_number}: {source}")]
     Parse {
         field_name: &'static str,
         line_number: usize,
@@ -22,16 +22,16 @@ pub enum ASPRError {
         source: FIPSParserError,
     },
     #[error(
-        "ASPR wrong field count on line {line_number}: expected {expected}, found {found}"
+        "population reader wrong field count on line {line_number}: expected {expected}, found {found}"
     )]
     WrongFieldCount {
         expected: usize,
         found: usize,
         line_number: usize,
     },
-    #[error("ASPR data file is empty: {0}")]
+    #[error("population reader data file is empty: {0}")]
     EmptyFile(PathBuf),
-    #[error("ASPR Zip error: {0}")]
+    #[error("population reader zip error: {0}")]
     ZipError(#[source] ZipError),
 }
 

--- a/src/pop_reader/fips_code.rs
+++ b/src/pop_reader/fips_code.rs
@@ -1,0 +1,635 @@
+//! Defines the `FIPSCode` types to represent FIPS geographic region codes (and “code fragments”) very efficiently.
+//!
+//! # Encoding Scheme
+//!
+//! A table of how FIPS Geo IDs are structured is provided in the module-level documentation for [`crate::parser`]
+//! (slightly modified from
+//! [the source table in the standard](https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html)).
+//! The rows in the table up to and including Block (that is, all but the last five rows) form a linear order with
+//! respect to prefix inclusion ("is prefix of"). This encoding scheme is for these codes. The last four rows are
+//! treated separately.
+//!
+//! In the following table, we describe the data "fragments" and their storage requirements.
+//!
+//! |                                   | **Decimal Digits** | **Actual Max Value** | **Bits** |    **Capacity (`2^bits - 1`)** |
+//! |:--------------------------------- | ------------------:| --------------------:| --------:| ------------------------------:|
+//! | **Sate**                          |                  2 |                   56 |        7 |                            127 |
+//! | **County**                        |                  3 |                  840 |       10 |                          1,023 |
+//! | **Tract**                         |                  6 |              990,101 |       20 |                      1,048,575 |
+//! | **Subtotal**                      |                    |                      |   **37** | **Bits needed for tract code** |
+//! |                                   |                    |                      |          |                                |
+//! | **Monotonically Increasing Id's** |                    |                      |          |                                |
+//! | **homeId**                        |                4-5 |               20,507 |       15 |                         32,767 |
+//! | **publicschoolId**                |                3-4 |                2,789 |       12 |                          4,095 |
+//! | **privateschoolId**               |                  4 |                1,722 |       11 |                          2,047 |
+//! | **workplaceId**                   |                  5 |               14,938 |       14 |                         16,383 |
+//! | **Max:**                          |                    |                      |   **15** |                                |
+//! | **Total:**                        |                    |                      |   **52** |                                |
+//!
+//! State codes for states have values <= 56, but there are "state codes" for outlying areas, some historic codes, and
+//! maritime extension codes in use in the wild. We therefore use an extra bit than strictly required to represent it.
+//! To the 52 bits apparently required to store this data we add an additional 4 bits for a category tag to distinguish
+//! between home, public school, private school, workplace, and census tract, a field useful for representing ASPR
+//! synthetic population data, for example. Only 2 bits are required to distinguish these 4 categories, so the additional
+//! 2 bits are left unused / for future use.
+//!
+//! We encode this data into a `u64` as follows:
+//!
+//!  | **Data**               |     **State** | **County** | **Tract** |  **Category Tag** | **Monotonically increasing ID number** | **Reserved / Unused** |
+//!  |:---------------------- | -------------:| ----------:| ---------:| -----------------:| --------------------------------------:| ---------------------:|
+//!  | **Bits**               |         63…57 |      56…47 |     46…27 |             26…23 |                                   22…8 |                   7…0 |
+//!  | **Ex. Value**          | `AK`, `AZ`, … |        258 |   223,100 | `Home`, `Work`, … |                                 12,345 |                     0 |
+//!  | **Bit Count**          |             7 |         10 |        20 |                 4 |                                     15 |                     8 |
+//!  | **Capacity**           |           128 |      1,024 | 1,048,576 |                16 |                                 32,768 |                   256 |
+//!  | **Decimal Digits**     |             2 |          3 |         6 |                 - |                                 3 to 5 |                     - |
+//!  | **Max Observed Value** |            56 |        840 |   990,101 |                 4 |                                 20,507 |                     - |
+//!
+//! Observe that:
+//!
+//!  - We give the "category tag" 4 bits to allow up to 16 distinct categories. In some applications this field might be unused.
+//!  - The least significant 8 bits are completely unused by this encoding. It may be used for application-specific storage.
+//!  - The field for ID number only requires 12 bits for `publicschoolId`, for example. That is, the storage it requires
+//!    depends on the category tag.
+//!  - The category tag is encoded after the tract code but before the ID field so that numerical ordering coincides with
+//!    the hierarchical ordering.
+//!  - Likewise, the unused 8 bits are the least significant bits so that numerical ordering coincides with the
+//!    hierarchical ordering modulo those bits.
+//!
+//! # Nonhierarchical FIPS Codes
+//!
+//! The encoding of the previous section excludes the nonhierarchical codes of the last five rows from the first table
+//! above:
+//!
+//!  - Places
+//!  - Congressional District (113th Congress)
+//!  - State Legislative District (Upper Chamber)
+//!  - State Legislative District (Lower Chamber)
+//!  - ZCTA
+//!
+//! We could easily accommodate these codes as well in a variety of ways, e.g.:
+//!  - assign each of these a category tag and store their corresponding code fragments in the ID field
+//!  - use the 15 bits of the ID field and the unused 8 least significant bits, allowing the category tag to remain
+//!    orthogonal
+//!
+//! We leave them unspecified until we have a use case for them.
+use std::cmp::Ordering;
+use std::fmt::{Debug, Display, Formatter};
+use std::num::NonZero;
+use serde::{Deserialize, Serialize};
+use super::{DataCode, errors::FIPSError, states::USState, StateCode, CountyCode, TractCode, SettingCategoryCode, IdCode};
+
+
+// Convenience constants
+const FOUR_BIT_MASK: u8 = 15; // 2^4-1
+const SEVEN_BIT_MASK: u8 = 127; // 2^7-1
+const EIGHT_BIT_MASK: u16 = 255; // 2^8-1
+const TEN_BIT_MASK: u16 = 1023; // 2^10-1
+pub(crate) const FIFTEEN_BIT_MASK: u16 = 32_767; // 2^15-1
+const TWENTY_BIT_MASK: u32 = 1_048_575; // 2^20-1
+
+// Offsets of the bit fields in the encoded FIPS code
+const STATE_OFFSET: usize = 57;
+const COUNTY_OFFSET: usize = 47;
+const TRACT_OFFSET: usize = 27;
+const CATEGORY_OFFSET: usize = 23;
+const ID_OFFSET: usize = 8;
+// const DATA_OFFSET: usize = 0;
+
+/// Encodes a hierarchical FIPS geographic region code in 64 bits. Excludes the nonhierarchical codes places,
+/// congressional or state legislative districts, and ZIP code tabulation areas. (See the
+/// [module level documentation](`crate::fips_code`).)
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FIPSCode(NonZero<u64>);
+
+impl FIPSCode {
+    // region Constructors
+    /// Constructs a new [`FIPSCode`] from a [`USState`]. Unlike the other constructors, this constructor is infallible.
+    #[must_use]
+    pub fn with_state(state: USState) -> Self {
+        Self::new(state.into(), 0, 0, 0, 0, 0).unwrap()
+    }
+    /// Constructs a new [`FIPSCode`].
+    /// Returns `Err(())` if the data provided is out of range.
+    pub fn with_state_code(state_code: StateCode) -> Result<Self, FIPSError> {
+        Self::new(state_code, 0, 0, 0, 0, 0)
+    }
+    /// Constructs a new [`FIPSCode`].
+    /// Returns `Err(())` if the data provided is out of range.
+    pub fn with_county(state: StateCode, county: CountyCode) -> Result<Self, FIPSError> {
+        Self::new(state, county, 0, 0, 0, 0)
+    }
+    /// Constructs a new [`FIPSCode`].
+    /// Returns `Err(())` if the data provided is out of range.
+    pub fn with_tract(
+        state: StateCode,
+        county: CountyCode,
+        tract: TractCode,
+    ) -> Result<Self, FIPSError> {
+        Self::new(state, county, tract, 0, 0, 0)
+    }
+    /// Constructs a new [`FIPSCode`].
+    /// Returns `Err(())` if the data provided is out of range.
+    pub fn with_category(
+        state: StateCode,
+        county: CountyCode,
+        tract: TractCode,
+        category: SettingCategoryCode,
+    ) -> Result<Self, FIPSError> {
+        Self::new(state, county, tract, category, 0, 0)
+    }
+
+    pub fn new(
+        state: StateCode,
+        county: CountyCode,
+        tract: TractCode,
+        category: SettingCategoryCode,
+        id: IdCode,
+        data: DataCode,
+    ) -> Result<Self, FIPSError> {
+        let encoded: u64 = Self::encode_state(state)?
+            | Self::encode_county(county)?
+            | Self::encode_tract(tract)?
+            | Self::encode_category(category)?
+            | Self::encode_id(id)?
+            | Self::encode_data(data)?;
+        // At the very least, `USState.encode()` will return a non-zero value, so this unwrapping is safe.
+        let encoded = NonZero::new(encoded).unwrap();
+        Ok(Self(encoded))
+    }
+    // endregion Constructors
+
+    // region Accessors
+
+    /// Returns the FIPS STATE as a [`USState`] enum variant.
+    /// Returns `Err(())` if [`USState`] cannot represent the state code. Use [`FIPSCode::state_code()`] to
+    /// retrieve the state code in this case.
+    #[inline(always)]
+    pub fn state(&self) -> Result<USState, FIPSError> {
+        USState::decode(self.state_code())
+    }
+
+    /// Returns the FIPS STATE code as a [`StateCode`] (a `u8`)
+    #[inline(always)]
+    #[must_use]
+    pub fn state_code(&self) -> StateCode {
+        // The state code occupies the 7 most significant bits, bits 57..63
+        (self.0.get() >> STATE_OFFSET) as StateCode
+    }
+
+    /// Returns the numeric FIPS COUNTY code
+    #[inline(always)]
+    #[must_use]
+    pub fn county_code(&self) -> CountyCode {
+        // The county code occupies the 10 bits from bits 47..56
+        ((self.0.get() >> COUNTY_OFFSET) as CountyCode) & TEN_BIT_MASK
+    }
+
+    /// Returns the numeric FIPS CENSUS TRACT code
+    #[inline(always)]
+    #[must_use]
+    pub fn census_tract_code(&self) -> TractCode {
+        // The census tract code occupies the 20 bits from bits 27..46
+        ((self.0.get() >> TRACT_OFFSET) as TractCode) & TWENTY_BIT_MASK
+    }
+
+    /// Returns the numeric SETTING CATEGORY code
+    #[inline(always)]
+    #[must_use]
+    pub fn category_code(&self) -> SettingCategoryCode {
+        // The category code occupies the 4 bits from bits 23..26
+        ((self.0.get() >> CATEGORY_OFFSET) as SettingCategoryCode) & FOUR_BIT_MASK
+    }
+
+    /// Returns the monotonically increasing ID number as an [`IdCode`]
+    #[inline(always)]
+    #[must_use]
+    pub fn id(&self) -> IdCode {
+        // The ID number occupies the 15 bits from bits 8..22.
+        ((self.0.get() >> ID_OFFSET) as IdCode) & FIFTEEN_BIT_MASK
+    }
+
+    /// Returns the unused data region occupying the 8 least significant bits.
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&self) -> DataCode {
+        self.0.get() as DataCode & EIGHT_BIT_MASK
+    }
+    // endregion Accessors
+
+    // region Setters
+
+    /// Creates a copy of `self` with the FIPS STATE set to `state`.
+    #[must_use]
+    pub fn set_state(&self, state: USState) -> Self {
+        self.set_state_code(state.into()).unwrap()
+    }
+
+    /// Creates a copy of `self` with the FIPS STATE set to `state`.
+    pub fn set_state_code(&self, state_code: StateCode) -> Result<Self, FIPSError> {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.state = state_code;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the FIPS COUNTY set to `county`.
+    pub fn set_county(&self, county: CountyCode) -> Result<Self, FIPSError> {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.county = county;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the FIPS CENSUS TRACT set to `tract`.
+    pub fn set_tract(&self, tract: TractCode) -> Result<Self, FIPSError> {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.tract = tract;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the setting category set to `category`.
+    pub fn set_category(&self, category: SettingCategoryCode) -> Result<Self, FIPSError> {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.category = category;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the ID number set to `id`.
+    pub fn set_id(&self, id: IdCode) -> Result<Self, FIPSError> {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.id = id;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the unused data region set to `data`.
+    pub fn set_data(&self, data: DataCode) -> Result<Self, FIPSError> {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.data = data;
+        expanded.to_fips_code()
+    }
+
+    // endregion Setters
+
+    /// Sets the unused data region occupying the 8 least significant bits in place.
+    /// Returns `Ok(())` if `data` is in range, `Err(FIPSError)` otherwise.
+    #[inline(always)]
+    pub fn set_data_in_place(&mut self, data: DataCode) -> Result<(), FIPSError> {
+        if data <= EIGHT_BIT_MASK {
+            let inverse_mask = !(EIGHT_BIT_MASK as u64);
+            let code = (self.0.get() & inverse_mask) | ((data & EIGHT_BIT_MASK) as u64);
+            // The result is guaranteed to be nonzero if the original code was valid, so unwrap will succeed.
+            self.0 = NonZero::new(code).unwrap();
+            Ok(())
+        } else {
+            Err(FIPSError::from_data_code(data))
+        }
+    }
+
+    /// Compares the given values without respect to the data region (the Least Significant Bits). Use the usual
+    /// equality operators for comparing `FIPSCode`s including the data region.
+    #[inline(always)]
+    #[must_use]
+    pub fn compare_non_data(&self, other: Self) -> Ordering {
+        let inverse_mask = !(EIGHT_BIT_MASK as u64);
+        let this = self.0.get() & inverse_mask;
+        let other = other.0.get() & inverse_mask;
+
+        this.cmp(&other)
+    }
+
+    // region Encoding
+    // It is convenient to factor out the encode operations into their own functions.
+    // These functions take numeric values and return encoded `u64` values. To encode
+    // enum variants, call the `encode` function on the enum variant.
+
+    #[inline(always)]
+    fn encode_state(state: StateCode) -> Result<u64, FIPSError> {
+        // Validate: Two decimal digits
+        if state <= 99 && state != 0 {
+            Ok((state as u64) << STATE_OFFSET)
+        } else {
+            Err(FIPSError::from_state_code(state))
+        }
+    }
+
+    #[inline(always)]
+    fn encode_county(county: CountyCode) -> Result<u64, FIPSError> {
+        // Validate: Three decimal digits
+        if county <= 999 {
+            Ok((county as u64) << COUNTY_OFFSET)
+        } else {
+            Err(FIPSError::from_county_code(county))
+        }
+    }
+
+    #[inline(always)]
+    fn encode_tract(tract: TractCode) -> Result<u64, FIPSError> {
+        // Validate: Six decimal digits
+        if tract <= 999_999 {
+            Ok((tract as u64) << TRACT_OFFSET)
+        } else {
+            Err(FIPSError::from_tract_code(tract))
+        }
+    }
+
+    #[inline(always)]
+    fn encode_category(setting_category: SettingCategoryCode) -> Result<u64, FIPSError> {
+        // Validate
+        if setting_category <= FOUR_BIT_MASK {
+            Ok((setting_category as u64) << CATEGORY_OFFSET)
+        } else {
+            Err(FIPSError::from_setting_category_code(setting_category))
+        }
+    }
+
+    #[inline(always)]
+    fn encode_id(id: IdCode) -> Result<u64, FIPSError> {
+        // Validate
+        if id <= FIFTEEN_BIT_MASK {
+            Ok((id as u64) << ID_OFFSET)
+        } else {
+            Err(FIPSError::from_id_code(id))
+        }
+    }
+
+    #[inline(always)]
+    fn encode_data(data: DataCode) -> Result<u64, FIPSError> {
+        // Validate
+        if data <= EIGHT_BIT_MASK {
+            Ok(data as u64)
+        } else {
+            Err(FIPSError::from_data_code(data))
+        }
+    }
+    // endregion Encoding
+}
+
+impl Display for FIPSCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", ExpandedFIPSCode::from_fips_code(*self))
+    }
+}
+
+impl Debug for FIPSCode {
+    /// Format the code as a string of hex digits with fields separated by dashes. Note that this is different
+    /// from serializing to the original FIPS code encoding. Use `format_as_fips_code`/`format_as_fips_code`
+    /// for that purpose.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:02}", self.state_code())?;
+        write!(f, "-{:03}", self.county_code())?;
+        write!(f, "-{:06}", self.census_tract_code())?;
+        write!(f, "-{:01}", self.category_code())?;
+        write!(f, "-{:05}", self.id())?;
+        write!(f, "-{:02x}", self.data())?;
+        Ok(())
+    }
+}
+
+/// A struct that holds an expanded version of a [`FIPSCode`] in which all fields are represented by
+/// their associated numeric types.
+///
+/// It is up to the client code to ensure the field values are within
+/// range. See the module level docs for range constraints.
+///
+/// This struct is useful for converting raw data to/from a [`FIPSCode`] for temporary direct field access.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct ExpandedFIPSCode {
+    pub state: StateCode,
+    pub county: CountyCode,
+    pub tract: TractCode,
+    pub category: SettingCategoryCode,
+    pub id: IdCode,
+    pub data: DataCode,
+}
+
+impl ExpandedFIPSCode {
+    #[must_use]
+    pub fn from_fips_code(fips_code: FIPSCode) -> Self {
+        Self {
+            state: fips_code.state_code(),
+            county: fips_code.county_code(),
+            tract: fips_code.census_tract_code(),
+            category: fips_code.category_code(),
+            id: fips_code.id(),
+            data: fips_code.data(),
+        }
+    }
+
+    pub fn to_fips_code(&self) -> Result<FIPSCode, FIPSError> {
+        FIPSCode::new(
+            self.state,
+            self.county,
+            self.tract,
+            self.category,
+            self.id,
+            self.data,
+        )
+    }
+}
+
+impl Display for ExpandedFIPSCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Format the state if possible
+        if let Ok(state) = USState::decode(self.state) {
+            write!(f, "state: {}", state)?;
+        } else {
+            write!(f, "state: {}", self.state)?;
+        }
+        // For the remaining fields, only print them if they are nonzero
+        if self.county != 0 {
+            write!(f, ", county: {}", self.county)?;
+        }
+        if self.tract != 0 {
+            write!(f, ", tract: {}", self.tract)?;
+        }
+        if self.category != 0 {
+            write!(f, ", setting: {}", self.category)?;
+        }
+        if self.id != 0 {
+            write!(f, ", id: {}", self.id)?;
+        }
+        if self.data != 0 {
+            write!(f, ", data field: {}", self.data)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[repr(u8)]
+    enum SettingCategory {
+        Unspecified = 0,
+        Home,
+        School,
+        Work,
+        CensusTract,
+    }
+
+    impl From<SettingCategory> for SettingCategoryCode {
+        fn from(value: SettingCategory) -> Self {
+            value as SettingCategoryCode
+        }
+    }
+
+    #[test]
+    fn test_data_ranges() {
+        // Encode functions
+        assert!(FIPSCode::encode_state(99).is_ok());
+        assert!(FIPSCode::encode_state(100).is_err());
+        assert!(FIPSCode::encode_county(999).is_ok());
+        assert!(FIPSCode::encode_county(1000).is_err());
+        assert!(FIPSCode::encode_tract(999_999).is_ok());
+        assert!(FIPSCode::encode_tract(1_000_000).is_err());
+        assert!(FIPSCode::encode_category(FOUR_BIT_MASK).is_ok());
+        assert!(FIPSCode::encode_category(FOUR_BIT_MASK + 1).is_err());
+        assert!(FIPSCode::encode_id(FIFTEEN_BIT_MASK).is_ok());
+        assert!(FIPSCode::encode_id(FIFTEEN_BIT_MASK + 1).is_err());
+        assert!(FIPSCode::encode_data(EIGHT_BIT_MASK).is_ok());
+        assert!(FIPSCode::encode_data(EIGHT_BIT_MASK + 1).is_err());
+        // Constructors
+        assert!(FIPSCode::with_state_code(1).is_ok());
+        assert!(FIPSCode::with_state_code(0).is_err());
+        assert!(FIPSCode::with_state_code(100).is_err());
+        assert!(FIPSCode::with_county(1, 0).is_ok());
+        assert!(FIPSCode::with_county(1, 1000).is_err());
+        assert!(FIPSCode::with_tract(1, 0, 0).is_ok());
+        assert!(FIPSCode::with_tract(1, 0, 1_000_000).is_err());
+        assert!(FIPSCode::with_category(1, 0, 0, 0).is_ok());
+        assert!(FIPSCode::with_category(1, 0, 0, FOUR_BIT_MASK + 1).is_err());
+    }
+
+    #[test]
+    fn fields_round_trip() {
+        let fips_code = FIPSCode::new(
+            USState::TX.into(),
+            123,
+            990101,
+            SettingCategory::Home.into(),
+            14938,
+            123,
+        )
+        .unwrap();
+        assert_eq!(fips_code.state().unwrap(), USState::TX);
+        assert_eq!(fips_code.county_code(), 123);
+        assert_eq!(fips_code.census_tract_code(), 990101);
+        assert_eq!(fips_code.category_code(), <SettingCategory as Into<u8>>::into(SettingCategory::Home));
+        assert_eq!(fips_code.id(), 14938);
+        assert_eq!(fips_code.data(), 123);
+    }
+
+    #[test]
+    fn expanded_round_trip() {
+        let fips_code = FIPSCode::new(
+            USState::TX.into(),
+            123,
+            990101,
+            SettingCategory::Home.into(),
+            14938,
+            0x00ff,
+        )
+        .unwrap();
+        let expanded = ExpandedFIPSCode::from_fips_code(fips_code);
+        let result = expanded.to_fips_code().unwrap();
+        assert_eq!(result, fips_code);
+    }
+
+    #[test]
+    fn test_compare_non_data() {
+        let fips_code_a = FIPSCode::new(
+            USState::TX.into(),
+            123,
+            990101,
+            SettingCategory::Home.into(),
+            14938,
+            0x00ff,
+        )
+        .unwrap();
+        let fips_code_b = FIPSCode::new(
+            USState::TX.into(),
+            123,
+            990101,
+            SettingCategory::Home.into(),
+            14938,
+            0x000f,
+        )
+        .unwrap();
+
+        assert_eq!(fips_code_a.compare_non_data(fips_code_b), Ordering::Equal);
+        assert_eq!(fips_code_a.cmp(&fips_code_b), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_set_id() {
+        // Exercises case that triggered a bug that causes a panic.
+        let fips_code = FIPSCode::with_category(
+            USState::AK.into(),
+            0,
+            0,
+            SettingCategory::CensusTract.into(),
+        )
+        .unwrap();
+
+        let other_fips_code = fips_code.set_id(0).unwrap();
+        assert_eq!(fips_code, other_fips_code);
+    }
+
+    #[test]
+    fn test_fips_error() {
+        let err = FIPSError::new("foo", 1, 2, 3);
+        assert_eq!(
+            format!("{}", err),
+            "value 1 provided for foo is outside valid range of 2..3"
+        );
+
+        let e = USState::decode(58).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 58 provided for USState Code is outside valid range of 1..57"
+        );
+
+        let e = FIPSCode::encode_state(100).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 100 provided for StateCode is outside valid range of 1..100"
+        );
+
+        let e = FIPSCode::encode_state(0).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 0 provided for StateCode is outside valid range of 1..100"
+        );
+
+        let e = FIPSCode::encode_county(1000).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 1000 provided for CountyCode is outside valid range of 0..1000"
+        );
+
+        let e = FIPSCode::encode_tract(1_000_000).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 1000000 provided for TractCode is outside valid range of 0..1000000"
+        );
+
+        let e = FIPSCode::encode_category(16).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 16 provided for SettingCategoryCode is outside valid range of 0..16"
+        );
+
+        let e = FIPSCode::encode_id(32_768).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 32768 provided for IdCode is outside valid range of 0..32768"
+        );
+
+        let e = FIPSCode::encode_data(256).unwrap_err();
+        assert_eq!(
+            e.to_string(),
+            "value 256 provided for DataCode is outside valid range of 0..256"
+        );
+    }
+}

--- a/src/pop_reader/fips_code.rs
+++ b/src/pop_reader/fips_code.rs
@@ -72,12 +72,14 @@
 //!    orthogonal
 //!
 //! We leave them unspecified until we have a use case for them.
+use super::{
+    CountyCode, DataCode, IdCode, SettingCategoryCode, StateCode, TractCode, errors::FIPSError,
+    states::USState,
+};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::num::NonZero;
-use serde::{Deserialize, Serialize};
-use super::{DataCode, errors::FIPSError, states::USState, StateCode, CountyCode, TractCode, SettingCategoryCode, IdCode};
-
 
 // Convenience constants
 const FOUR_BIT_MASK: u8 = 15; // 2^4-1
@@ -515,7 +517,10 @@ mod tests {
         assert_eq!(fips_code.state().unwrap(), USState::TX);
         assert_eq!(fips_code.county_code(), 123);
         assert_eq!(fips_code.census_tract_code(), 990101);
-        assert_eq!(fips_code.category_code(), <SettingCategory as Into<u8>>::into(SettingCategory::Home));
+        assert_eq!(
+            fips_code.category_code(),
+            <SettingCategory as Into<u8>>::into(SettingCategory::Home)
+        );
         assert_eq!(fips_code.id(), 14938);
         assert_eq!(fips_code.data(), 123);
     }

--- a/src/pop_reader/mod.rs
+++ b/src/pop_reader/mod.rs
@@ -1,0 +1,251 @@
+/*!
+
+This module provides routines to make it easier to work with the ASPR synthetic population dataset.
+It provides basic parsing functionality for parsing the codes found in the dataset. The `archive`
+submodule additionally allows for reading CSV files in this format, including files within zipped
+archives. That submodule addresses source files using a configured data path plus file paths that
+are interpreted relative to that data path; see [`archive`] for the detailed path semantics and
+examples.
+
+This dataset encodes `homeId`, `schoolId`, and `workplaceId` using a FIPS geographic region code
+prefix. The published ASPR description says that each row has a single entry for each person with:
+
+1. **Age** as an integer by single year
+2. **Home ID** as an 11-digit tract plus a 4-digit within-tract sequential id
+3. **School ID** as either:
+    - Public: 11-digit tract + 3-digit within-tract sequential id
+    - Private: 5-digit county + “xprvx” + 4-digit within-county sequential id
+4. **Work ID** as an 11-digit tract plus a 5-digit within-tract sequential id
+
+However, the observed ASPR synthetic population data is slightly wider in some categories:
+
+- home IDs may use a 5-digit suffix when the within-tract sequence exceeds 9,999
+- public-school IDs may use a 4-digit suffix when the within-tract sequence exceeds 999
+- private-school IDs are still observed with a 4-digit suffix
+- workplace IDs are still observed with a 5-digit suffix
+
+This module therefore treats the geographic prefix as fixed-width, but parses the setting-id suffix as
+an integer and requires only that it be nonempty and fit in the 15-bit `FIPSCode` id field.
+
+These IDs are encoded as a `FIPSCode` struct from `ixa-fips`, an efficient 64-bit representation.
+This type is re-exported for convenience.
+
+*/
+#![allow(dead_code)]
+
+use std::fmt::{Display, Write};
+
+
+pub use fips_code::FIPSCode;
+
+pub mod archive;
+pub mod errors;
+pub mod parser;
+pub mod states;
+pub mod fips_code;
+
+
+// Numeric types used for code fragments. By convention, zero values are reserved for "no data."
+
+/// The numeric type used for the state code fragment; `u8`
+pub type StateCode = u8;
+/// The numeric type used for the county code fragment; `u16`
+pub type CountyCode = u16;
+/// The numeric type used for the tract code fragment; `u32`
+pub type TractCode = u32;
+/// The numeric type used for the setting category code fragment; `u8`
+pub type SettingCategoryCode = u8;
+/// The numeric type used for the id code fragment; `u16`
+pub type IdCode = u16;
+/// The numeric type used for the data code fragment; `u16`
+pub type DataCode = u16;
+
+
+/// A record representing a person in the ASPR synthetic population dataset.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
+pub struct ASPRPersonRecord {
+    pub age: u8,
+    pub home_id: Option<FIPSCode>,
+    pub school_id: Option<FIPSCode>,
+    pub work_id: Option<FIPSCode>,
+}
+
+impl Display for ASPRPersonRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Age: {}", self.age)?;
+
+        if let Some(home) = &self.home_id {
+            write!(f, ", Home: ({})", home)?;
+        }
+        if let Some(school) = &self.school_id {
+            write!(f, ", School: ({})", school)?;
+        }
+        if let Some(work) = &self.work_id {
+            write!(f, ", Work: ({})", work)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A `ASPRSettingCategory` is not a FIPS code but is implicit in the ASPR synthetic population dataset
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
+#[repr(u8)]
+pub enum ASPRSettingCategory {
+    // We expect applications that do not use `SettingCategory` to have this field zeroed out.
+    #[default]
+    Unspecified = 0,
+    Home,
+    Workplace,
+    PublicSchool,
+    PrivateSchool,
+    CensusTract,
+}
+
+impl ASPRSettingCategory {
+    /// Decode a numeric value to a `SettingCategory`
+    #[inline(always)]
+    pub fn decode(value: SettingCategoryCode) -> Option<Self> {
+        // ToDo: This isn't great, as we need to keep this limit updated with the number of variants in `SettingCategory`.
+        if value <= 5 {
+            Some(unsafe { std::mem::transmute(value) })
+        } else {
+            None
+        }
+    }
+
+    /// Encode a `SettingCategory` as a `u8`
+    #[inline(always)]
+    pub fn encode(self) -> SettingCategoryCode {
+        self as u8
+    }
+}
+
+impl From<ASPRSettingCategory> for SettingCategoryCode {
+    fn from(category: ASPRSettingCategory) -> Self {
+        category.encode()
+    }
+}
+
+impl Display for ASPRSettingCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ASPRSettingCategory::Unspecified => write!(f, "Unspecified"),
+            ASPRSettingCategory::Home => write!(f, "Home"),
+            ASPRSettingCategory::Workplace => write!(f, "Workplace"),
+            ASPRSettingCategory::PublicSchool => write!(f, "Public School"),
+            ASPRSettingCategory::PrivateSchool => write!(f, "Private School"),
+            ASPRSettingCategory::CensusTract => write!(f, "Census Tract"),
+        }
+    }
+}
+
+/// This formats the FIPS code as a string according to the ASPR format, which augments FIPS region
+/// codes with setting IDs. The category code and "data" field are not represented in this format.
+/// However, this function should round-trip for IDs from the ASPR synthetic population dataset.
+fn format_as_fips_code<W: Write>(f: &mut W, fips_code: FIPSCode) -> std::fmt::Result {
+    write!(f, "{:02}", fips_code.state_code())?;
+    write!(f, "{:03}", fips_code.county_code())?;
+
+    match ASPRSettingCategory::decode(fips_code.category_code()) {
+        Some(ASPRSettingCategory::Home) => {
+            // Published form: 11-digit tract + 4-digit within-tract sequential id.
+            // The width is a minimum, so observed 5-digit suffixes are preserved.
+            write!(f, "{:06}", fips_code.census_tract_code())?;
+            write!(f, "{:04}", fips_code.id())
+        }
+
+        Some(ASPRSettingCategory::Workplace) => {
+            // Published form: 11-digit tract + 5-digit within-tract sequential id.
+            write!(f, "{:06}", fips_code.census_tract_code())?;
+            write!(f, "{:05}", fips_code.id())
+        }
+
+        Some(ASPRSettingCategory::PublicSchool) => {
+            // Published form: 11-digit tract + 3-digit within-tract sequential id.
+            // The width is a minimum, so observed 4-digit suffixes are preserved.
+            write!(f, "{:06}", fips_code.census_tract_code())?;
+            write!(f, "{:03}", fips_code.id())
+        }
+
+        Some(ASPRSettingCategory::PrivateSchool) => {
+            // Published form: 5-digit county + “xprvx” + 4-digit within-county sequential id
+            write!(f, "xprvx")?;
+            write!(f, "{:04}", fips_code.id())
+        }
+
+        // ToDo: Give a reasonable representation for these categories.
+        Some(ASPRSettingCategory::Unspecified)
+        | Some(ASPRSettingCategory::CensusTract)
+        | None => Err(std::fmt::Error),
+    }
+    // The category code and "data" field are not represented in this format.
+    // write!(f, "{:01}", fips_code.category_code())?;
+    // write!(f, "{:03}", fips_code.data())?;
+}
+
+fn format_as_fips_code_string(fips_code: FIPSCode) -> String {
+    let mut buf = String::new();
+    format_as_fips_code(&mut buf, fips_code).unwrap();
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pop_reader::parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id};
+
+    #[test]
+    fn text_round_trip_formatting() {
+        let home_id = "110010109000024";
+        let workplace_id = "1100100620201546";
+        let public_school_id = "11001009810157";
+        let private_school_id = "24031xprvx0085";
+
+        let (_, parsed_home_id) = parse_fips_home_id(home_id.as_bytes()).unwrap();
+        let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id.as_bytes()).unwrap();
+        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id.as_bytes()).unwrap();
+        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id.as_bytes()).unwrap();
+
+        assert_eq!(home_id, format_as_fips_code_string(parsed_home_id));
+        assert_eq!(
+            workplace_id,
+            format_as_fips_code_string(parsed_workplace_id)
+        );
+        assert_eq!(
+            public_school_id,
+            format_as_fips_code_string(parsed_public_school_id)
+        );
+        assert_eq!(
+            private_school_id,
+            format_as_fips_code_string(parsed_private_school_id)
+        );
+    }
+
+    #[test]
+    fn text_round_trip_formatting_for_observed_wider_suffixes() {
+        let home_id = "1600101040120507";
+        let workplace_id = "1600101040114938";
+        let public_school_id = "160010104012789";
+        let private_school_id = "24031xprvx1722";
+
+        let (_, parsed_home_id) = parse_fips_home_id(home_id.as_bytes()).unwrap();
+        let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id.as_bytes()).unwrap();
+        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id.as_bytes()).unwrap();
+        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id.as_bytes()).unwrap();
+
+        assert_eq!(home_id, format_as_fips_code_string(parsed_home_id));
+        assert_eq!(
+            workplace_id,
+            format_as_fips_code_string(parsed_workplace_id)
+        );
+        assert_eq!(
+            public_school_id,
+            format_as_fips_code_string(parsed_public_school_id)
+        );
+        assert_eq!(
+            private_school_id,
+            format_as_fips_code_string(parsed_private_school_id)
+        );
+    }
+}

--- a/src/pop_reader/mod.rs
+++ b/src/pop_reader/mod.rs
@@ -40,10 +40,9 @@ pub use fips_code::FIPSCode;
 
 pub mod archive;
 pub mod errors;
+pub mod fips_code;
 pub mod parser;
 pub mod states;
-pub mod fips_code;
-
 
 // Numeric types used for code fragments. By convention, zero values are reserved for "no data."
 
@@ -59,7 +58,6 @@ pub type SettingCategoryCode = u8;
 pub type IdCode = u16;
 /// The numeric type used for the data code fragment; `u16`
 pub type DataCode = u16;
-
 
 /// A parsed person record from the supported CSV format.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
@@ -178,7 +176,9 @@ fn format_as_fips_code_string(fips_code: FIPSCode) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pop_reader::parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id};
+    use crate::pop_reader::parser::{
+        parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id,
+    };
 
     #[test]
     fn text_round_trip_formatting() {
@@ -189,8 +189,10 @@ mod tests {
 
         let (_, parsed_home_id) = parse_fips_home_id(home_id.as_bytes()).unwrap();
         let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id.as_bytes()).unwrap();
-        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id.as_bytes()).unwrap();
-        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id.as_bytes()).unwrap();
+        let (_, parsed_public_school_id) =
+            parse_fips_school_id(public_school_id.as_bytes()).unwrap();
+        let (_, parsed_private_school_id) =
+            parse_fips_school_id(private_school_id.as_bytes()).unwrap();
 
         assert_eq!(home_id, format_as_fips_code_string(parsed_home_id));
         assert_eq!(
@@ -216,8 +218,10 @@ mod tests {
 
         let (_, parsed_home_id) = parse_fips_home_id(home_id.as_bytes()).unwrap();
         let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id.as_bytes()).unwrap();
-        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id.as_bytes()).unwrap();
-        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id.as_bytes()).unwrap();
+        let (_, parsed_public_school_id) =
+            parse_fips_school_id(public_school_id.as_bytes()).unwrap();
+        let (_, parsed_private_school_id) =
+            parse_fips_school_id(private_school_id.as_bytes()).unwrap();
 
         assert_eq!(home_id, format_as_fips_code_string(parsed_home_id));
         assert_eq!(

--- a/src/pop_reader/mod.rs
+++ b/src/pop_reader/mod.rs
@@ -1,14 +1,13 @@
 /*!
 
-This module provides routines to make it easier to work with the ASPR synthetic population dataset.
-It provides basic parsing functionality for parsing the codes found in the dataset. The `archive`
-submodule additionally allows for reading CSV files in this format, including files within zipped
-archives. That submodule addresses source files using a configured data path plus file paths that
-are interpreted relative to that data path; see [`archive`] for the detailed path semantics and
-examples.
+This module provides routines for working with a compatible population person-record format.
+It includes parsing functionality for the setting identifiers found in that format. The `archive`
+submodule additionally reads CSV files in this format, including files within zipped archives.
+That submodule addresses source files using a configured data path plus file paths interpreted
+relative to that data path; see [`archive`] for the detailed path semantics and examples.
 
-This dataset encodes `homeId`, `schoolId`, and `workplaceId` using a FIPS geographic region code
-prefix. The published ASPR description says that each row has a single entry for each person with:
+This format encodes `homeId`, `schoolId`, and `workplaceId` using a FIPS geographic region code
+prefix. Compatible rows have a single entry for each person with:
 
 1. **Age** as an integer by single year
 2. **Home ID** as an 11-digit tract plus a 4-digit within-tract sequential id
@@ -17,7 +16,7 @@ prefix. The published ASPR description says that each row has a single entry for
     - Private: 5-digit county + “xprvx” + 4-digit within-county sequential id
 4. **Work ID** as an 11-digit tract plus a 5-digit within-tract sequential id
 
-However, the observed ASPR synthetic population data is slightly wider in some categories:
+However, observed data in commonly used datasets is slightly wider in some categories:
 
 - home IDs may use a 5-digit suffix when the within-tract sequence exceeds 9,999
 - public-school IDs may use a 4-digit suffix when the within-tract sequence exceeds 999
@@ -35,6 +34,7 @@ This type is re-exported for convenience.
 
 use std::fmt::{Display, Write};
 
+use strum::FromRepr;
 
 pub use fips_code::FIPSCode;
 
@@ -61,16 +61,16 @@ pub type IdCode = u16;
 pub type DataCode = u16;
 
 
-/// A record representing a person in the ASPR synthetic population dataset.
+/// A parsed person record from the supported CSV format.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
-pub struct ASPRPersonRecord {
+pub struct PersonRecord {
     pub age: u8,
     pub home_id: Option<FIPSCode>,
     pub school_id: Option<FIPSCode>,
     pub work_id: Option<FIPSCode>,
 }
 
-impl Display for ASPRPersonRecord {
+impl Display for PersonRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Age: {}", self.age)?;
 
@@ -88,10 +88,10 @@ impl Display for ASPRPersonRecord {
     }
 }
 
-/// A `ASPRSettingCategory` is not a FIPS code but is implicit in the ASPR synthetic population dataset
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
+/// A `PopulationReaderSettingCategory` is not itself a FIPS code, but it is implicit in this population record format.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug, FromRepr)]
 #[repr(u8)]
-pub enum ASPRSettingCategory {
+pub enum PopulationReaderSettingCategory {
     // We expect applications that do not use `SettingCategory` to have this field zeroed out.
     #[default]
     Unspecified = 0,
@@ -102,18 +102,7 @@ pub enum ASPRSettingCategory {
     CensusTract,
 }
 
-impl ASPRSettingCategory {
-    /// Decode a numeric value to a `SettingCategory`
-    #[inline(always)]
-    pub fn decode(value: SettingCategoryCode) -> Option<Self> {
-        // ToDo: This isn't great, as we need to keep this limit updated with the number of variants in `SettingCategory`.
-        if value <= 5 {
-            Some(unsafe { std::mem::transmute(value) })
-        } else {
-            None
-        }
-    }
-
+impl PopulationReaderSettingCategory {
     /// Encode a `SettingCategory` as a `u8`
     #[inline(always)]
     pub fn encode(self) -> SettingCategoryCode {
@@ -121,62 +110,56 @@ impl ASPRSettingCategory {
     }
 }
 
-impl From<ASPRSettingCategory> for SettingCategoryCode {
-    fn from(category: ASPRSettingCategory) -> Self {
-        category.encode()
-    }
-}
-
-impl Display for ASPRSettingCategory {
+impl Display for PopulationReaderSettingCategory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ASPRSettingCategory::Unspecified => write!(f, "Unspecified"),
-            ASPRSettingCategory::Home => write!(f, "Home"),
-            ASPRSettingCategory::Workplace => write!(f, "Workplace"),
-            ASPRSettingCategory::PublicSchool => write!(f, "Public School"),
-            ASPRSettingCategory::PrivateSchool => write!(f, "Private School"),
-            ASPRSettingCategory::CensusTract => write!(f, "Census Tract"),
+            PopulationReaderSettingCategory::Unspecified => write!(f, "Unspecified"),
+            PopulationReaderSettingCategory::Home => write!(f, "Home"),
+            PopulationReaderSettingCategory::Workplace => write!(f, "Workplace"),
+            PopulationReaderSettingCategory::PublicSchool => write!(f, "Public School"),
+            PopulationReaderSettingCategory::PrivateSchool => write!(f, "Private School"),
+            PopulationReaderSettingCategory::CensusTract => write!(f, "Census Tract"),
         }
     }
 }
 
-/// This formats the FIPS code as a string according to the ASPR format, which augments FIPS region
-/// codes with setting IDs. The category code and "data" field are not represented in this format.
-/// However, this function should round-trip for IDs from the ASPR synthetic population dataset.
+/// Serializes a `FIPSCode` value to the same string format expected by the population file
+/// reader and parser code. The category code and "data" field are not represented in this format.
+/// This should round-trip for supported IDs, including ASPR-compatible dataset values.
 fn format_as_fips_code<W: Write>(f: &mut W, fips_code: FIPSCode) -> std::fmt::Result {
     write!(f, "{:02}", fips_code.state_code())?;
     write!(f, "{:03}", fips_code.county_code())?;
 
-    match ASPRSettingCategory::decode(fips_code.category_code()) {
-        Some(ASPRSettingCategory::Home) => {
+    match PopulationReaderSettingCategory::from_repr(fips_code.category_code()) {
+        Some(PopulationReaderSettingCategory::Home) => {
             // Published form: 11-digit tract + 4-digit within-tract sequential id.
             // The width is a minimum, so observed 5-digit suffixes are preserved.
             write!(f, "{:06}", fips_code.census_tract_code())?;
             write!(f, "{:04}", fips_code.id())
         }
 
-        Some(ASPRSettingCategory::Workplace) => {
+        Some(PopulationReaderSettingCategory::Workplace) => {
             // Published form: 11-digit tract + 5-digit within-tract sequential id.
             write!(f, "{:06}", fips_code.census_tract_code())?;
             write!(f, "{:05}", fips_code.id())
         }
 
-        Some(ASPRSettingCategory::PublicSchool) => {
+        Some(PopulationReaderSettingCategory::PublicSchool) => {
             // Published form: 11-digit tract + 3-digit within-tract sequential id.
             // The width is a minimum, so observed 4-digit suffixes are preserved.
             write!(f, "{:06}", fips_code.census_tract_code())?;
             write!(f, "{:03}", fips_code.id())
         }
 
-        Some(ASPRSettingCategory::PrivateSchool) => {
+        Some(PopulationReaderSettingCategory::PrivateSchool) => {
             // Published form: 5-digit county + “xprvx” + 4-digit within-county sequential id
             write!(f, "xprvx")?;
             write!(f, "{:04}", fips_code.id())
         }
 
         // ToDo: Give a reasonable representation for these categories.
-        Some(ASPRSettingCategory::Unspecified)
-        | Some(ASPRSettingCategory::CensusTract)
+        Some(PopulationReaderSettingCategory::Unspecified)
+        | Some(PopulationReaderSettingCategory::CensusTract)
         | None => Err(std::fmt::Error),
     }
     // The category code and "data" field are not represented in this format.
@@ -184,6 +167,8 @@ fn format_as_fips_code<W: Write>(f: &mut W, fips_code: FIPSCode) -> std::fmt::Re
     // write!(f, "{:03}", fips_code.data())?;
 }
 
+/// Serializes a `FIPSCode` value to a `String` in the same format expected by the population
+/// file reader and parser code.
 fn format_as_fips_code_string(fips_code: FIPSCode) -> String {
     let mut buf = String::new();
     format_as_fips_code(&mut buf, fips_code).unwrap();

--- a/src/pop_reader/parser.rs
+++ b/src/pop_reader/parser.rs
@@ -2,14 +2,8 @@
 //! These high-level functions parse the concatenated FIPS code and ids.
 
 use super::{
-    errors::FIPSParserError,
-    fips_code::FIFTEEN_BIT_MASK,
-    CountyCode,
-    IdCode,
-    TractCode,
-    FIPSCode,
-    PopulationReaderSettingCategory,
-    StateCode
+    CountyCode, FIPSCode, IdCode, PopulationReaderSettingCategory, StateCode, TractCode,
+    errors::FIPSParserError, fips_code::FIFTEEN_BIT_MASK,
 };
 
 /// Parser result used throughout this module.
@@ -37,7 +31,7 @@ pub fn parse_decimal_digits_to_bits(
     let mut input_bytes = input.iter();
     let mut computed_value: u64 = 0;
 
-    for idx in 0..digit_count as usize {
+    for idx in 0..digit_count {
         match input_bytes.next() {
             Some(c) => {
                 if c.is_ascii_digit() {
@@ -92,7 +86,7 @@ pub fn parse_decimal_digits_to_bits(
         } // end match next byte
     } // end for idx
 
-    let remaining = &input[digit_count as usize..];
+    let remaining = &input[digit_count..];
     Ok((remaining, computed_value))
 }
 
@@ -305,8 +299,10 @@ pub fn parse_integer(input: &[u8]) -> FIPSParseResult<u64> {
 
 #[cfg(test)]
 mod tests {
-    use crate::pop_reader::{fips_code::ExpandedFIPSCode, StateCode, states::USState, SettingCategoryCode};
     use super::*;
+    use crate::pop_reader::{
+        SettingCategoryCode, StateCode, fips_code::ExpandedFIPSCode, states::USState,
+    };
 
     #[test]
     fn test_parse_home_id() {
@@ -358,7 +354,10 @@ mod tests {
 
         // Maximum allowed value (15 bits max = 32767)
         assert_eq!(parse_private_school_id(b"32767"), Ok((&b""[..], 32767)));
-        assert_eq!(parse_private_school_id(b"xprvx32767"), Ok((&b""[..], 32767)));
+        assert_eq!(
+            parse_private_school_id(b"xprvx32767"),
+            Ok((&b""[..], 32767))
+        );
 
         // Edge cases
         assert_eq!(parse_private_school_id(b"0000test"), Ok((&b"test"[..], 0)));
@@ -401,7 +400,10 @@ mod tests {
         assert_eq!(parse_public_school_id(b"2789"), Ok((&b""[..], 2789)));
 
         // Maximum allowed value (15 bits max = 32767)
-        assert_eq!(parse_public_school_id(b"32767abc"), Ok((&b"abc"[..], 32767)));
+        assert_eq!(
+            parse_public_school_id(b"32767abc"),
+            Ok((&b"abc"[..], 32767))
+        );
 
         // Edge cases
         assert_eq!(parse_public_school_id(b"000test"), Ok((&b"test"[..], 0)));
@@ -540,7 +542,8 @@ mod tests {
         let state_code: StateCode = USState::ID.into();
         let county_code: CountyCode = 1;
         let tract_code: TractCode = 10401;
-        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::PublicSchool.encode();
+        let setting_cat_code: SettingCategoryCode =
+            PopulationReaderSettingCategory::PublicSchool.encode();
         let public_school_id_code = 2789;
 
         let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id).unwrap();
@@ -558,7 +561,8 @@ mod tests {
         let state_code: StateCode = 24;
         let county_code: CountyCode = 31;
         let tract_code: TractCode = 0;
-        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::PrivateSchool.encode();
+        let setting_cat_code: SettingCategoryCode =
+            PopulationReaderSettingCategory::PrivateSchool.encode();
         let private_school_id_code = 1722;
 
         let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id).unwrap();
@@ -576,7 +580,8 @@ mod tests {
         let state_code: StateCode = USState::ID.into();
         let county_code: CountyCode = 1;
         let tract_code: TractCode = 10401;
-        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::Workplace.encode();
+        let setting_cat_code: SettingCategoryCode =
+            PopulationReaderSettingCategory::Workplace.encode();
         let workplace_id_code = 14938;
 
         let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id).unwrap();

--- a/src/pop_reader/parser.rs
+++ b/src/pop_reader/parser.rs
@@ -8,7 +8,7 @@ use super::{
     IdCode,
     TractCode,
     FIPSCode,
-    ASPRSettingCategory,
+    PopulationReaderSettingCategory,
     StateCode
 };
 
@@ -115,14 +115,14 @@ pub fn parse_fips_home_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
         state,
         county,
         tract,
-        ASPRSettingCategory::Home.into(),
+        PopulationReaderSettingCategory::Home.encode(),
         home_id,
         0,
     );
     match fips_code {
         Ok(fips_code) => Ok((rest, fips_code)),
         Err(_) => {
-            panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+            panic!("FIPS code is invalid. This is a bug in the population ID parser.");
         }
     }
 }
@@ -140,14 +140,14 @@ pub fn parse_fips_school_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
             state,
             county,
             0,
-            ASPRSettingCategory::PrivateSchool.into(),
+            PopulationReaderSettingCategory::PrivateSchool.encode(),
             school_id,
             0,
         );
         match fips_code {
             Ok(fips_code) => Ok((rest, fips_code)),
             Err(_) => {
-                panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+                panic!("FIPS code is invalid. This is a bug in the population ID parser.");
             }
         }
     } else {
@@ -159,14 +159,14 @@ pub fn parse_fips_school_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
             state,
             county,
             tract,
-            ASPRSettingCategory::PublicSchool.into(),
+            PopulationReaderSettingCategory::PublicSchool.encode(),
             school_id,
             0,
         );
         match fips_code {
             Ok(fips_code) => Ok((rest, fips_code)),
             Err(_) => {
-                panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+                panic!("FIPS code is invalid. This is a bug in the population ID parser.");
             }
         }
     }
@@ -184,14 +184,14 @@ pub fn parse_fips_workplace_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
         state,
         county,
         tract,
-        ASPRSettingCategory::Workplace.into(),
+        PopulationReaderSettingCategory::Workplace.encode(),
         workplace_id,
         0,
     );
     match fips_code {
         Ok(fips_code) => Ok((rest, fips_code)),
         Err(_) => {
-            panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+            panic!("FIPS code is invalid. This is a bug in the population ID parser.");
         }
     }
 }
@@ -212,7 +212,7 @@ fn parse_tract_code(input: &[u8]) -> FIPSParseResult<TractCode> {
 /// parsed value fits in the 15-bit `FIPSCode` id field. Unlike many other `parse_*` functions,
 /// this function consumes all remaining decimal digits of the input.
 // ToDo: Is it an error if we do not parse the minimum number of digits described in the description
-//       of the ASPR dataset? Right now: an empty string is an error, but any nonempty string of
+//       for this population format? Right now: an empty string is an error, but any nonempty string of
 //       digits is allowed as long as it fits in the 15-bit id field.
 fn parse_setting_id(input: &[u8]) -> FIPSParseResult<IdCode> {
     let (rest, value) = parse_integer(input)?;
@@ -474,7 +474,7 @@ mod tests {
         let state_code: StateCode = USState::ID.into();
         let county_code: CountyCode = 1;
         let tract_code: TractCode = 10401;
-        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::Home.into();
+        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::Home.encode();
         let home_id_code = 10000;
 
         let (_, parsed_home_id) = parse_fips_home_id(home_id).unwrap();
@@ -540,7 +540,7 @@ mod tests {
         let state_code: StateCode = USState::ID.into();
         let county_code: CountyCode = 1;
         let tract_code: TractCode = 10401;
-        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::PublicSchool.into();
+        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::PublicSchool.encode();
         let public_school_id_code = 2789;
 
         let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id).unwrap();
@@ -558,7 +558,7 @@ mod tests {
         let state_code: StateCode = 24;
         let county_code: CountyCode = 31;
         let tract_code: TractCode = 0;
-        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::PrivateSchool.into();
+        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::PrivateSchool.encode();
         let private_school_id_code = 1722;
 
         let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id).unwrap();
@@ -576,7 +576,7 @@ mod tests {
         let state_code: StateCode = USState::ID.into();
         let county_code: CountyCode = 1;
         let tract_code: TractCode = 10401;
-        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::Workplace.into();
+        let setting_cat_code: SettingCategoryCode = PopulationReaderSettingCategory::Workplace.encode();
         let workplace_id_code = 14938;
 
         let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id).unwrap();

--- a/src/pop_reader/parser.rs
+++ b/src/pop_reader/parser.rs
@@ -1,0 +1,826 @@
+#![allow(mismatched_lifetime_syntaxes)]
+//! These high-level functions parse the concatenated FIPS code and ids.
+
+use super::{
+    errors::FIPSParserError,
+    fips_code::FIFTEEN_BIT_MASK,
+    CountyCode,
+    IdCode,
+    TractCode,
+    FIPSCode,
+    ASPRSettingCategory,
+    StateCode
+};
+
+/// Parser result used throughout this module.
+///
+/// On success, returns `(remaining_input, parsed_value)`. On failure,
+/// returns `(original_input, error)`, where `error` is a [`FIPSParserError`].
+pub type FIPSParseResult<'a, T> = Result<(&'a [u8], T), (&'a [u8], FIPSParserError)>;
+
+/// Parses a fixed number of ASCII decimal digits from `input`, enforcing that the parsed value
+/// fits into `bit_count` bits.
+///
+/// This mirrors `ixa_fips::parser::parse_decimal_digits_to_bits`, but operates on `&[u8]`
+/// instead of `&str` to avoid UTF-8/string handling on CSV byte slices.
+pub fn parse_decimal_digits_to_bits(
+    digit_count: usize,
+    bit_count: u8,
+    input: &[u8],
+) -> FIPSParseResult<'_, u64> {
+    let maximum_allowed_value = if bit_count >= 64 {
+        // Shifting by >= 64 bits is undefined behavior
+        u64::MAX
+    } else {
+        (1u64 << bit_count) - 1
+    };
+    let mut input_bytes = input.iter();
+    let mut computed_value: u64 = 0;
+
+    for idx in 0..digit_count as usize {
+        match input_bytes.next() {
+            Some(c) => {
+                if c.is_ascii_digit() {
+                    let digit = (c - b'0') as u64;
+
+                    // Enforce the bit count constraint.
+                    if computed_value > maximum_allowed_value / 10
+                        || (computed_value == maximum_allowed_value / 10
+                            && digit > maximum_allowed_value % 10)
+                    {
+                        return Err((
+                            input,
+                            FIPSParserError::ValueExceedsCapacity {
+                                value_prefix: std::str::from_utf8(&input[..=idx])
+                                    .unwrap()
+                                    .to_owned(),
+                                capacity: maximum_allowed_value,
+                            },
+                        ));
+                    }
+
+                    computed_value = computed_value * 10 + digit;
+                } else {
+                    // Try to decode the offending character as UTF-8.
+                    // The UTF-8 encoded character at `idx` might not be represented as a single byte.
+                    // However, as we assume ASCII decimal digits, we are guaranteed that the first
+                    // `idx-1` bytes represent `idx-1` characters.
+                    let found = std::str::from_utf8(&input[idx..])
+                        .ok()
+                        .and_then(|s| s.chars().next());
+
+                    return Err((
+                        input,
+                        FIPSParserError::InvalidDigit {
+                            found,
+                            at_index: idx,
+                        },
+                    ));
+                }
+            }
+
+            None => {
+                // Ran out of digits before we were done parsing.
+                return Err((
+                    input,
+                    FIPSParserError::InvalidLength {
+                        expected: digit_count,
+                        found: idx,
+                    },
+                ));
+            }
+        } // end match next byte
+    } // end for idx
+
+    let remaining = &input[digit_count as usize..];
+    Ok((remaining, computed_value))
+}
+
+/// Parses the first two decimal digits of `input` into a [`StateCode`].
+fn parse_state_code(input: &[u8]) -> FIPSParseResult<StateCode> {
+    parse_decimal_digits_to_bits(2, 7, input).map(|(rest, value)| (rest, value as StateCode))
+}
+
+/// Parses the input as a FIPS code for a home id. Returns `(rest, FIPSCode)`,
+/// where `rest` is the remaining input after the FIPS code.
+pub fn parse_fips_home_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
+    let (rest, state): (&[u8], StateCode) = parse_state_code(input)?;
+    let (rest, county): (&[u8], CountyCode) = parse_county_code(rest)?;
+    let (rest, tract): (&[u8], TractCode) = parse_tract_code(rest)?;
+    let (rest, home_id): (&[u8], IdCode) = parse_home_id(rest)?;
+
+    // Because the parser functions verify that the parsed values fit into the required number of bits,
+    // this should be infallible unless the parser and `FIPSCode` constructor invariants drift apart.
+    let fips_code = FIPSCode::new(
+        state,
+        county,
+        tract,
+        ASPRSettingCategory::Home.into(),
+        home_id,
+        0,
+    );
+    match fips_code {
+        Ok(fips_code) => Ok((rest, fips_code)),
+        Err(_) => {
+            panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+        }
+    }
+}
+
+/// Parses the input as a FIPS code for a school id. Returns `(rest, FIPSCode)`,
+/// where `rest` is the remaining input after the FIPS code.
+pub fn parse_fips_school_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
+    let (rest, state): (&[u8], StateCode) = parse_state_code(input)?;
+    let (rest, county): (&[u8], CountyCode) = parse_county_code(rest)?;
+
+    if rest.starts_with(b"x") {
+        // Private school id
+        let (rest, school_id): (&[u8], IdCode) = parse_private_school_id(rest)?;
+        let fips_code = FIPSCode::new(
+            state,
+            county,
+            0,
+            ASPRSettingCategory::PrivateSchool.into(),
+            school_id,
+            0,
+        );
+        match fips_code {
+            Ok(fips_code) => Ok((rest, fips_code)),
+            Err(_) => {
+                panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+            }
+        }
+    } else {
+        // Public school
+        // Public schools also have a tract code.
+        let (rest, tract): (&[u8], TractCode) = parse_tract_code(rest)?;
+        let (rest, school_id): (&[u8], IdCode) = parse_public_school_id(rest)?;
+        let fips_code = FIPSCode::new(
+            state,
+            county,
+            tract,
+            ASPRSettingCategory::PublicSchool.into(),
+            school_id,
+            0,
+        );
+        match fips_code {
+            Ok(fips_code) => Ok((rest, fips_code)),
+            Err(_) => {
+                panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+            }
+        }
+    }
+}
+
+/// Parses the input as a FIPS code for a workplace id. Returns `(rest, FIPSCode)`,
+/// where `rest` is the remaining input after the FIPS code.
+pub fn parse_fips_workplace_id(input: &[u8]) -> FIPSParseResult<FIPSCode> {
+    let (rest, state): (&[u8], StateCode) = parse_state_code(input)?;
+    let (rest, county): (&[u8], CountyCode) = parse_county_code(rest)?;
+    let (rest, tract): (&[u8], TractCode) = parse_tract_code(rest)?;
+    let (rest, workplace_id): (&[u8], IdCode) = parse_workplace_id(rest)?;
+
+    let fips_code = FIPSCode::new(
+        state,
+        county,
+        tract,
+        ASPRSettingCategory::Workplace.into(),
+        workplace_id,
+        0,
+    );
+    match fips_code {
+        Ok(fips_code) => Ok((rest, fips_code)),
+        Err(_) => {
+            panic!("FIPS code is invalid. This is a bug in the ASPR parser.");
+        }
+    }
+}
+
+/// Parses the first three digits of `input` as a county code. Enforces the requirement that the
+/// value is representable using 10 bits (which is tautologically always true).
+fn parse_county_code(input: &[u8]) -> FIPSParseResult<CountyCode> {
+    parse_decimal_digits_to_bits(3, 10, input).map(|(rest, value)| (rest, value as CountyCode))
+}
+
+/// Parses the first six digits of `input` as a tract code. Enforces the requirement that the value
+/// is representable using 20 bits (which is tautologically always true).
+fn parse_tract_code(input: &[u8]) -> FIPSParseResult<TractCode> {
+    parse_decimal_digits_to_bits(6, 20, input).map(|(rest, value)| (rest, value as TractCode))
+}
+
+/// Parses the next sequence of decimal digits in `input` as a setting id and verifies that the
+/// parsed value fits in the 15-bit `FIPSCode` id field. Unlike many other `parse_*` functions,
+/// this function consumes all remaining decimal digits of the input.
+// ToDo: Is it an error if we do not parse the minimum number of digits described in the description
+//       of the ASPR dataset? Right now: an empty string is an error, but any nonempty string of
+//       digits is allowed as long as it fits in the 15-bit id field.
+fn parse_setting_id(input: &[u8]) -> FIPSParseResult<IdCode> {
+    let (rest, value) = parse_integer(input)?;
+
+    if value <= u64::from(FIFTEEN_BIT_MASK) {
+        Ok((rest, value as IdCode))
+    } else {
+        let parsed_len = input.len() - rest.len();
+        Err((
+            input,
+            FIPSParserError::ValueExceedsCapacity {
+                value_prefix: std::str::from_utf8(&input[..parsed_len])
+                    .unwrap()
+                    .to_owned(),
+                capacity: u64::from(FIFTEEN_BIT_MASK),
+            },
+        ))
+    }
+}
+
+/// Parses the next sequence of decimal digits in `input` as a home id and verifies that the value
+/// fits in the 15-bit `FIPSCode` id field.
+fn parse_home_id(input: &[u8]) -> FIPSParseResult<IdCode> {
+    parse_setting_id(input)
+}
+
+/// Parses the next sequence of decimal digits in `input` as a private-school id after stripping
+/// `"xprvx"`, if it exists, and verifies that the value fits in the 15-bit `FIPSCode` id field.
+fn parse_private_school_id(input: &[u8]) -> FIPSParseResult<IdCode> {
+    let input = input.strip_prefix(b"xprvx").unwrap_or(input);
+    parse_setting_id(input)
+}
+
+/// Parses the next sequence of decimal digits in `input` as a public-school id and verifies that
+/// the value fits in the 15-bit `FIPSCode` id field.
+fn parse_public_school_id(input: &[u8]) -> FIPSParseResult<IdCode> {
+    parse_setting_id(input)
+}
+
+/// Parses the next sequence of decimal digits in `input` as a workplace id and verifies that the
+/// value fits in the 15-bit `FIPSCode` id field.
+fn parse_workplace_id(input: &[u8]) -> FIPSParseResult<IdCode> {
+    parse_setting_id(input)
+}
+
+/// Parses the next sequence of decimal digits in `input` without respect to its length or how many
+/// bits are required to represent it (though it must implicitly be at most 64).
+pub fn parse_integer(input: &[u8]) -> FIPSParseResult<u64> {
+    let mut computed_value = 0u64;
+    const MAXIMUM_ALLOWED_VALUE: u64 = u64::MAX;
+    let mut idx = 0usize;
+
+    // Find the first non-digit character while accumulating the value.
+    for &c in input {
+        if c.is_ascii_digit() {
+            let digit = u64::from(c - b'0');
+
+            if computed_value > MAXIMUM_ALLOWED_VALUE / 10
+                || (computed_value == MAXIMUM_ALLOWED_VALUE / 10
+                    && digit > MAXIMUM_ALLOWED_VALUE % 10)
+            {
+                return Err((
+                    input,
+                    FIPSParserError::ValueExceedsCapacity {
+                        value_prefix: std::str::from_utf8(&input[..=idx]).unwrap().to_owned(),
+                        capacity: MAXIMUM_ALLOWED_VALUE,
+                    },
+                ));
+            }
+
+            computed_value = computed_value * 10 + digit;
+            idx += 1;
+        } else {
+            break;
+        }
+    }
+
+    if idx == 0 {
+        return Err((
+            input,
+            FIPSParserError::InvalidLength {
+                expected: 1,
+                found: 0,
+            },
+        ));
+    }
+
+    Ok((&input[idx..], computed_value))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::pop_reader::{fips_code::ExpandedFIPSCode, StateCode, states::USState, SettingCategoryCode};
+    use super::*;
+
+    #[test]
+    fn test_parse_home_id() {
+        // Basic successful parsing
+        assert_eq!(parse_home_id(b"1234rest"), Ok((&b"rest"[..], 1234)));
+        assert_eq!(parse_home_id(b"0001xyz"), Ok((&b"xyz"[..], 1)));
+        assert_eq!(parse_home_id(b"20507"), Ok((&b""[..], 20507)));
+
+        // Maximum allowed value (15 bits max = 32767)
+        assert_eq!(parse_home_id(b"32767abc"), Ok((&b"abc"[..], 32767)));
+
+        // Edge cases
+        assert_eq!(parse_home_id(b"0000test"), Ok((&b"test"[..], 0)));
+        assert_eq!(parse_home_id(b"12"), Ok((&b""[..], 12)));
+
+        // Error cases
+        assert!(parse_home_id(b"").is_err()); // Empty string
+        assert!(parse_home_id(b"abc").is_err()); // No digits
+        assert_eq!(
+            parse_home_id(b"32768"),
+            Err((
+                &b"32768"[..],
+                FIPSParserError::ValueExceedsCapacity {
+                    value_prefix: "32768".to_owned(),
+                    capacity: u64::from(FIFTEEN_BIT_MASK),
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_private_school_id() {
+        // Basic successful parsing
+        assert_eq!(
+            parse_private_school_id(b"1234rest"),
+            Ok((&b"rest"[..], 1234))
+        );
+        assert_eq!(parse_private_school_id(b"0001xyz"), Ok((&b"xyz"[..], 1)));
+
+        // With 'xprvx' prefix
+        assert_eq!(
+            parse_private_school_id(b"xprvx1234rest"),
+            Ok((&b"rest"[..], 1234))
+        );
+        assert_eq!(
+            parse_private_school_id(b"xprvx1722xyz"),
+            Ok((&b"xyz"[..], 1722))
+        );
+
+        // Maximum allowed value (15 bits max = 32767)
+        assert_eq!(parse_private_school_id(b"32767"), Ok((&b""[..], 32767)));
+        assert_eq!(parse_private_school_id(b"xprvx32767"), Ok((&b""[..], 32767)));
+
+        // Edge cases
+        assert_eq!(parse_private_school_id(b"0000test"), Ok((&b"test"[..], 0)));
+        assert_eq!(
+            parse_private_school_id(b"xprvx0000test"),
+            Ok((&b"test"[..], 0))
+        );
+
+        // Error cases
+        assert!(parse_private_school_id(b"").is_err()); // Empty string
+        assert!(parse_private_school_id(b"xprvx").is_err()); // Empty after prefix
+        assert!(parse_private_school_id(b"xprvxabc").is_err()); // No digits after prefix
+        assert_eq!(
+            parse_private_school_id(b"32768"),
+            Err((
+                &b"32768"[..],
+                FIPSParserError::ValueExceedsCapacity {
+                    value_prefix: "32768".to_owned(),
+                    capacity: u64::from(FIFTEEN_BIT_MASK),
+                },
+            ))
+        );
+        assert_eq!(
+            parse_private_school_id(b"xprvx32768"),
+            Err((
+                &b"32768"[..],
+                FIPSParserError::ValueExceedsCapacity {
+                    value_prefix: "32768".to_owned(),
+                    capacity: u64::from(FIFTEEN_BIT_MASK),
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_public_school_id() {
+        // Basic successful parsing
+        assert_eq!(parse_public_school_id(b"123rest"), Ok((&b"rest"[..], 123)));
+        assert_eq!(parse_public_school_id(b"001xyz"), Ok((&b"xyz"[..], 1)));
+        assert_eq!(parse_public_school_id(b"2789"), Ok((&b""[..], 2789)));
+
+        // Maximum allowed value (15 bits max = 32767)
+        assert_eq!(parse_public_school_id(b"32767abc"), Ok((&b"abc"[..], 32767)));
+
+        // Edge cases
+        assert_eq!(parse_public_school_id(b"000test"), Ok((&b"test"[..], 0)));
+        assert_eq!(parse_public_school_id(b"12"), Ok((&b""[..], 12)));
+
+        // Error cases
+        assert!(parse_public_school_id(b"").is_err()); // Empty string
+        assert!(parse_public_school_id(b"abc").is_err()); // No digits
+        assert_eq!(
+            parse_public_school_id(b"32768"),
+            Err((
+                &b"32768"[..],
+                FIPSParserError::ValueExceedsCapacity {
+                    value_prefix: "32768".to_owned(),
+                    capacity: u64::from(FIFTEEN_BIT_MASK),
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_workplace_id() {
+        // Basic successful parsing
+        assert_eq!(parse_workplace_id(b"12345rest"), Ok((&b"rest"[..], 12345)));
+        assert_eq!(parse_workplace_id(b"00001xyz"), Ok((&b"xyz"[..], 1)));
+        assert_eq!(parse_workplace_id(b"14938"), Ok((&b""[..], 14938)));
+
+        // Maximum allowed value (15 bits max = 32767)
+        assert_eq!(parse_workplace_id(b"32767abc"), Ok((&b"abc"[..], 32767)));
+
+        // Edge cases
+        assert_eq!(parse_workplace_id(b"00000test"), Ok((&b"test"[..], 0)));
+        assert_eq!(parse_workplace_id(b"1234"), Ok((&b""[..], 1234)));
+
+        // Error cases
+        assert!(parse_workplace_id(b"").is_err()); // Empty string
+        assert!(parse_workplace_id(b"abc").is_err()); // No digits
+        assert_eq!(
+            parse_workplace_id(b"32768"),
+            Err((
+                &b"32768"[..],
+                FIPSParserError::ValueExceedsCapacity {
+                    value_prefix: "32768".to_owned(),
+                    capacity: u64::from(FIFTEEN_BIT_MASK),
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn test_fips_home_id() {
+        let home_id = b"110010109000024";
+        let state_code: StateCode = 11;
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 10900;
+        let home_id_code = 24;
+
+        let (_, parsed_home_id) = parse_fips_home_id(home_id).unwrap();
+
+        assert_eq!(parsed_home_id.state_code(), state_code);
+        assert_eq!(parsed_home_id.county_code(), county_code);
+        assert_eq!(parsed_home_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_home_id.id(), home_id_code);
+    }
+
+    // A real life edge case
+    #[test]
+    fn test_fips_home_id_edge_case() {
+        let home_id = b"1600101040110000";
+        let state_code: StateCode = USState::ID.into();
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 10401;
+        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::Home.into();
+        let home_id_code = 10000;
+
+        let (_, parsed_home_id) = parse_fips_home_id(home_id).unwrap();
+
+        assert_eq!(parsed_home_id.state_code(), state_code);
+        assert_eq!(parsed_home_id.county_code(), county_code);
+        assert_eq!(parsed_home_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_home_id.category_code(), setting_cat_code);
+        assert_eq!(parsed_home_id.id(), home_id_code);
+    }
+
+    #[test]
+    fn test_fips_work_id() {
+        let workplace_id = b"1100100620201546";
+        let state_code: StateCode = 11;
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 6202;
+        let workplace_id_code = 1546;
+
+        let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id).unwrap();
+
+        assert_eq!(parsed_workplace_id.state_code(), state_code);
+        assert_eq!(parsed_workplace_id.county_code(), county_code);
+        assert_eq!(parsed_workplace_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_workplace_id.id(), workplace_id_code);
+    }
+
+    #[test]
+    fn test_fips_public_school_id() {
+        let public_school_id = b"11001009810157";
+        let state_code: StateCode = 11;
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 9810;
+        let public_school_id_code = 157;
+
+        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id).unwrap();
+
+        assert_eq!(parsed_public_school_id.state_code(), state_code);
+        assert_eq!(parsed_public_school_id.county_code(), county_code);
+        assert_eq!(parsed_public_school_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_public_school_id.id(), public_school_id_code);
+    }
+
+    #[test]
+    fn test_fips_private_school_id() {
+        let private_school_id = b"24031xprvx0150";
+        let state_code: StateCode = 24;
+        let county_code: CountyCode = 31;
+        let tract_code: TractCode = 0;
+        let private_school_id_code = 150;
+
+        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id).unwrap();
+
+        assert_eq!(parsed_private_school_id.state_code(), state_code);
+        assert_eq!(parsed_private_school_id.county_code(), county_code);
+        assert_eq!(parsed_private_school_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_private_school_id.id(), private_school_id_code);
+    }
+
+    #[test]
+    fn test_fips_public_school_id_edge_case() {
+        let public_school_id = b"160010104012789";
+        let state_code: StateCode = USState::ID.into();
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 10401;
+        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::PublicSchool.into();
+        let public_school_id_code = 2789;
+
+        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id).unwrap();
+
+        assert_eq!(parsed_public_school_id.state_code(), state_code);
+        assert_eq!(parsed_public_school_id.county_code(), county_code);
+        assert_eq!(parsed_public_school_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_public_school_id.category_code(), setting_cat_code);
+        assert_eq!(parsed_public_school_id.id(), public_school_id_code);
+    }
+
+    #[test]
+    fn test_fips_private_school_id_edge_case() {
+        let private_school_id = b"24031xprvx1722";
+        let state_code: StateCode = 24;
+        let county_code: CountyCode = 31;
+        let tract_code: TractCode = 0;
+        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::PrivateSchool.into();
+        let private_school_id_code = 1722;
+
+        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id).unwrap();
+
+        assert_eq!(parsed_private_school_id.state_code(), state_code);
+        assert_eq!(parsed_private_school_id.county_code(), county_code);
+        assert_eq!(parsed_private_school_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_private_school_id.category_code(), setting_cat_code);
+        assert_eq!(parsed_private_school_id.id(), private_school_id_code);
+    }
+
+    #[test]
+    fn test_fips_work_id_edge_case() {
+        let workplace_id = b"1600101040114938";
+        let state_code: StateCode = USState::ID.into();
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 10401;
+        let setting_cat_code: SettingCategoryCode = ASPRSettingCategory::Workplace.into();
+        let workplace_id_code = 14938;
+
+        let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id).unwrap();
+
+        assert_eq!(parsed_workplace_id.state_code(), state_code);
+        assert_eq!(parsed_workplace_id.county_code(), county_code);
+        assert_eq!(parsed_workplace_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_workplace_id.category_code(), setting_cat_code);
+        assert_eq!(parsed_workplace_id.id(), workplace_id_code);
+    }
+
+    #[test]
+    fn test_parse_integer() {
+        // Basic successful parsing
+        assert_eq!(parse_integer(b"123rest"), Ok((&b"rest"[..], 123)));
+        assert_eq!(parse_integer(b"0xyz"), Ok((&b"xyz"[..], 0)));
+        assert_eq!(parse_integer(b"9876543210"), Ok((&b""[..], 9876543210)));
+
+        // Single digit
+        assert_eq!(parse_integer(b"5abc"), Ok((&b"abc"[..], 5)));
+
+        // Long number
+        assert_eq!(
+            parse_integer(b"18446744073709551615end"),
+            Ok((&b"end"[..], 18446744073709551615))
+        ); // u64 max
+
+        // Error cases
+        assert!(parse_integer(b"").is_err()); // Empty string
+        assert!(parse_integer(b"abc").is_err()); // No digits
+    }
+
+    // Additional combined tests
+    #[test]
+    fn test_combined_scenarios() {
+        // Test with leading zeros
+        assert_eq!(parse_home_id(b"0123"), Ok((&b""[..], 123)));
+        assert_eq!(parse_private_school_id(b"xprvx0042"), Ok((&b""[..], 42)));
+
+        // `parse_integer` consumes all contiguous digits.
+        assert_eq!(parse_public_school_id(b"12345"), Ok((&b""[..], 12345)));
+
+        // Test with value equal to max
+        assert_eq!(parse_workplace_id(b"32767@#$%"), Ok((&b"@#$%"[..], 32767)));
+
+        // Test with value exceeding max
+        assert_eq!(
+            parse_workplace_id(b"32768@#$%"),
+            Err((
+                &b"32768@#$%"[..],
+                FIPSParserError::ValueExceedsCapacity {
+                    value_prefix: "32768".to_owned(),
+                    capacity: u64::from(FIFTEEN_BIT_MASK),
+                }
+            ))
+        );
+
+        // Test with special characters after digits
+        assert_eq!(parse_workplace_id(b"14938@#$%"), Ok((&b"@#$%"[..], 14938)));
+    }
+
+    #[test]
+    fn test_parse_aspr_data() {
+        let test_data = vec![
+            (
+                b"481559501000128".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 155,
+                    tract: 950100,
+                    category: 1,
+                    id: 128,
+                    data: 0,
+                },
+            ),
+            (
+                b"48155950100001".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 155,
+                    tract: 950100,
+                    category: 3,
+                    id: 1,
+                    data: 0,
+                },
+            ),
+            (
+                b"021300003000173".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 300,
+                    category: 1,
+                    id: 173,
+                    data: 0,
+                },
+            ),
+            (
+                b"02130000400002".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 400,
+                    category: 3,
+                    id: 2,
+                    data: 0,
+                },
+            ),
+            (
+                b"021300001000499".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 100,
+                    category: 1,
+                    id: 499,
+                    data: 0,
+                },
+            ),
+            (
+                b"484879507000440".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 487,
+                    tract: 950700,
+                    category: 1,
+                    id: 440,
+                    data: 0,
+                },
+            ),
+            (
+                b"4848795060000714".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 487,
+                    tract: 950600,
+                    category: 2,
+                    id: 714,
+                    data: 0,
+                },
+            ),
+            (
+                b"484879506001139".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 487,
+                    tract: 950600,
+                    category: 1,
+                    id: 1139,
+                    data: 0,
+                },
+            ),
+            (
+                b"484879506001457".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 487,
+                    tract: 950600,
+                    category: 1,
+                    id: 1457,
+                    data: 0,
+                },
+            ),
+            (
+                b"4848795050000091".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 487,
+                    tract: 950500,
+                    category: 2,
+                    id: 91,
+                    data: 0,
+                },
+            ),
+            (
+                b"021300003000687".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 300,
+                    category: 1,
+                    id: 687,
+                    data: 0,
+                },
+            ),
+            (
+                b"021300002001412".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 200,
+                    category: 1,
+                    id: 1412,
+                    data: 0,
+                },
+            ),
+            (
+                b"0213000020000291".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 200,
+                    category: 2,
+                    id: 291,
+                    data: 0,
+                },
+            ),
+            (
+                b"484879505000385".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::TX.into(),
+                    county: 487,
+                    tract: 950500,
+                    category: 1,
+                    id: 385,
+                    data: 0,
+                },
+            ),
+            (
+                b"021300002001170".as_slice(),
+                ExpandedFIPSCode {
+                    state: USState::AK.into(),
+                    county: 130,
+                    tract: 200,
+                    category: 1,
+                    id: 1170,
+                    data: 0,
+                },
+            ),
+        ];
+
+        for (fips_code, expected) in test_data {
+            // These codes are context sensitive. We cheat by storing the `SettingCategory` in the expected value
+            // and using that to parse the code.
+            let result = match expected.category {
+                1 => parse_fips_home_id(fips_code),
+                2 => parse_fips_workplace_id(fips_code),
+                3 | 4 => parse_fips_school_id(fips_code),
+                _ => panic!("Invalid category"),
+            };
+            let result: (&[u8], FIPSCode) = result.unwrap_or_else(|_| {
+                panic!("Failed to parse {}", String::from_utf8_lossy(fips_code))
+            });
+            assert_eq!(ExpandedFIPSCode::from_fips_code(result.1), expected)
+        }
+    }
+}

--- a/src/pop_reader/states.rs
+++ b/src/pop_reader/states.rs
@@ -76,7 +76,7 @@ impl USState {
     /// Returns true if the given state code is a state or District of Columbia
     #[must_use]
     pub fn is_state_code(value: StateCode) -> bool {
-        value <= 56u8 && ![3u8, 7, 14, 43, 52].contains(&value)
+        value <= 56u8 && ![0u8, 3, 7, 14, 43, 52].contains(&value)
     }
 
     /// Returns the numeric FIPS code for this state.

--- a/src/pop_reader/states.rs
+++ b/src/pop_reader/states.rs
@@ -5,10 +5,10 @@
 //! Note that the `FIPSCode` encoded type only uses six bits to encode the state code, which can
 //! accommodate codes <= 63. Thus, it is best to only use `FIPSCode` for these states.
 
-use strum::{IntoStaticStr, FromRepr, Display};
+use strum::{Display, FromRepr, IntoStaticStr};
 
-use super::errors::FIPSError;
 use super::StateCode;
+use super::errors::FIPSError;
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, IntoStaticStr, FromRepr, Display)]
 #[repr(u8)]
@@ -84,7 +84,7 @@ impl USState {
     pub fn encode(&self) -> StateCode {
         *self as StateCode
     }
-    
+
     /// Gives the static string representation of this state.
     #[must_use]
     pub fn to_static_str(&self) -> &'static str {

--- a/src/pop_reader/states.rs
+++ b/src/pop_reader/states.rs
@@ -1,0 +1,140 @@
+//! An enum for U.S. states as represented by FIPS Geographic Region Codes. This is a minimal subset
+//! of FIPS state codes, which have been stable for every FIPS standard revision so far. See
+//! <https://www.census.gov/library/reference/code-lists/ansi.html#states>.
+//!
+//! Note that the `FIPSCode` encoded type only uses six bits to encode the state code, which can
+//! accommodate codes <= 63. Thus, it is best to only use `FIPSCode` for these states.
+
+use strum::{IntoStaticStr, FromRepr, Display};
+
+use super::errors::FIPSError;
+use super::StateCode;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, IntoStaticStr, FromRepr, Display)]
+#[repr(u8)]
+pub enum USState {
+    AL = 1,
+    AK = 2,
+    AZ = 4,
+    AR = 5,
+    CA = 6,
+    CO = 8,
+    CT = 9,
+    DE = 10,
+    DC = 11, // District of Columbia
+    FL = 12,
+    GA = 13,
+    HI = 15,
+    ID = 16,
+    IL = 17,
+    IN = 18,
+    IA = 19,
+    KS = 20,
+    KY = 21,
+    LA = 22,
+    ME = 23,
+    MD = 24,
+    MA = 25,
+    MI = 26,
+    MN = 27,
+    MS = 28,
+    MO = 29,
+    MT = 30,
+    NE = 31,
+    NV = 32,
+    NH = 33,
+    NJ = 34,
+    NM = 35,
+    NY = 36,
+    NC = 37,
+    ND = 38,
+    OH = 39,
+    OK = 40,
+    OR = 41,
+    PA = 42,
+    RI = 44,
+    SC = 45,
+    SD = 46,
+    TN = 47,
+    TX = 48,
+    UT = 49,
+    VT = 50,
+    VA = 51,
+    WA = 53,
+    WV = 54,
+    WI = 55,
+    WY = 56,
+}
+
+impl USState {
+    /// Returns true if `self` is a state or District of Columbia
+    #[must_use]
+    pub fn is_state(&self) -> bool {
+        USState::is_state_code(*self as StateCode)
+    }
+
+    /// Returns true if the given state code is a state or District of Columbia
+    #[must_use]
+    pub fn is_state_code(value: StateCode) -> bool {
+        value <= 56u8 && ![3u8, 7, 14, 43, 52].contains(&value)
+    }
+
+    /// Returns the numeric FIPS code for this state.
+    #[must_use]
+    pub fn encode(&self) -> StateCode {
+        *self as StateCode
+    }
+    
+    /// Gives the static string representation of this state.
+    #[must_use]
+    pub fn to_static_str(&self) -> &'static str {
+        self.into()
+    }
+
+    /// Returns the state for the given numeric FIPS code.
+    /// Returns `Err(FIPSError)` if the code is invalid.
+    pub fn decode(value: StateCode) -> Result<USState, FIPSError> {
+        Self::from_repr(value).ok_or(FIPSError::from_us_state(value))
+    }
+}
+
+impl From<USState> for StateCode {
+    fn from(value: USState) -> Self {
+        value.encode()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(USState::AK.to_static_str(), "AK");
+    }
+
+    #[test]
+    fn test_is_state() {
+        assert!(USState::AK.is_state());
+        assert!(USState::DC.is_state());
+    }
+
+    #[test]
+    fn test_decode() {
+        assert_eq!(USState::DC, USState::decode(11).unwrap());
+        assert_eq!(USState::MN, USState::decode(27).unwrap());
+
+        assert!(USState::decode(99).is_err());
+        assert!(USState::decode(62).is_err());
+        assert!(USState::decode(63).is_err());
+        assert!(USState::decode(80).is_err());
+        assert!(USState::decode(90).is_err());
+        assert!(USState::decode(0).is_err());
+    }
+
+    #[test]
+    fn test_encode() {
+        assert_eq!(USState::DC.encode(), 11u8);
+        assert_eq!(USState::MN.encode(), 27u8);
+    }
+}

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,15 +1,15 @@
 use ixa::{impl_derived_property, prelude::*};
 
-use serde::{Serialize};
+use serde::Serialize;
 use std::path::PathBuf;
 
-use crate::pop_reader::{
-    PersonRecord, PopulationReaderSettingCategory, FIPSCode,
-    archive::{PersonRecordIterator, set_data_path},
-};
 use crate::error::ModelError;
 use crate::parameters::ContextParametersExt;
-use crate::settings::{ContextSettingExt, SETTING_COUNT, SettingCategory, SettingId, SettingCode};
+use crate::pop_reader::{
+    FIPSCode, PersonRecord, PopulationReaderSettingCategory,
+    archive::{PersonRecordIterator, set_data_path},
+};
+use crate::settings::{ContextSettingExt, SETTING_COUNT, SettingCategory, SettingCode, SettingId};
 use ixa::profiling::open_span;
 
 define_entity!(Person);
@@ -74,12 +74,15 @@ impl_derived_property!(CommunityId, Person, [SettingIds], [], |setting_ids| {
 fn community_code_from_home(home_id: SettingCode) -> SettingCode {
     let home_id = home_id.0;
     // Since we are calling this constructor with values that we know are valid, we can unwrap.
-    SettingCode(FIPSCode::with_category(
-        home_id.state_code(),
-        home_id.county_code(),
-        home_id.census_tract_code(),
-        PopulationReaderSettingCategory::CensusTract.encode(),
-    ).unwrap())
+    SettingCode(
+        FIPSCode::with_category(
+            home_id.state_code(),
+            home_id.county_code(),
+            home_id.census_tract_code(),
+            PopulationReaderSettingCategory::CensusTract.encode(),
+        )
+        .unwrap(),
+    )
 }
 
 fn create_person_from_record(
@@ -98,7 +101,7 @@ fn create_person_from_record(
         Some(home_id),
         person_record.work_id.map(SettingCode),
         person_record.school_id.map(SettingCode),
-        Some(community_id)
+        Some(community_id),
     )?;
     Ok(())
 }
@@ -135,11 +138,11 @@ pub fn init(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::pop_reader::{
         errors::PopulationReaderError,
         parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id},
     };
-    use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::settings::{Setting, SettingCategory, SettingCode};
     use ixa::HashMap;
     use std::io::Write;
@@ -152,7 +155,6 @@ mod test {
         let (_file, path) = file.keep().unwrap();
         path
     }
-
 
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)
@@ -271,7 +273,7 @@ mod test {
         let mut context = setup();
         let home_code = make_home_id(b"160379602000001");
         let school_code = make_home_id(b"16037960200002");
-        let record = PersonRecord{
+        let record = PersonRecord {
             age: 43,
             home_id: Some(home_code.0),
             school_id: Some(school_code.0),
@@ -296,7 +298,7 @@ mod test {
             "42,160379602000002,16037960200004,\n",
         );
         let synth_file = persist_tmp_csv(input);
-        let _ = load_synth_population(&mut context, synth_file).unwrap_or_else(|e| panic!("{}", e));
+        load_synth_population(&mut context, synth_file).unwrap_or_else(|e| panic!("{}", e));
         context.initialize_setting_size().unwrap();
         let age = [43, 42];
         let school_id = [

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,23 +1,18 @@
-use ixa::{csv, impl_derived_property, prelude::*};
+use ixa::{impl_derived_property, prelude::*};
 
-use serde::{Deserialize, Serialize};
+use serde::{Serialize};
 use std::path::PathBuf;
 
+use crate::pop_reader::{
+    ASPRPersonRecord, ASPRSettingCategory, FIPSCode,
+    archive::{ASPRRecordIterator, set_aspr_data_path},
+};
 use crate::error::ModelError;
 use crate::parameters::ContextParametersExt;
-use crate::settings::{ContextSettingExt, SETTING_COUNT, SettingCategory, SettingId};
+use crate::settings::{ContextSettingExt, SETTING_COUNT, SettingCategory, SettingId, SettingCode};
 use ixa::profiling::open_span;
 
 define_entity!(Person);
-
-#[derive(Deserialize, Debug)]
-#[allow(non_snake_case)]
-pub struct PeopleRecord<'a> {
-    age: u8,
-    homeId: &'a [u8],
-    schoolId: &'a [u8],
-    workplaceId: &'a [u8],
-}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
 pub struct Age(pub u8);
@@ -76,27 +71,35 @@ impl_derived_property!(CommunityId, Person, [SettingIds], [], |setting_ids| {
     CommunityId(setting_ids.setting_ids[SettingCategory::Community])
 });
 
+fn community_code_from_home(home_id: SettingCode) -> SettingCode {
+    let home_id = home_id.0;
+    // Since we are calling this constructor with values that we know are valid, we can unwrap.
+    SettingCode(FIPSCode::with_category(
+        home_id.state_code(),
+        home_id.county_code(),
+        home_id.census_tract_code(),
+        ASPRSettingCategory::CensusTract.into(),
+    ).unwrap())
+}
+
 fn create_person_from_record(
     context: &mut Context,
-    person_record: &PeopleRecord,
+    person_record: ASPRPersonRecord,
 ) -> Result<(), ModelError> {
-    // Create itinerary entries for all setting memberships in input file
-    let community_id: Option<usize> = String::from_utf8(person_record.homeId[..11].to_owned())?
-        .parse::<usize>()
-        .ok();
-    let home_id: Option<usize> = String::from_utf8(person_record.homeId.to_owned())?
-        .parse::<usize>()
-        .ok();
-    let school_id: Option<usize> = String::from_utf8(person_record.schoolId.to_owned())?
-        .parse::<usize>()
-        .ok();
-    let work_id: Option<usize> = String::from_utf8(person_record.workplaceId.to_owned())?
-        .parse::<usize>()
-        .ok();
+    let home_id = person_record.home_id.ok_or_else(|| {
+        ModelError::ModelError("ASPR person record is missing required home_id".to_string())
+    })?;
+    let home_id = SettingCode(home_id);
+    let community_id = community_code_from_home(home_id);
 
-    // Add person to context
     let person_id: PersonId = context.add_entity((Age(person_record.age),)).unwrap();
-    context.add_person_to_settings(person_id, home_id, work_id, school_id, community_id)?;
+    context.add_person_to_settings(
+        person_id,
+        Some(home_id),
+        person_record.work_id.map(SettingCode),
+        person_record.school_id.map(SettingCode),
+        Some(community_id)
+    )?;
     Ok(())
 }
 
@@ -104,13 +107,11 @@ fn load_synth_population(
     context: &mut Context,
     synth_input_file: PathBuf,
 ) -> Result<(), ModelError> {
-    let mut reader = csv::Reader::from_path(synth_input_file)?;
-    let mut raw_record = csv::ByteRecord::new();
-    let headers = reader.byte_headers()?.clone();
+    set_aspr_data_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
 
-    while reader.read_byte_record(&mut raw_record)? {
-        let record: PeopleRecord = raw_record.deserialize(Some(&headers))?;
-        create_person_from_record(context, &record)?;
+    let records = ASPRRecordIterator::from_path(synth_input_file)?;
+    for record in records {
+        create_person_from_record(context, record?)?;
     }
     Ok(())
 }
@@ -134,6 +135,10 @@ pub fn init(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::pop_reader::{
+        errors::ASPRError,
+        parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id},
+    };
     use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::settings::{Setting, SettingCategory, SettingCode};
     use ixa::HashMap;
@@ -141,11 +146,24 @@ mod test {
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
 
-    fn persist_tmp_csv(content: &String) -> PathBuf {
+    fn persist_tmp_csv(content: &str) -> PathBuf {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(content.as_bytes()).unwrap();
         let (_file, path) = file.keep().unwrap();
         path
+    }
+
+
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
+
+    fn make_school_id(school_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_school_id(school_id).unwrap().1)
+    }
+
+    fn make_workplace_id(workplace_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_workplace_id(workplace_id).unwrap().1)
     }
 
     fn setup() -> Context {
@@ -182,15 +200,20 @@ mod test {
     #[test]
     fn check_synth_file_tract() {
         let mut context = setup();
-        let input = String::from(
-            "age,homeId,schoolId,workplaceId\n43,360930331020001,,\n42,360930331020002,,",
+        let input = concat!(
+            "age,homeId,schoolId,workplaceId\n",
+            "43,160379602000001,,\n",
+            "42,160379602000002,,\n",
         );
-        let synth_file = persist_tmp_csv(&input);
+        let synth_file = persist_tmp_csv(input);
         load_synth_population(&mut context, synth_file).unwrap();
         context.initialize_setting_size().unwrap();
         let age = [43, 42];
-        let home_id = [360_930_331_020_001, 360_930_331_020_002];
-        let census_tract_id = 36_093_033_102;
+        let home_id = [
+            make_home_id(b"160379602000001"),
+            make_home_id(b"160379602000002"),
+        ];
+        let census_tract_id = community_code_from_home(home_id[0]);
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
         assert_eq!(
@@ -206,18 +229,15 @@ mod test {
             assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
         }
         let home_id1 = context
-            .query_result_iterator::<Setting, _>((SettingCode(home_id[0]), SettingCategory::Home))
+            .query_result_iterator::<Setting, _>((home_id[0], SettingCategory::Home))
             .next()
             .unwrap();
         let home_id2 = context
-            .query_result_iterator::<Setting, _>((SettingCode(home_id[1]), SettingCategory::Home))
+            .query_result_iterator::<Setting, _>((home_id[1], SettingCategory::Home))
             .next()
             .unwrap();
         let censustract_id = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(census_tract_id),
-                SettingCategory::Community,
-            ))
+            .query_result_iterator::<Setting, _>((census_tract_id, SettingCategory::Community))
             .next()
             .unwrap();
         assert_eq!(1, context.get_setting_size(home_id1).unwrap());
@@ -226,56 +246,89 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "range end index 11 out of range for slice of length 9")]
     fn check_invalid_census_tract() {
         let mut context = setup();
-        let input =
-            String::from("age,homeId,schoolId,workplaceId\n43,360930331,,\n42,360930331020002,,");
-        let synth_file = persist_tmp_csv(&input);
-        load_synth_population(&mut context, synth_file).unwrap();
+        let input = concat!(
+            "age,homeId,schoolId,workplaceId\n",
+            "43,160379602,,\n",
+            "42,160379602000002,,\n",
+        );
+        let synth_file = persist_tmp_csv(input);
+        let error = load_synth_population(&mut context, synth_file).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ModelError::ASPRError(ASPRError::Parse {
+                field_name: "homeId",
+                line_number: 2,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn minimal_reproducible_test() {
+        let mut context = setup();
+        let home_code = make_home_id(b"160379602000001");
+        let school_code = make_home_id(b"16037960200002");
+        let record = ASPRPersonRecord{
+            age: 43,
+            home_id: Some(home_code.0),
+            school_id: Some(school_code.0),
+            work_id: None,
+        };
+        create_person_from_record(&mut context, record).unwrap_or_else(|e| panic!("{}", e));
+
+        let home_id1 = context
+            .query_result_iterator::<Setting, _>((home_code, SettingCategory::Home))
+            .next()
+            .unwrap();
+        let cat: SettingCategory = context.get_property(home_id1);
+        println!("Found {:?} for setting {:?}", cat, home_id1);
     }
 
     #[test]
     fn check_synth_file_school() {
         let mut context = setup();
-        let input = String::from(
-            "age,homeId,schoolId,workplaceId\n43,360930331020001,1,\n42,360930331020002,2,",
+        let input = concat!(
+            "age,homeId,schoolId,workplaceId\n",
+            "43,160379602000001,16037960200002,\n",
+            "42,160379602000002,16037960200004,\n",
         );
-        let synth_file = persist_tmp_csv(&input);
-        load_synth_population(&mut context, synth_file).unwrap();
+        let synth_file = persist_tmp_csv(input);
+        let _ = load_synth_population(&mut context, synth_file).unwrap_or_else(|e| panic!("{}", e));
         context.initialize_setting_size().unwrap();
         let age = [43, 42];
-        let school_id = [1, 2];
-        let home_id = [360_930_331_020_001, 360_930_331_020_002];
-        let census_tract_id = 36_093_033_102;
+        let school_id = [
+            make_school_id(b"16037960200002"),
+            make_school_id(b"16037960200004"),
+        ];
+        let home_id = [
+            make_home_id(b"160379602000001"),
+            make_home_id(b"160379602000002"),
+        ];
+        let census_tract_id = community_code_from_home(home_id[0]);
 
         let home_id1 = context
-            .query_result_iterator::<Setting, _>((SettingCode(home_id[0]), SettingCategory::Home))
+            .query_result_iterator::<Setting, _>((home_id[0], SettingCategory::Home))
             .next()
             .unwrap();
+        let cat: SettingCategory = context.get_property(home_id1);
+        println!("Found {:?} for setting {:?}", cat, home_id1);
         let home_id2 = context
-            .query_result_iterator::<Setting, _>((SettingCode(home_id[1]), SettingCategory::Home))
+            .query_result_iterator::<Setting, _>((home_id[1], SettingCategory::Home))
             .next()
             .unwrap();
         let school_id1 = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(school_id[0]),
-                SettingCategory::School,
-            ))
+            .query_result_iterator::<Setting, _>((school_id[0], SettingCategory::School))
             .next()
             .unwrap();
         let school_id2 = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(school_id[1]),
-                SettingCategory::School,
-            ))
+            .query_result_iterator::<Setting, _>((school_id[1], SettingCategory::School))
             .next()
             .unwrap();
         let censustract_id = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(census_tract_id),
-                SettingCategory::Community,
-            ))
+            .query_result_iterator::<Setting, _>((census_tract_id, SettingCategory::Community))
             .next()
             .unwrap();
 
@@ -306,44 +359,44 @@ mod test {
     #[test]
     fn check_synth_file_workplace() {
         let mut context = setup();
-        let input = String::from(
-            "age,homeId,schoolId,workplaceId\n43,360930331020001,,1\n42,360930331020002,,2",
+        let input = concat!(
+            "age,homeId,schoolId,workplaceId\n",
+            "43,160379602000001,,1603796020000220\n",
+            "42,160379602000002,,1603796020001332\n",
         );
-        let synth_file = persist_tmp_csv(&input);
+        let synth_file = persist_tmp_csv(input);
         load_synth_population(&mut context, synth_file).unwrap();
         context.initialize_setting_size().unwrap();
+
         let age = [43, 42];
-        let workplace_id = [1, 2];
-        let home_id = [360_930_331_020_001, 360_930_331_020_002];
-        let census_tract_id = 36_093_033_102;
+        let workplace_id = [
+            make_workplace_id(b"1603796020000220"),
+            make_workplace_id(b"1603796020001332"),
+        ];
+        let home_id = [
+            make_home_id(b"160379602000001"),
+            make_home_id(b"160379602000002"),
+        ];
+        let census_tract_id = community_code_from_home(home_id[0]);
 
         let home_id1 = context
-            .query_result_iterator::<Setting, _>((SettingCode(home_id[0]), SettingCategory::Home))
+            .query_result_iterator::<Setting, _>((home_id[0], SettingCategory::Home))
             .next()
             .unwrap();
         let home_id2 = context
-            .query_result_iterator::<Setting, _>((SettingCode(home_id[1]), SettingCategory::Home))
+            .query_result_iterator::<Setting, _>((home_id[1], SettingCategory::Home))
             .next()
             .unwrap();
         let workplace_id1 = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(workplace_id[0]),
-                SettingCategory::Work,
-            ))
+            .query_result_iterator::<Setting, _>((workplace_id[0], SettingCategory::Work))
             .next()
             .unwrap();
         let workplace_id2 = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(workplace_id[1]),
-                SettingCategory::Work,
-            ))
+            .query_result_iterator::<Setting, _>((workplace_id[1], SettingCategory::Work))
             .next()
             .unwrap();
         let censustract_id = context
-            .query_result_iterator::<Setting, _>((
-                SettingCode(census_tract_id),
-                SettingCategory::Community,
-            ))
+            .query_result_iterator::<Setting, _>((census_tract_id, SettingCategory::Community))
             .next()
             .unwrap();
 

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -4,8 +4,8 @@ use serde::{Serialize};
 use std::path::PathBuf;
 
 use crate::pop_reader::{
-    ASPRPersonRecord, ASPRSettingCategory, FIPSCode,
-    archive::{ASPRRecordIterator, set_aspr_data_path},
+    PersonRecord, PopulationReaderSettingCategory, FIPSCode,
+    archive::{PersonRecordIterator, set_data_path},
 };
 use crate::error::ModelError;
 use crate::parameters::ContextParametersExt;
@@ -78,16 +78,16 @@ fn community_code_from_home(home_id: SettingCode) -> SettingCode {
         home_id.state_code(),
         home_id.county_code(),
         home_id.census_tract_code(),
-        ASPRSettingCategory::CensusTract.into(),
+        PopulationReaderSettingCategory::CensusTract.encode(),
     ).unwrap())
 }
 
 fn create_person_from_record(
     context: &mut Context,
-    person_record: ASPRPersonRecord,
+    person_record: PersonRecord,
 ) -> Result<(), ModelError> {
     let home_id = person_record.home_id.ok_or_else(|| {
-        ModelError::ModelError("ASPR person record is missing required home_id".to_string())
+        ModelError::ModelError("person record is missing required home_id".to_string())
     })?;
     let home_id = SettingCode(home_id);
     let community_id = community_code_from_home(home_id);
@@ -107,9 +107,9 @@ fn load_synth_population(
     context: &mut Context,
     synth_input_file: PathBuf,
 ) -> Result<(), ModelError> {
-    set_aspr_data_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    set_data_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
 
-    let records = ASPRRecordIterator::from_path(synth_input_file)?;
+    let records = PersonRecordIterator::from_path(synth_input_file)?;
     for record in records {
         create_person_from_record(context, record?)?;
     }
@@ -136,7 +136,7 @@ pub fn init(
 mod test {
     use super::*;
     use crate::pop_reader::{
-        errors::ASPRError,
+        errors::PopulationReaderError,
         parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id},
     };
     use crate::parameters::{GlobalParams, Params, SettingProperties};
@@ -258,7 +258,7 @@ mod test {
 
         assert!(matches!(
             error,
-            ModelError::ASPRError(ASPRError::Parse {
+            ModelError::PopulationReaderError(PopulationReaderError::Parse {
                 field_name: "homeId",
                 line_number: 2,
                 ..
@@ -271,7 +271,7 @@ mod test {
         let mut context = setup();
         let home_code = make_home_id(b"160379602000001");
         let school_code = make_home_id(b"16037960200002");
-        let record = ASPRPersonRecord{
+        let record = PersonRecord{
             age: 43,
             home_id: Some(home_code.0),
             school_id: Some(school_code.0),

--- a/src/reports/incidence_report.rs
+++ b/src/reports/incidence_report.rs
@@ -170,6 +170,7 @@ pub fn init(context: &mut Context, file_name: &str, period: f64) -> Result<(), M
 #[cfg(test)]
 mod test {
     use crate::{
+        pop_reader::parser::parse_fips_home_id,
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, OrderedAgeGroupsParam, Params},
         population_loader::{Age, Person, PersonId},
@@ -181,6 +182,10 @@ mod test {
     use ixa::{csv, prelude::*};
     use std::path::PathBuf;
     use tempfile::tempdir;
+    
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
 
     fn setup_context_with_report(incidence_report: ReportParams) -> Context {
         let mut context = Context::new();
@@ -227,7 +232,7 @@ mod test {
         let source: PersonId = context.add_entity((Age(42),)).unwrap();
         let target: PersonId = context.add_entity((Age(43),)).unwrap();
         let home: SettingId = context
-            .add_entity((SettingCode(0), SettingCategory::Home))
+            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
             .unwrap();
         let setting = Some(home);
         let infection_time = 1.0;
@@ -288,7 +293,7 @@ mod test {
         let source: PersonId = context.add_entity((Age(42),)).unwrap();
         let target: PersonId = context.add_entity((Age(43),)).unwrap();
         let home: SettingId = context
-            .add_entity((SettingCode(0), SettingCategory::Home))
+            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
             .unwrap();
         let setting = Some(home);
         let infection_time = 1.0;

--- a/src/reports/incidence_report.rs
+++ b/src/reports/incidence_report.rs
@@ -170,9 +170,9 @@ pub fn init(context: &mut Context, file_name: &str, period: f64) -> Result<(), M
 #[cfg(test)]
 mod test {
     use crate::{
-        pop_reader::parser::parse_fips_home_id,
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, OrderedAgeGroupsParam, Params},
+        pop_reader::parser::parse_fips_home_id,
         population_loader::{Age, Person, PersonId},
         rate_fns::load_rate_fns,
         reports::ReportParams,
@@ -182,7 +182,7 @@ mod test {
     use ixa::{csv, prelude::*};
     use std::path::PathBuf;
     use tempfile::tempdir;
-    
+
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)
     }

--- a/src/reports/prevalence_report.rs
+++ b/src/reports/prevalence_report.rs
@@ -111,9 +111,9 @@ pub fn init(context: &mut Context, file_name: &str, period: f64) -> Result<(), M
 mod test {
     use crate::{
         Age,
-        pop_reader::parser::parse_fips_home_id,
         infectiousness_manager::{InfectionContextExt, InfectionStatus},
         parameters::{ContextParametersExt, GlobalParams, Params},
+        pop_reader::parser::parse_fips_home_id,
         population_loader::PersonId,
         rate_fns::load_rate_fns,
         reports::ReportParams,
@@ -122,7 +122,6 @@ mod test {
     use ixa::{csv, prelude::*};
     use std::path::PathBuf;
     use tempfile::tempdir;
-
 
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)

--- a/src/reports/prevalence_report.rs
+++ b/src/reports/prevalence_report.rs
@@ -111,6 +111,7 @@ pub fn init(context: &mut Context, file_name: &str, period: f64) -> Result<(), M
 mod test {
     use crate::{
         Age,
+        pop_reader::parser::parse_fips_home_id,
         infectiousness_manager::{InfectionContextExt, InfectionStatus},
         parameters::{ContextParametersExt, GlobalParams, Params},
         population_loader::PersonId,
@@ -121,6 +122,11 @@ mod test {
     use ixa::{csv, prelude::*};
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
 
     fn setup_context_with_report(prevalence_report: ReportParams) -> Context {
         let mut context = Context::new();
@@ -155,7 +161,7 @@ mod test {
         let source: PersonId = context.add_entity((Age(42),)).unwrap();
         let target: PersonId = context.add_entity((Age(43),)).unwrap();
         let home: SettingId = context
-            .add_entity((SettingCode(0), SettingCategory::Home))
+            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
             .unwrap();
         let setting = Some(home);
         let infection_time = 1.0;

--- a/src/reports/transmission_report.rs
+++ b/src/reports/transmission_report.rs
@@ -55,6 +55,7 @@ pub fn init(context: &mut Context, file_name: &str) -> Result<(), ModelError> {
 mod test {
     use crate::{
         Age,
+        pop_reader::parser::parse_fips_home_id,
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, Params},
         population_loader::PersonId,
@@ -68,6 +69,11 @@ mod test {
     };
     use std::path::PathBuf;
     use tempfile::tempdir;
+
+
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
 
     fn setup_context_with_report(transmission_report: ReportParams) -> Context {
         let mut context = Context::new();
@@ -102,7 +108,7 @@ mod test {
         let source: PersonId = context.add_entity((Age(30),)).unwrap();
         let target: PersonId = context.add_entity((Age(30),)).unwrap();
         let home: SettingId = context
-            .add_entity((SettingCode(0), SettingCategory::Home))
+            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
             .unwrap();
         let setting = Some(home);
         let infection_time = 1.0;

--- a/src/reports/transmission_report.rs
+++ b/src/reports/transmission_report.rs
@@ -55,9 +55,9 @@ pub fn init(context: &mut Context, file_name: &str) -> Result<(), ModelError> {
 mod test {
     use crate::{
         Age,
-        pop_reader::parser::parse_fips_home_id,
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, Params},
+        pop_reader::parser::parse_fips_home_id,
         population_loader::PersonId,
         rate_fns::load_rate_fns,
         reports::ReportParams,
@@ -69,7 +69,6 @@ mod test {
     };
     use std::path::PathBuf;
     use tempfile::tempdir;
-
 
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -385,7 +385,7 @@ mod test {
     use super::*;
     use crate::{
         Age, Params,
-        pop_reader::{ASPRSettingCategory, FIPSCode, parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id}},
+        pop_reader::{PopulationReaderSettingCategory, FIPSCode, parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id}},
         parameters::{GlobalParams, SettingProperties},
     };
     use ixa::{HashMap, assert_almost_eq};
@@ -408,7 +408,7 @@ mod test {
             home_id.state_code(),
             home_id.county_code(),
             home_id.census_tract_code(),
-            ASPRSettingCategory::CensusTract.into(),
+            PopulationReaderSettingCategory::CensusTract.encode(),
         )
         .unwrap()
         )

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,18 +4,18 @@ use std::{
     fmt::Debug,
     ops::{Index, IndexMut},
 };
-use strum::{EnumCount, IntoEnumIterator};
-use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 
-use core::f64;
 
 use crate::{
     ContextParametersExt, Params,
+    pop_reader::FIPSCode,
     error::ModelError,
     population_loader::{
-        CommunityId, HomeId, ItineraryRatios, Person, PersonId, SchoolId, SettingIds, WorkId,
+        CommunityId, HomeId, Person, PersonId, SchoolId, WorkId,
     },
 };
+use crate::population_loader::{ItineraryRatios, SettingIds};
 
 define_rng!(SettingRng);
 
@@ -50,7 +50,9 @@ impl<T> IndexMut<SettingCategory> for [T; SETTING_COUNT] {
 pub const SETTING_COUNT: usize = SettingCategory::COUNT;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
-pub struct SettingCode(pub usize);
+pub struct SettingCode(pub FIPSCode);
+// See #843:
+// pub type SettingCode = FIPSCode;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub struct Size(pub usize);
@@ -290,14 +292,15 @@ pub trait ContextSettingExt:
         &mut self,
         setting_ids: &mut [Option<SettingId>; SETTING_COUNT],
         itinerary_ratios: &mut [f64; SETTING_COUNT],
-        setting_id_parsed: Option<usize>,
+        setting_code: Option<SettingCode>,
         setting_category: SettingCategory,
     ) {
-        if setting_id_parsed.is_none() {
+        let Some(setting_code) = setting_code  else {
+            // Nothing to do.
             return;
-        }
+        };
         let setting_id = self
-            .add_index_setting(setting_category, SettingCode(setting_id_parsed.unwrap()))
+            .add_index_setting(setting_category, setting_code)
             .unwrap();
         setting_ids[setting_category] = Some(setting_id);
         itinerary_ratios[setting_category] = self.get_setting_ratio(setting_category).unwrap();
@@ -306,10 +309,10 @@ pub trait ContextSettingExt:
     fn add_person_to_settings(
         &mut self,
         person_id: PersonId,
-        home_id: Option<usize>,
-        work_id: Option<usize>,
-        school_id: Option<usize>,
-        community_id: Option<usize>,
+        home_id: Option<SettingCode>,
+        work_id: Option<SettingCode>,
+        school_id: Option<SettingCode>,
+        community_id: Option<SettingCode>,
     ) -> Result<(), ModelError> {
         let mut setting_ids = [None; SETTING_COUNT];
         let mut itinerary_ratios = [0.0; SETTING_COUNT];
@@ -382,9 +385,34 @@ mod test {
     use super::*;
     use crate::{
         Age, Params,
+        pop_reader::{ASPRSettingCategory, FIPSCode, parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id}},
         parameters::{GlobalParams, SettingProperties},
     };
     use ixa::{HashMap, assert_almost_eq};
+
+    fn make_home_id(home_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_home_id(home_id).unwrap().1)
+    }
+
+    fn make_school_id(school_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_school_id(school_id).unwrap().1)
+    }
+
+    fn make_workplace_id(workplace_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_workplace_id(workplace_id).unwrap().1)
+    }
+
+    fn make_community_id(home_id: &[u8]) -> SettingCode {
+        let home_id = make_home_id(home_id).0;
+        SettingCode(FIPSCode::with_category(
+            home_id.state_code(),
+            home_id.county_code(),
+            home_id.census_tract_code(),
+            ASPRSettingCategory::CensusTract.into(),
+        )
+        .unwrap()
+        )
+    }
 
     fn setup(alpha: f64) -> Context {
         let mut context = Context::new();
@@ -438,7 +466,7 @@ mod test {
     fn test_get_setting_size_empty() {
         let mut context = setup(0.0);
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(100), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000001"), SettingCategory::Home))
             .unwrap();
         // No persons assigned yet
         let size = context.get_setting_size(home_id).unwrap();
@@ -448,17 +476,26 @@ mod test {
     #[test]
     fn test_get_setting_size_multiple_categories() {
         let mut context = setup(0.0);
+        let home_code = make_home_id(b"160379602000002");
+        let community_code = make_community_id(b"160379602000002");
+        let work_code = make_workplace_id(b"1603796020000220");
+        context
+            .add_entity::<Setting, _>((home_code, SettingCategory::Home))
+            .unwrap();
+        context
+            .add_entity::<Setting, _>((work_code, SettingCategory::Work))
+            .unwrap();
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
         let person3 = context.add_entity::<Person, _>((Age(22),)).unwrap();
         context
-            .add_person_to_settings(person1, Some(1), None, None, Some(1))
+            .add_person_to_settings(person1, Some(home_code), None, None, Some(community_code))
             .unwrap();
         context
-            .add_person_to_settings(person2, Some(1), None, None, Some(1))
+            .add_person_to_settings(person2, Some(home_code), None, None, Some(community_code))
             .unwrap();
         context
-            .add_person_to_settings(person3, None, Some(1), None, None)
+            .add_person_to_settings(person3, None, Some(work_code), None, None)
             .unwrap();
         let home_id = context.get_property::<Person, HomeId>(person1).0.unwrap();
         let work_id = context.get_property::<Person, WorkId>(person3).0.unwrap();
@@ -472,13 +509,30 @@ mod test {
     #[test]
     fn test_get_setting_size_after_removal() {
         let mut context = setup(0.0);
+        let original_home_code = make_home_id(b"160379602000003");
+        let original_community_code = make_community_id(b"160379602000003");
+        let new_home_code = make_home_id(b"160379602000004");
+        let _ = context
+            .add_entity::<Setting, _>((original_home_code, SettingCategory::Home));
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
         context
-            .add_person_to_settings(person1, Some(1), None, None, Some(1))
+            .add_person_to_settings(
+                person1,
+                Some(original_home_code),
+                None,
+                None,
+                Some(original_community_code),
+            )
             .unwrap();
         context
-            .add_person_to_settings(person2, Some(1), None, None, Some(1))
+            .add_person_to_settings(
+                person2,
+                Some(original_home_code),
+                None,
+                None,
+                Some(original_community_code),
+            )
             .unwrap();
         let home_id = context.get_property::<Person, HomeId>(person1).0.unwrap();
         let community_id = context
@@ -491,7 +545,7 @@ mod test {
         assert_eq!(home_size, 2);
         assert_eq!(community_size, 2);
         context
-            .add_person_to_settings(person1, Some(2), None, None, None)
+            .add_person_to_settings(person1, Some(new_home_code), None, None, None)
             .unwrap();
         context.initialize_setting_size().unwrap();
         let home_size_after = context.get_setting_size(home_id).unwrap();
@@ -505,7 +559,13 @@ mod test {
         let mut context = setup(0.0);
         let person_id = context.add_entity::<Person, _>((Age(20),)).unwrap();
         context
-            .add_person_to_settings(person_id, Some(123), None, None, None)
+            .add_person_to_settings(
+                person_id,
+                Some(make_home_id(b"160379602000011")),
+                None,
+                None,
+                None,
+            )
             .unwrap();
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();
         let sampled = context.sample_person_from_setting(home_id).unwrap();
@@ -517,7 +577,13 @@ mod test {
         let mut context = setup(0.0);
         let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
         context
-            .add_person_to_settings(person_id, None, Some(123), None, None)
+            .add_person_to_settings(
+                person_id,
+                None,
+                Some(make_workplace_id(b"1603796020001332")),
+                None,
+                None,
+            )
             .unwrap();
         let work_id = context.get_property::<Person, WorkId>(person_id).0.unwrap();
         let sampled = context.sample_person_from_setting(work_id).unwrap();
@@ -529,7 +595,13 @@ mod test {
         let mut context = setup(0.0);
         let person_id = context.add_entity::<Person, _>((Age(10),)).unwrap();
         context
-            .add_person_to_settings(person_id, None, None, Some(123), None)
+            .add_person_to_settings(
+                person_id,
+                None,
+                None,
+                Some(make_school_id(b"16037960200002")),
+                None,
+            )
             .unwrap();
         let school_id = context
             .get_property::<Person, SchoolId>(person_id)
@@ -544,7 +616,13 @@ mod test {
         let mut context = setup(0.0);
         let person_id = context.add_entity::<Person, _>((Age(40),)).unwrap();
         context
-            .add_person_to_settings(person_id, None, None, None, Some(123))
+            .add_person_to_settings(
+                person_id,
+                None,
+                None,
+                None,
+                Some(make_community_id(b"160379602000011")),
+            )
             .unwrap();
         let community_id = context
             .get_property::<Person, CommunityId>(person_id)
@@ -558,7 +636,7 @@ mod test {
     fn test_get_setting_size() {
         let mut context = setup(0.0);
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(5), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000005"), SettingCategory::Home))
             .unwrap();
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
@@ -590,7 +668,7 @@ mod test {
     fn test_get_active_settings_for_person() {
         let mut context = setup(0.5);
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(7), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000006"), SettingCategory::Home))
             .unwrap();
         let person_id = context.add_entity::<Person, _>((Age(22),)).unwrap();
         assign_person_settings(
@@ -612,10 +690,10 @@ mod test {
         let alpha = 0.5;
         let mut context = setup(alpha);
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(8), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000007"), SettingCategory::Home))
             .unwrap();
         let work_id = context
-            .add_entity::<Setting, _>((SettingCode(9), SettingCategory::Work))
+            .add_entity::<Setting, _>((make_workplace_id(b"1603796020000042"), SettingCategory::Work))
             .unwrap();
         let p1 = context.add_entity::<Person, _>((Age(23),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(23),)).unwrap();
@@ -657,10 +735,10 @@ mod test {
         let alpha = 1.0;
         let mut context = setup(alpha);
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(9), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000008"), SettingCategory::Home))
             .unwrap();
         let work_id = context
-            .add_entity::<Setting, _>((SettingCode(10), SettingCategory::Work))
+            .add_entity::<Setting, _>((make_workplace_id(b"1603796020000709"), SettingCategory::Work))
             .unwrap();
         let p1 = context.add_entity::<Person, _>((Age(24),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(24),)).unwrap();
@@ -689,7 +767,7 @@ mod test {
     fn test_sample_person_from_setting() {
         let mut context = setup(0.0);
         let comm_id = context
-            .add_entity::<Setting, _>((SettingCode(10), SettingCategory::Community))
+            .add_entity::<Setting, _>((make_community_id(b"160379602000008"), SettingCategory::Community))
             .unwrap();
         let person_id = context.add_entity::<Person, _>((Age(25),)).unwrap();
         assign_person_settings(
@@ -706,7 +784,7 @@ mod test {
     fn test_sample_from_setting_with_exclusion() {
         let mut context = setup(0.0);
         let work_id = context
-            .add_entity::<Setting, _>((SettingCode(11), SettingCategory::Work))
+            .add_entity::<Setting, _>((make_workplace_id(b"1603796020000121"), SettingCategory::Work))
             .unwrap();
         let p1 = context.add_entity::<Person, _>((Age(26),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(27),)).unwrap();
@@ -733,7 +811,7 @@ mod test {
     fn test_sample_active_setting() {
         let mut context = setup(0.0);
         let home_id = context
-            .add_entity::<Setting, _>((SettingCode(13), SettingCategory::Home))
+            .add_entity::<Setting, _>((make_home_id(b"160379602000009"), SettingCategory::Home))
             .unwrap();
         let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
         assign_person_settings(
@@ -751,8 +829,9 @@ mod test {
     fn test_add_person_to_setting_and_add_index_setting() {
         let mut context = setup(0.0);
         let person_id = context.add_entity::<Person, _>((Age(31),)).unwrap();
+        let setting_code = make_home_id(b"160379602000010");
         context
-            .add_person_to_settings(person_id, Some(123), None, None, None)
+            .add_person_to_settings(person_id, Some(setting_code), None, None, None)
             .unwrap();
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();
         let setting_ids = context

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,16 +6,13 @@ use std::{
 };
 use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 
-
+use crate::population_loader::{ItineraryRatios, SettingIds};
 use crate::{
     ContextParametersExt, Params,
-    pop_reader::FIPSCode,
     error::ModelError,
-    population_loader::{
-        CommunityId, HomeId, Person, PersonId, SchoolId, WorkId,
-    },
+    pop_reader::FIPSCode,
+    population_loader::{CommunityId, HomeId, Person, PersonId, SchoolId, WorkId},
 };
-use crate::population_loader::{ItineraryRatios, SettingIds};
 
 define_rng!(SettingRng);
 
@@ -295,7 +292,7 @@ pub trait ContextSettingExt:
         setting_code: Option<SettingCode>,
         setting_category: SettingCategory,
     ) {
-        let Some(setting_code) = setting_code  else {
+        let Some(setting_code) = setting_code else {
             // Nothing to do.
             return;
         };
@@ -385,8 +382,11 @@ mod test {
     use super::*;
     use crate::{
         Age, Params,
-        pop_reader::{PopulationReaderSettingCategory, FIPSCode, parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id}},
         parameters::{GlobalParams, SettingProperties},
+        pop_reader::{
+            FIPSCode, PopulationReaderSettingCategory,
+            parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id},
+        },
     };
     use ixa::{HashMap, assert_almost_eq};
 
@@ -404,13 +404,14 @@ mod test {
 
     fn make_community_id(home_id: &[u8]) -> SettingCode {
         let home_id = make_home_id(home_id).0;
-        SettingCode(FIPSCode::with_category(
-            home_id.state_code(),
-            home_id.county_code(),
-            home_id.census_tract_code(),
-            PopulationReaderSettingCategory::CensusTract.encode(),
-        )
-        .unwrap()
+        SettingCode(
+            FIPSCode::with_category(
+                home_id.state_code(),
+                home_id.county_code(),
+                home_id.census_tract_code(),
+                PopulationReaderSettingCategory::CensusTract.encode(),
+            )
+            .unwrap(),
         )
     }
 
@@ -512,8 +513,7 @@ mod test {
         let original_home_code = make_home_id(b"160379602000003");
         let original_community_code = make_community_id(b"160379602000003");
         let new_home_code = make_home_id(b"160379602000004");
-        let _ = context
-            .add_entity::<Setting, _>((original_home_code, SettingCategory::Home));
+        let _ = context.add_entity::<Setting, _>((original_home_code, SettingCategory::Home));
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
         context
@@ -693,7 +693,10 @@ mod test {
             .add_entity::<Setting, _>((make_home_id(b"160379602000007"), SettingCategory::Home))
             .unwrap();
         let work_id = context
-            .add_entity::<Setting, _>((make_workplace_id(b"1603796020000042"), SettingCategory::Work))
+            .add_entity::<Setting, _>((
+                make_workplace_id(b"1603796020000042"),
+                SettingCategory::Work,
+            ))
             .unwrap();
         let p1 = context.add_entity::<Person, _>((Age(23),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(23),)).unwrap();
@@ -738,7 +741,10 @@ mod test {
             .add_entity::<Setting, _>((make_home_id(b"160379602000008"), SettingCategory::Home))
             .unwrap();
         let work_id = context
-            .add_entity::<Setting, _>((make_workplace_id(b"1603796020000709"), SettingCategory::Work))
+            .add_entity::<Setting, _>((
+                make_workplace_id(b"1603796020000709"),
+                SettingCategory::Work,
+            ))
             .unwrap();
         let p1 = context.add_entity::<Person, _>((Age(24),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(24),)).unwrap();
@@ -767,7 +773,10 @@ mod test {
     fn test_sample_person_from_setting() {
         let mut context = setup(0.0);
         let comm_id = context
-            .add_entity::<Setting, _>((make_community_id(b"160379602000008"), SettingCategory::Community))
+            .add_entity::<Setting, _>((
+                make_community_id(b"160379602000008"),
+                SettingCategory::Community,
+            ))
             .unwrap();
         let person_id = context.add_entity::<Person, _>((Age(25),)).unwrap();
         assign_person_settings(
@@ -784,7 +793,10 @@ mod test {
     fn test_sample_from_setting_with_exclusion() {
         let mut context = setup(0.0);
         let work_id = context
-            .add_entity::<Setting, _>((make_workplace_id(b"1603796020000121"), SettingCategory::Work))
+            .add_entity::<Setting, _>((
+                make_workplace_id(b"1603796020000121"),
+                SettingCategory::Work,
+            ))
             .unwrap();
         let p1 = context.add_entity::<Person, _>((Age(26),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(27),)).unwrap();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -48,8 +48,6 @@ pub const SETTING_COUNT: usize = SettingCategory::COUNT;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub struct SettingCode(pub FIPSCode);
-// See #843:
-// pub type SettingCode = FIPSCode;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub struct Size(pub usize);
@@ -352,7 +350,7 @@ pub trait ContextSettingExt:
         &mut self,
         setting_category: SettingCategory,
         setting_code: SettingCode,
-    ) -> Result<SettingId, IxaError> {
+    ) -> Result<SettingId, ModelError> {
         if let Some(setting_id) = self
             .query_result_iterator::<Setting, _>(((setting_category, setting_code),))
             .next()

--- a/uv.lock
+++ b/uv.lock
@@ -691,6 +691,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pandas-stubs" },
     { name = "pyarrow" },
     { name = "pygris" },
     { name = "pytest" },
@@ -709,6 +710,7 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.3.4" },
     { name = "pandas", specifier = ">=3.0.0" },
+    { name = "pandas-stubs", specifier = "~=3.0.0" },
     { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "pygris", specifier = ">=0.2.1" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -1482,6 +1484,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/a0/ed160a00fb4f37d806406bc0a79a8b62fe67f29d00950f8d16203ff3409b/pandas-3.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:125eb901e233f155b268bbef9abd9afb5819db74f0e677e89a61b246228c71ac", size = 11799386, upload-time = "2026-01-21T15:51:57.457Z" },
     { url = "https://files.pythonhosted.org/packages/36/c8/2ac00d7255252c5e3cf61b35ca92ca25704b0188f7454ca4aec08a33cece/pandas-3.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b86d113b6c109df3ce0ad5abbc259fe86a1bd4adfd4a31a89da42f84f65509bb", size = 10873041, upload-time = "2026-01-21T15:52:00.034Z" },
     { url = "https://files.pythonhosted.org/packages/e6/3f/a80ac00acbc6b35166b42850e98a4f466e2c0d9c64054161ba9620f95680/pandas-3.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1c39eab3ad38f2d7a249095f0a3d8f8c22cc0f847e98ccf5bbe732b272e2d9fa", size = 9441003, upload-time = "2026-01-21T15:52:02.281Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.0.260204"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl", hash = "sha256:5ab9e4d55a6e2752e9720828564af40d48c4f709e6a2c69b743014a6fcb6c241", size = 168540, upload-time = "2026-02-04T15:17:15.615Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds:

1.  a 64-bit binary representation of setting IDs (setting codes, `homeId`, `schoolId`, `workplaceId`), called `FIPSCode`,  with accessors for the data they encode
2.  noncopying byte-slice oriented parsers to convert from textual setting IDs (setting codes) into `FIPSCode` values
3.  a fast file parser / reader for datasets formatted like the ASPR synthetic population dataset, including support for transparently reading from data in zip archives ~and some convenience methods for reading from the ASPR dataset specifically~ (Edit: removed ASPR-specific stuff)
4.  wiring of model code (`population_loader`) to use the new `FIPSCode` type for `SettingCode` and to use the new file reader facilities to load synth pop data
5.  modifications to `scripts/create_synthetic_population.py` to generate setting IDs in the same format as the ASPR dataset so we can use the same parser / file reader code for both

The code for (1)-(3) takes the form of a new module `pop_reader` that includes code originally in the `ixa-fips` crate and the defunct `ixa-aspr` crate. The plan is to incubate this code in `ixa-epi-covid` and then backport it to `ixa-fips` when we are confident it has general utility. 

**Out of scope for this PR:**

- Changing any model code whatsoever except to swap out the synthetic population file reader and to swap the definition `SettingCode` (previously a `usize` newtype) with `FIPSCode` (now a type alias `SettingCode = FIPSCode`).
  - no optimizations leveraging the fact that `SettingCode` / `FIPSCode` now carries its setting category
- Changes to how `scripts/create_synthetic_population.py` generates synthetic population data is limited only to the "sequential ID" suffix.
  - the sequential ID was changed from a global counter to a "within-tract" counter to align with the ASPR dataset
  - the formatting of the suffix was aligned with the format used in the ASPR dataset, including allowing a potential extra digit for overflowing sequential IDs
  - the data sources and other mechanisms for synthesis were left unmodified
  - no distinction between public & private schools was added
- Choices of data sources and additional validation of input data. If it parses to a `FIPSCode`, it's usable.

**Housekeeping work done:**

- Removed several unused crate dependencies
- Added `scripts/syn-pop-generation.md` documenting how `scripts/create_synthetic_population.py` works.
- Added `test-syn-pop` command to `Makefile` that runs `uv run pytest scripts/test_create_synthetic_population.py`.
- Added `clean-synthetic-population` command to `Makefile` that takes optional STATE and SIZE parameters that removes _generated_ `input/synth_pop_people_*` and `input/synth_pop_region_*` files.
- gitignore additions for IDE and macOS junk.

## Modularity of FIPS Code / Population Reader Functionality

Even though we've brought the code under a single module while it is being incubated, we still organize the FIPS Code representation, parser functionality, and file reader utilities in distinct layers, the deeper layers depending on the earlier layers, so that when we return it to a separate crate users can choose to pull into their projects only what they use.

### Layer 1: Compact, efficient FIPS Code binary representation

Previously in its own crate `ixa-fips` but now incubated in the `pop_reader::fips_code` module, we have:

- **`FIPSCode`:** a 64-bit compact binary representation of FIPS geographic region codes (and “code fragments”)
  - Accessor methods for component "fields"
  - Convenience constructor methods
- **`ExpandedFIPSCode`:** an "expanded" struct representation in which the `FIPSCode` fields are real, explicit fields. You can easily convert between `FIPSCode` and `ExpandedFIPSCode`.
- **`USState`:** An enum for U. S. states, because *numeric state code* to state conversion is not a simple linear map.

This layer is concerned only with binary representation. It is intended to be generally useful to represent things having a FIPS hierarchical geo ID tract prefix, but our motivating use case is to represent `homeId`, `schoolId`, and `workplaceId` values as they are used, for example, in the ASPR dataset.

### Layer 2: Setting ID / FIPS Code Parsing

Previously in its own crate `ixa-aspr` but now incubated in the `pop_reader::parser` module, we have utilities for parsing setting codes as they appear in the ASPR synthetic population data set:

- **High-level parsers** of setting code strings to `FIPSCode`: `parse_fips_home_id`, `parse_fips_school_id`, `parse_fips_workplace_id`.
- **Low-lever component parsers:**  `parse_county_code`, `parse_tract_code`, etc.
- **`PopulationReaderSettingCategory`:** Distinguishes public and private schools and includes `CensusTract` and an `Unspecified` variant (the `0` or "empty" case).
- **`FIPSParserError`:** Errors specific to parser utilities.

Uses types from Layer 1, concerned with synthetic population specific data parsing and representation.

### Layer 3: Synthetic Population Data Reading

Previously in crate `ixa-aspr`  gated by a feature flag but now incubated in `pop_reader::archive`, we have utilities for reading records from the CSV files in a particular format.

- **`PersonRecord`:** a struct with an age (required) and an `Option<FIPSCode>` field for each of home, school, and work IDs (not required).
- **`PersonRecordIterator`:** A stream of `PersonRecord` values parsed on demand from a given source. Convenience constructors for reading a particular file path.
- **`PopulationReaderError`:** High-level error type, wraps `FIPSParserError` as a source for errors parsing individual fields, with other variants for IO errors, `ZipError` wrapper, and `PopulationReaderError::WrongFieldCount` for malformed rows. Row-local errors are recoverable—parser moves to the next line. All others are trap states, and `next` will return `None`.
- Transparently handles reading files within a zip archive or plain files on the filesystem.
- Very efficient, byte-oriented non-copying parser specifically for the format used in this dataset.
- Useful for any synthetic population dataset in the same format.
- Specific conveniences for the ASPR dataset in particular have been removed.

## Issues and Questions

- Convenience items specific to the ASPR synthetic population dataset have been removed. This code is generally compatible with any dataset in the same format.

- Making the synthetic population reader code actually parse setting IDs into `FIPSCode` values also makes it more brittle, as it is parsing *more* structure. This PR makes the `create_synthetic_population.py` script emit more structured data to satisfy the new parser. So we have increased code complexity in two different places in the code. 

  The (short term) motivation for doing this is, `SettingCode` (now ~an alias~ a newtype for `FIPSCode`) now carries its `SettingCategory` with it, and so the setting category can be determined by inspection of the value rather than us needing to store this information elsewhere.  (We don't take advantage of this in this PR—that's deferred to another PR.)

  But we are parsing a lot more structure than just setting category, namely the state, county, and tract data, and we aren't using it, and we don't have any near term plans to use it, as far as I know. This is not necessarily a problem, but it's something to at least be aware of.

- Related to the previous: There's no getting around the fact that *parsing more structure* takes more time. Still, my optimized parser is fast: init runs ~10% *faster* than in the original implementation.

- The `FIPSCode` type can represent things that carry a FIPS hierarchical geographic region code down to the `tract` granularity with three additional fields: setting category (4 bits), sequential ID (15 bits), and "data" (8 bits, currently unused). This data type might be overspecified. I argue that it's fine for right now, and if we need something different later, we make something different later.

- I have tests that assume the existence of 

  - a zip file containing the zipped ASPR synth pop dataset
  - the unzipped ASPR synth pop dataset

  These tests are gated behind the `aspr_zip_tests` and `aspr_dataset_tests` feature flags respectively, which features are disabled by default. I run them on my local dev machine.

  We should probably set the default "data directory" as defined in `src/pop_reader/archive.rs:DEFAULT_DATA_PATH` to the value of an environment variable at compile time to point to the dataset on the developer's machine. Then we can enable these tests by default.

- ~Are there better names for things I've named `ASPR`?~ Renamed.