### PR TITLE
feat: New SettingMembership index, remove SettingCategory property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ input/synth_pop_people_%.csv:
 # Run the model with a synthetic population (e.g., make run SIZE=1_000_000)
 # Generates the population file if it doesn't exist.
 run: input/synth_pop_people_$(STATE)_$(NORMALIZED_SIZE).csv
-	cargo run --release --features profiling -- -c input/input.json -o output --no-stats -f --synth-population input/synth_pop_people_$(STATE)_$(NORMALIZED_SIZE).csv
+	cargo run --release --features profiling -- -c input/input.json -o output -f --synth-population input/synth_pop_people_$(STATE)_$(NORMALIZED_SIZE).csv
 
 run-small:
 	make run SIZE=10_000

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -75,11 +75,11 @@ mod test {
     use crate::infection_propagation_loop::InfectionRng;
     use crate::infectiousness_manager::InfectionData;
     use crate::pop_reader::{
-        FIPSCode, PopulationReaderSettingCategory,
-        parser::{parse_fips_home_id, parse_fips_workplace_id},
+        FIPSCode, PopulationReaderSettingCategory, parser::parse_fips_home_id,
     };
     use crate::population_loader::PersonId;
-    use crate::settings::{ContextSettingExt, SettingCategory, SettingCode};
+    use crate::setting_code::SettingCode;
+    use crate::settings::{ContextSettingExt, SettingCategory};
     use crate::{
         infection_propagation_loop::{
             InfectionStatus, init, schedule_next_forecasted_infection, schedule_recovery,
@@ -92,10 +92,6 @@ mod test {
 
     fn make_home_id(home_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_home_id(home_id).unwrap().1)
-    }
-
-    fn make_workplace_id(workplace_id: &[u8]) -> SettingCode {
-        SettingCode(parse_fips_workplace_id(workplace_id).unwrap().1)
     }
 
     fn make_community_id(home_id: &[u8]) -> SettingCode {
@@ -116,8 +112,7 @@ mod test {
         person_id: PersonId,
     ) -> Result<(), crate::error::ModelError> {
         let community_code = make_community_id(b"160379602000001");
-        context.add_person_to_settings(person_id, None, None, None, Some(community_code))?;
-        context.initialize_setting_size()?;
+        context.add_person_to_settings(person_id, None, None, None, Some(community_code));
         Ok(())
     }
 
@@ -412,6 +407,10 @@ mod test {
             let num_infected_censustract = Rc::new(RefCell::new(0usize));
             let num_infected_workplace = Rc::new(RefCell::new(0usize));
 
+            let home_code = SettingCode::arbitrary_home_code();
+            let community_code = home_code.extract_community();
+            let workplace_code = home_code.as_arbitrary_workplace_code();
+
             for seed in 0..num_sims {
                 let num_infected_home_clone = Rc::clone(&num_infected_home);
                 let num_infected_cenustract_clone = Rc::clone(&num_infected_censustract);
@@ -424,41 +423,28 @@ mod test {
                 let person_censustract: PersonId = context.add_entity((Age(30),)).unwrap();
                 let person_workplace: PersonId = context.add_entity((Age(30),)).unwrap();
 
-                let home_code = make_home_id(b"160379602000001");
-                let community_code = make_community_id(b"160379602000001");
-                let workplace_code = make_workplace_id(b"1603796020000220");
-
-                context
-                    .add_person_to_settings(person_home, Some(home_code), None, None, None)
-                    .unwrap();
-                context
-                    .add_person_to_settings(
-                        person_workplace,
-                        None,
-                        Some(workplace_code),
-                        None,
-                        None,
-                    )
-                    .unwrap();
-                context
-                    .add_person_to_settings(
-                        person_censustract,
-                        None,
-                        None,
-                        None,
-                        Some(community_code),
-                    )
-                    .unwrap();
-                context
-                    .add_person_to_settings(
-                        infectious_person,
-                        Some(home_code),
-                        Some(workplace_code),
-                        None,
-                        Some(community_code),
-                    )
-                    .unwrap();
-                context.initialize_setting_size().unwrap();
+                context.add_person_to_settings(person_home, Some(home_code), None, None, None);
+                context.add_person_to_settings(
+                    person_workplace,
+                    None,
+                    Some(workplace_code),
+                    None,
+                    None,
+                );
+                context.add_person_to_settings(
+                    person_censustract,
+                    None,
+                    None,
+                    None,
+                    Some(community_code),
+                );
+                context.add_person_to_settings(
+                    infectious_person,
+                    Some(home_code),
+                    Some(workplace_code),
+                    None,
+                    Some(community_code),
+                );
 
                 // We don't want infectious people beyond our index case to be able to transmit, so we
                 // have to do setup on our own since just calling `init` will trigger a watcher for

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     population_loader::PersonId,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, ScaledRateFn},
-    settings::{ContextSettingExt, SettingId},
+    settings::{ContextSettingExt, SettingCode},
 };
 
 use crate::population_loader::Person;
@@ -18,7 +18,7 @@ pub enum InfectionData {
     Infectious {
         infection_time: f64,
         infected_by: Option<PersonId>,
-        infection_setting_id: Option<SettingId>,
+        infection_setting_id: Option<SettingCode>,
     },
     Recovered {
         infection_time: f64,
@@ -171,7 +171,7 @@ pub trait InfectionContextExt: PluginContext + InfectiousnessRateExt {
         &mut self,
         target_id: PersonId,
         source_id: Option<PersonId>,
-        setting_id: Option<SettingId>,
+        setting_id: Option<SettingCode>,
     ) {
         let infection_time = self.get_current_time();
         trace!("Person {target_id}: Infected at {infection_time}");
@@ -215,41 +215,24 @@ mod test {
     use super::{
         InfectionContextExt, evaluate_forecast, get_forecast, max_total_infectiousness_multiplier,
     };
+    use crate::setting_code::SettingCode;
     use crate::{
         Age,
         infectiousness_manager::{InfectionData, InfectionStatus},
         parameters::{GlobalParams, Params, SettingProperties},
-        pop_reader::{FIPSCode, PopulationReaderSettingCategory, parser::parse_fips_home_id},
         population_loader::{Person, PersonId},
         rate_fns::{InfectiousnessRateExt, load_rate_fns},
-        settings::{ContextSettingExt, Setting, SettingCategory, SettingCode},
+        settings::{ContextSettingExt, SettingCategory},
     };
     use ixa::{HashMap, assert_almost_eq, prelude::*};
-
-    fn make_home_id(home_id: &[u8]) -> SettingCode {
-        SettingCode(parse_fips_home_id(home_id).unwrap().1)
-    }
-
-    fn make_community_id(home_id: &[u8]) -> SettingCode {
-        let home_id = make_home_id(home_id).0;
-        SettingCode(
-            FIPSCode::with_category(
-                home_id.state_code(),
-                home_id.county_code(),
-                home_id.census_tract_code(),
-                PopulationReaderSettingCategory::CensusTract.encode(),
-            )
-            .unwrap(),
-        )
-    }
 
     fn set_homogeneous_mixing_itinerary(
         context: &mut Context,
         person_id: PersonId,
     ) -> Result<(), crate::error::ModelError> {
-        let community_code = make_community_id(b"160379602000001");
-        context.add_person_to_settings(person_id, None, None, None, Some(community_code))?;
-        context.initialize_setting_size()?;
+        let community_code = SettingCode::arbitrary_home_code().extract_community();
+        context.add_person_to_settings(person_id, None, None, None, Some(community_code));
+
         Ok(())
     }
 
@@ -413,9 +396,7 @@ mod test {
         let mut context = setup_context();
         let index: PersonId = context.add_entity((Age(30),)).unwrap();
         let contact: PersonId = context.add_entity((Age(30),)).unwrap();
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000001"), SettingCategory::Home))
-            .unwrap();
+        let home_id = SettingCode::arbitrary_home_code();
         let infection_setting_id = Some(home_id);
         context.infect_person(contact, Some(index), infection_setting_id);
         context.execute();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod pop_reader;
 pub mod population_loader;
 pub mod rate_fns;
 pub mod reports;
+mod setting_code;
 pub mod settings;
 pub mod symptom_status_manager;
 

--- a/src/pop_reader/errors.rs
+++ b/src/pop_reader/errors.rs
@@ -91,7 +91,7 @@ pub struct FIPSError {
 
 impl FIPSError {
     #[must_use]
-    pub fn new(parameter_name: &'static str, value: u64, min: u64, max: u64) -> Self {
+    pub const fn new(parameter_name: &'static str, value: u64, min: u64, max: u64) -> Self {
         Self {
             parameter_name,
             value,
@@ -106,7 +106,7 @@ impl FIPSError {
     /// This one is unique in that it represents an error converting a (presumably valid) [`StateCode`] to a [`USState`]
     /// variant. We lie a little bit and claim that values in 1..57 are valid when 3, 7, 14, 43, and 52 are not.
     #[must_use]
-    pub fn from_us_state(value: StateCode) -> Self {
+    pub const fn from_us_state(value: StateCode) -> Self {
         Self {
             parameter_name: "USState Code",
             value: value as u64,
@@ -116,7 +116,7 @@ impl FIPSError {
     }
 
     #[must_use]
-    pub fn from_state_code(value: StateCode) -> Self {
+    pub const fn from_state_code(value: StateCode) -> Self {
         Self {
             parameter_name: "StateCode",
             value: value as u64,
@@ -126,7 +126,7 @@ impl FIPSError {
     }
 
     #[must_use]
-    pub fn from_county_code(value: CountyCode) -> Self {
+    pub const fn from_county_code(value: CountyCode) -> Self {
         Self {
             parameter_name: "CountyCode",
             value: value as u64,
@@ -136,7 +136,7 @@ impl FIPSError {
     }
 
     #[must_use]
-    pub fn from_tract_code(value: TractCode) -> Self {
+    pub const fn from_tract_code(value: TractCode) -> Self {
         Self {
             parameter_name: "TractCode",
             value: value as u64,
@@ -146,7 +146,7 @@ impl FIPSError {
     }
 
     #[must_use]
-    pub fn from_setting_category_code(value: SettingCategoryCode) -> Self {
+    pub const fn from_setting_category_code(value: SettingCategoryCode) -> Self {
         Self {
             parameter_name: "SettingCategoryCode",
             value: value as u64,
@@ -156,7 +156,7 @@ impl FIPSError {
     }
 
     #[must_use]
-    pub fn from_id_code(value: IdCode) -> Self {
+    pub const fn from_id_code(value: IdCode) -> Self {
         Self {
             parameter_name: "IdCode",
             value: value as u64,
@@ -166,7 +166,7 @@ impl FIPSError {
     }
 
     #[must_use]
-    pub fn from_data_code(value: DataCode) -> Self {
+    pub const fn from_data_code(value: DataCode) -> Self {
         Self {
             parameter_name: "DataCode",
             value: value as u64,

--- a/src/pop_reader/fips_code.rs
+++ b/src/pop_reader/fips_code.rs
@@ -109,7 +109,7 @@ impl FIPSCode {
     /// Constructs a new [`FIPSCode`] from a [`USState`]. Unlike the other constructors, this constructor is infallible.
     #[must_use]
     pub fn with_state(state: USState) -> Self {
-        Self::new(state.into(), 0, 0, 0, 0, 0).unwrap()
+        Self::new(state.encode(), 0, 0, 0, 0, 0).unwrap()
     }
     /// Constructs a new [`FIPSCode`].
     /// Returns `Err(())` if the data provided is out of range.
@@ -224,7 +224,7 @@ impl FIPSCode {
     /// Creates a copy of `self` with the FIPS STATE set to `state`.
     #[must_use]
     pub fn set_state(&self, state: USState) -> Self {
-        self.set_state_code(state.into()).unwrap()
+        self.set_state_code(state.encode()).unwrap()
     }
 
     /// Creates a copy of `self` with the FIPS STATE set to `state`.
@@ -235,21 +235,21 @@ impl FIPSCode {
     }
 
     /// Creates a copy of `self` with the FIPS COUNTY set to `county`.
-    pub fn set_county(&self, county: CountyCode) -> Result<Self, FIPSError> {
+    pub fn set_county_code(&self, county: CountyCode) -> Result<Self, FIPSError> {
         let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
         expanded.county = county;
         expanded.to_fips_code()
     }
 
     /// Creates a copy of `self` with the FIPS CENSUS TRACT set to `tract`.
-    pub fn set_tract(&self, tract: TractCode) -> Result<Self, FIPSError> {
+    pub fn set_tract_code(&self, tract: TractCode) -> Result<Self, FIPSError> {
         let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
         expanded.tract = tract;
         expanded.to_fips_code()
     }
 
     /// Creates a copy of `self` with the setting category set to `category`.
-    pub fn set_category(&self, category: SettingCategoryCode) -> Result<Self, FIPSError> {
+    pub fn set_category_code(&self, category: SettingCategoryCode) -> Result<Self, FIPSError> {
         let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
         expanded.category = category;
         expanded.to_fips_code()

--- a/src/pop_reader/states.rs
+++ b/src/pop_reader/states.rs
@@ -81,7 +81,7 @@ impl USState {
 
     /// Returns the numeric FIPS code for this state.
     #[must_use]
-    pub fn encode(&self) -> StateCode {
+    pub const fn encode(&self) -> StateCode {
         *self as StateCode
     }
 

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,4 +1,4 @@
-use ixa::{impl_derived_property, prelude::*};
+use ixa::{impl_derived_property, prelude::*, profiling::open_span};
 
 use serde::Serialize;
 use std::path::PathBuf;
@@ -6,11 +6,11 @@ use std::path::PathBuf;
 use crate::error::ModelError;
 use crate::parameters::ContextParametersExt;
 use crate::pop_reader::{
-    FIPSCode, PersonRecord, PopulationReaderSettingCategory,
+    PersonRecord,
     archive::{PersonRecordIterator, set_data_path},
 };
-use crate::settings::{ContextSettingExt, SETTING_COUNT, SettingCategory, SettingCode, SettingId};
-use ixa::profiling::open_span;
+use crate::setting_code::SettingCode;
+use crate::settings::{ContextSettingExt, SETTING_COUNT, SettingCategory};
 
 define_entity!(Person);
 
@@ -24,7 +24,7 @@ impl_property!(Alive, Person, default_const = Alive(true));
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
 pub struct SettingIds {
-    pub setting_ids: [Option<SettingId>; SETTING_COUNT],
+    pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
 }
 impl_property!(
     SettingIds,
@@ -47,13 +47,13 @@ impl_property!(
 );
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct HomeId(pub Option<SettingId>);
+pub struct HomeId(pub Option<SettingCode>);
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct SchoolId(pub Option<SettingId>);
+pub struct SchoolId(pub Option<SettingCode>);
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct WorkId(pub Option<SettingId>);
+pub struct WorkId(pub Option<SettingCode>);
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct CommunityId(pub Option<SettingId>);
+pub struct CommunityId(pub Option<SettingCode>);
 
 impl_derived_property!(HomeId, Person, [SettingIds], [], |setting_ids| HomeId(
     setting_ids.setting_ids[SettingCategory::Home]
@@ -71,20 +71,6 @@ impl_derived_property!(CommunityId, Person, [SettingIds], [], |setting_ids| {
     CommunityId(setting_ids.setting_ids[SettingCategory::Community])
 });
 
-fn community_code_from_home(home_id: SettingCode) -> SettingCode {
-    let home_id = home_id.0;
-    // Since we are calling this constructor with values that we know are valid, we can unwrap.
-    SettingCode(
-        FIPSCode::with_category(
-            home_id.state_code(),
-            home_id.county_code(),
-            home_id.census_tract_code(),
-            PopulationReaderSettingCategory::CensusTract.encode(),
-        )
-        .unwrap(),
-    )
-}
-
 fn create_person_from_record(
     context: &mut Context,
     person_record: PersonRecord,
@@ -93,7 +79,7 @@ fn create_person_from_record(
         ModelError::ModelError("person record is missing required home_id".to_string())
     })?;
     let home_id = SettingCode(home_id);
-    let community_id = community_code_from_home(home_id);
+    let community_id = home_id.extract_community();
 
     let person_id: PersonId = context.add_entity((Age(person_record.age),)).unwrap();
     context.add_person_to_settings(
@@ -102,7 +88,7 @@ fn create_person_from_record(
         person_record.work_id.map(SettingCode),
         person_record.school_id.map(SettingCode),
         Some(community_id),
-    )?;
+    );
     Ok(())
 }
 
@@ -127,11 +113,6 @@ pub fn init(
     let file = synth_population_override
         .unwrap_or_else(|| context.get_params().synth_population_file.clone());
     load_synth_population(context, file)?;
-    context.index_property::<Person, HomeId>();
-    context.index_property::<Person, SchoolId>();
-    context.index_property::<Person, WorkId>();
-    context.index_property::<Person, CommunityId>();
-    context.initialize_setting_size()?;
     Ok(())
 }
 
@@ -143,7 +124,8 @@ mod test {
         errors::PopulationReaderError,
         parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id},
     };
-    use crate::settings::{Setting, SettingCategory, SettingCode};
+    use crate::setting_code::SettingCode;
+    use crate::settings::SettingCategory;
     use ixa::HashMap;
     use std::io::Write;
     use std::path::PathBuf;
@@ -209,42 +191,25 @@ mod test {
         );
         let synth_file = persist_tmp_csv(input);
         load_synth_population(&mut context, synth_file).unwrap();
-        context.initialize_setting_size().unwrap();
+
         let age = [43, 42];
         let home_id = [
             make_home_id(b"160379602000001"),
             make_home_id(b"160379602000002"),
         ];
-        let census_tract_id = community_code_from_home(home_id[0]);
+        let census_tract_id = home_id[0].extract_community();
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Home,)),
-            2
-        );
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Community,)),
-            1
-        );
 
         for item in age.iter().take(1) {
             assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
         }
-        let home_id1 = context
-            .query_result_iterator::<Setting, _>((home_id[0], SettingCategory::Home))
-            .next()
-            .unwrap();
-        let home_id2 = context
-            .query_result_iterator::<Setting, _>((home_id[1], SettingCategory::Home))
-            .next()
-            .unwrap();
-        let censustract_id = context
-            .query_result_iterator::<Setting, _>((census_tract_id, SettingCategory::Community))
-            .next()
-            .unwrap();
-        assert_eq!(1, context.get_setting_size(home_id1).unwrap());
-        assert_eq!(1, context.get_setting_size(home_id2).unwrap());
-        assert_eq!(2, context.get_setting_size(censustract_id).unwrap());
+        let home_id1 = home_id[0];
+        let home_id2 = home_id[1];
+
+        assert_eq!(1, context.get_setting_size(home_id1));
+        assert_eq!(1, context.get_setting_size(home_id2));
+        assert_eq!(2, context.get_setting_size(census_tract_id));
     }
 
     #[test]
@@ -269,27 +234,6 @@ mod test {
     }
 
     #[test]
-    fn minimal_reproducible_test() {
-        let mut context = setup();
-        let home_code = make_home_id(b"160379602000001");
-        let school_code = make_home_id(b"16037960200002");
-        let record = PersonRecord {
-            age: 43,
-            home_id: Some(home_code.0),
-            school_id: Some(school_code.0),
-            work_id: None,
-        };
-        create_person_from_record(&mut context, record).unwrap_or_else(|e| panic!("{}", e));
-
-        let home_id1 = context
-            .query_result_iterator::<Setting, _>((home_code, SettingCategory::Home))
-            .next()
-            .unwrap();
-        let cat: SettingCategory = context.get_property(home_id1);
-        println!("Found {:?} for setting {:?}", cat, home_id1);
-    }
-
-    #[test]
     fn check_synth_file_school() {
         let mut context = setup();
         let input = concat!(
@@ -299,7 +243,6 @@ mod test {
         );
         let synth_file = persist_tmp_csv(input);
         load_synth_population(&mut context, synth_file).unwrap_or_else(|e| panic!("{}", e));
-        context.initialize_setting_size().unwrap();
         let age = [43, 42];
         let school_id = [
             make_school_id(b"16037960200002"),
@@ -309,53 +252,18 @@ mod test {
             make_home_id(b"160379602000001"),
             make_home_id(b"160379602000002"),
         ];
-        let census_tract_id = community_code_from_home(home_id[0]);
-
-        let home_id1 = context
-            .query_result_iterator::<Setting, _>((home_id[0], SettingCategory::Home))
-            .next()
-            .unwrap();
-        let cat: SettingCategory = context.get_property(home_id1);
-        println!("Found {:?} for setting {:?}", cat, home_id1);
-        let home_id2 = context
-            .query_result_iterator::<Setting, _>((home_id[1], SettingCategory::Home))
-            .next()
-            .unwrap();
-        let school_id1 = context
-            .query_result_iterator::<Setting, _>((school_id[0], SettingCategory::School))
-            .next()
-            .unwrap();
-        let school_id2 = context
-            .query_result_iterator::<Setting, _>((school_id[1], SettingCategory::School))
-            .next()
-            .unwrap();
-        let censustract_id = context
-            .query_result_iterator::<Setting, _>((census_tract_id, SettingCategory::Community))
-            .next()
-            .unwrap();
+        let census_tract_id = home_id[0].extract_community();
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Home,)),
-            2
-        );
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::School,)),
-            2
-        );
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Community,)),
-            1
-        );
 
         for item in age.iter().take(1) {
             assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
         }
-        assert_eq!(1, context.get_setting_size(home_id1).unwrap());
-        assert_eq!(1, context.get_setting_size(home_id2).unwrap());
-        assert_eq!(1, context.get_setting_size(school_id1).unwrap());
-        assert_eq!(1, context.get_setting_size(school_id2).unwrap());
-        assert_eq!(2, context.get_setting_size(censustract_id).unwrap());
+        assert_eq!(1, context.get_setting_size(home_id[0]));
+        assert_eq!(1, context.get_setting_size(home_id[1]));
+        assert_eq!(1, context.get_setting_size(school_id[0]));
+        assert_eq!(1, context.get_setting_size(school_id[1]));
+        assert_eq!(2, context.get_setting_size(census_tract_id));
     }
 
     #[test]
@@ -368,7 +276,6 @@ mod test {
         );
         let synth_file = persist_tmp_csv(input);
         load_synth_population(&mut context, synth_file).unwrap();
-        context.initialize_setting_size().unwrap();
 
         let age = [43, 42];
         let workplace_id = [
@@ -379,49 +286,17 @@ mod test {
             make_home_id(b"160379602000001"),
             make_home_id(b"160379602000002"),
         ];
-        let census_tract_id = community_code_from_home(home_id[0]);
-
-        let home_id1 = context
-            .query_result_iterator::<Setting, _>((home_id[0], SettingCategory::Home))
-            .next()
-            .unwrap();
-        let home_id2 = context
-            .query_result_iterator::<Setting, _>((home_id[1], SettingCategory::Home))
-            .next()
-            .unwrap();
-        let workplace_id1 = context
-            .query_result_iterator::<Setting, _>((workplace_id[0], SettingCategory::Work))
-            .next()
-            .unwrap();
-        let workplace_id2 = context
-            .query_result_iterator::<Setting, _>((workplace_id[1], SettingCategory::Work))
-            .next()
-            .unwrap();
-        let censustract_id = context
-            .query_result_iterator::<Setting, _>((census_tract_id, SettingCategory::Community))
-            .next()
-            .unwrap();
+        let census_tract_id = home_id[0].extract_community();
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Home,)),
-            2
-        );
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Work,)),
-            2
-        );
-        assert_eq!(
-            context.query_entity_count::<Setting, _>((SettingCategory::Community,)),
-            1
-        );
+
         for item in age.iter().take(1) {
             assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
         }
-        assert_eq!(1, context.get_setting_size(home_id1).unwrap());
-        assert_eq!(1, context.get_setting_size(home_id2).unwrap());
-        assert_eq!(1, context.get_setting_size(workplace_id1).unwrap());
-        assert_eq!(1, context.get_setting_size(workplace_id2).unwrap());
-        assert_eq!(2, context.get_setting_size(censustract_id).unwrap());
+        assert_eq!(1, context.get_setting_size(home_id[0]));
+        assert_eq!(1, context.get_setting_size(home_id[1]));
+        assert_eq!(1, context.get_setting_size(workplace_id[0]));
+        assert_eq!(1, context.get_setting_size(workplace_id[1]));
+        assert_eq!(2, context.get_setting_size(census_tract_id));
     }
 }

--- a/src/reports/incidence_report.rs
+++ b/src/reports/incidence_report.rs
@@ -172,20 +172,15 @@ mod test {
     use crate::{
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, OrderedAgeGroupsParam, Params},
-        pop_reader::parser::parse_fips_home_id,
         population_loader::{Age, Person, PersonId},
         rate_fns::load_rate_fns,
         reports::ReportParams,
-        settings::{SettingCategory, SettingCode, SettingId},
+        settings::SettingCode,
         symptom_status_manager::SymptomAgeGroup,
     };
     use ixa::{csv, prelude::*};
     use std::path::PathBuf;
     use tempfile::tempdir;
-
-    fn make_home_id(home_id: &[u8]) -> SettingCode {
-        SettingCode(parse_fips_home_id(home_id).unwrap().1)
-    }
 
     fn setup_context_with_report(incidence_report: ReportParams) -> Context {
         let mut context = Context::new();
@@ -231,9 +226,7 @@ mod test {
 
         let source: PersonId = context.add_entity((Age(42),)).unwrap();
         let target: PersonId = context.add_entity((Age(43),)).unwrap();
-        let home: SettingId = context
-            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
-            .unwrap();
+        let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;
 
@@ -292,9 +285,7 @@ mod test {
 
         let source: PersonId = context.add_entity((Age(42),)).unwrap();
         let target: PersonId = context.add_entity((Age(43),)).unwrap();
-        let home: SettingId = context
-            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
-            .unwrap();
+        let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;
 

--- a/src/reports/prevalence_report.rs
+++ b/src/reports/prevalence_report.rs
@@ -113,19 +113,14 @@ mod test {
         Age,
         infectiousness_manager::{InfectionContextExt, InfectionStatus},
         parameters::{ContextParametersExt, GlobalParams, Params},
-        pop_reader::parser::parse_fips_home_id,
         population_loader::PersonId,
         rate_fns::load_rate_fns,
         reports::ReportParams,
-        settings::{SettingCategory, SettingCode, SettingId},
+        settings::SettingCode,
     };
     use ixa::{csv, prelude::*};
     use std::path::PathBuf;
     use tempfile::tempdir;
-
-    fn make_home_id(home_id: &[u8]) -> SettingCode {
-        SettingCode(parse_fips_home_id(home_id).unwrap().1)
-    }
 
     fn setup_context_with_report(prevalence_report: ReportParams) -> Context {
         let mut context = Context::new();
@@ -159,9 +154,7 @@ mod test {
 
         let source: PersonId = context.add_entity((Age(42),)).unwrap();
         let target: PersonId = context.add_entity((Age(43),)).unwrap();
-        let home: SettingId = context
-            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
-            .unwrap();
+        let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;
 

--- a/src/reports/transmission_report.rs
+++ b/src/reports/transmission_report.rs
@@ -1,7 +1,7 @@
 use crate::error::ModelError;
 use crate::infectiousness_manager::InfectionData;
 use crate::population_loader::{Person, PersonId};
-use crate::settings::SettingId;
+use crate::settings::SettingCode;
 use ixa::prelude::*;
 use ixa::profiling::open_span;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ struct TransmissionReport {
     time: f64,
     target_id: PersonId,
     infected_by: Option<PersonId>,
-    infection_setting_id: Option<SettingId>,
+    infection_setting_id: Option<SettingCode>,
 }
 
 define_report!(TransmissionReport);
@@ -20,7 +20,7 @@ fn record_transmission_event(
     context: &mut Context,
     target_id: PersonId,
     infected_by: Option<PersonId>,
-    infection_setting_id: Option<SettingId>,
+    infection_setting_id: Option<SettingCode>,
 ) {
     if infected_by.is_some() {
         context.send_report(TransmissionReport {
@@ -57,11 +57,10 @@ mod test {
         Age,
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, Params},
-        pop_reader::parser::parse_fips_home_id,
         population_loader::PersonId,
         rate_fns::load_rate_fns,
         reports::ReportParams,
-        settings::{SettingCategory, SettingCode, SettingId},
+        settings::SettingCode,
     };
     use ixa::{
         Context, ContextEntitiesExt, ContextGlobalPropertiesExt, ContextRandomExt,
@@ -69,10 +68,6 @@ mod test {
     };
     use std::path::PathBuf;
     use tempfile::tempdir;
-
-    fn make_home_id(home_id: &[u8]) -> SettingCode {
-        SettingCode(parse_fips_home_id(home_id).unwrap().1)
-    }
 
     fn setup_context_with_report(transmission_report: ReportParams) -> Context {
         let mut context = Context::new();
@@ -106,9 +101,7 @@ mod test {
 
         let source: PersonId = context.add_entity((Age(30),)).unwrap();
         let target: PersonId = context.add_entity((Age(30),)).unwrap();
-        let home: SettingId = context
-            .add_entity((make_home_id(b"160379602000001"), SettingCategory::Home))
-            .unwrap();
+        let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;
 

--- a/src/setting_code.rs
+++ b/src/setting_code.rs
@@ -1,0 +1,126 @@
+//! Setting codes are used to identify settings in the population. The `SettingCode` type is
+//! a newtype for `FIPSCode`. Thus, it knows its setting category, state, county, and tract.
+
+use crate::pop_reader::{FIPSCode, PopulationReaderSettingCategory};
+use crate::settings::SettingCategory;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub struct SettingCode(pub FIPSCode);
+
+impl SettingCode {
+    pub fn category(&self) -> SettingCategory {
+        match PopulationReaderSettingCategory::from_repr(self.0.category_code()) {
+            Some(PopulationReaderSettingCategory::Home) => SettingCategory::Home,
+            Some(PopulationReaderSettingCategory::PrivateSchool)
+            | Some(PopulationReaderSettingCategory::PublicSchool) => SettingCategory::School,
+            Some(PopulationReaderSettingCategory::Workplace) => SettingCategory::Work,
+            Some(PopulationReaderSettingCategory::CensusTract) => SettingCategory::Community,
+            _ => panic!("Invalid setting category code: {}", self.0.category_code()),
+        }
+    }
+
+    pub fn extract_community(&self) -> Self {
+        let home_id = self.0;
+        // Since we are calling this constructor with values that we know are valid, we can unwrap.
+        SettingCode(
+            FIPSCode::with_category(
+                home_id.state_code(),
+                home_id.county_code(),
+                home_id.census_tract_code(),
+                PopulationReaderSettingCategory::CensusTract.encode(),
+            )
+            .unwrap(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::pop_reader::PopulationReaderSettingCategory;
+    use crate::pop_reader::fips_code::ExpandedFIPSCode;
+    use crate::pop_reader::states::USState;
+    use std::sync::atomic::AtomicU16;
+
+    // Helper methods to generate arbitrary SettingCodes for unit tests
+    impl SettingCode {
+        fn next_home_code() -> u16 {
+            static COUNTER: AtomicU16 = AtomicU16::new(0);
+
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        }
+
+        fn next_school_code() -> u16 {
+            static COUNTER: AtomicU16 = AtomicU16::new(0);
+
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        }
+
+        fn next_workplace_code() -> u16 {
+            static COUNTER: AtomicU16 = AtomicU16::new(0);
+
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        }
+
+        pub fn arbitrary_home_code() -> SettingCode {
+            let fips_code = ExpandedFIPSCode {
+                state: USState::WY.encode(),
+                county: 1,
+                tract: 1,
+                category: PopulationReaderSettingCategory::Home.encode(),
+                id: Self::next_home_code(),
+                data: 0,
+            }
+            .to_fips_code()
+            .unwrap();
+            SettingCode(fips_code)
+        }
+
+        pub fn arbitrary_school_code() -> SettingCode {
+            let fips_code = ExpandedFIPSCode {
+                state: USState::WY.encode(),
+                county: 1,
+                tract: 1,
+                category: PopulationReaderSettingCategory::PublicSchool.encode(),
+                id: Self::next_school_code(),
+                data: 0,
+            }
+            .to_fips_code()
+            .unwrap();
+            SettingCode(fips_code)
+        }
+
+        pub fn arbitrary_workplace_code() -> SettingCode {
+            let fips_code = ExpandedFIPSCode {
+                state: USState::WY.encode(),
+                county: 1,
+                tract: 1,
+                category: PopulationReaderSettingCategory::Workplace.encode(),
+                id: Self::next_workplace_code(),
+                data: 0,
+            }
+            .to_fips_code()
+            .unwrap();
+            SettingCode(fips_code)
+        }
+
+        /// Constructs an arbitrary workplace setting code with the same state, county, and tract
+        /// as `self`.
+        pub fn as_arbitrary_workplace_code(&self) -> SettingCode {
+            let fips_code = self.0;
+
+            let new_fips_code = ExpandedFIPSCode {
+                state: fips_code.state_code(),
+                county: fips_code.county_code(),
+                tract: fips_code.census_tract_code(),
+                category: PopulationReaderSettingCategory::Workplace.encode(),
+                id: Self::next_workplace_code(),
+                data: 0,
+            }
+            .to_fips_code()
+            .unwrap();
+            SettingCode(new_fips_code)
+        }
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,3 +1,4 @@
+use ixa::HashMap;
 use ixa::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -6,17 +7,79 @@ use std::{
 };
 use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 
-use crate::population_loader::{ItineraryRatios, SettingIds};
-use crate::{
+pub(crate) use crate::{
     ContextParametersExt, Params,
     error::ModelError,
-    pop_reader::FIPSCode,
-    population_loader::{CommunityId, HomeId, Person, PersonId, SchoolId, WorkId},
+    population_loader::{ItineraryRatios, Person, PersonId, SettingIds},
+    setting_code::SettingCode,
 };
 
 define_rng!(SettingRng);
 
-define_entity!(Setting);
+// define_entity!(Setting);
+
+/// An index of settings as represented by their setting codes.
+#[derive(Default)]
+pub struct SettingMembership {
+    members: HashMap<SettingCode, Vec<PersonId>>,
+}
+
+impl SettingMembership {
+    pub fn new() -> Self {
+        Self {
+            members: HashMap::default(),
+        }
+    }
+
+    pub fn add_member(&mut self, setting_code: SettingCode, person_id: PersonId) {
+        let members = self.members.entry(setting_code).or_default();
+        if !members.contains(&person_id) {
+            members.push(person_id);
+        }
+    }
+
+    pub fn add_members(&mut self, setting_codes: &[Option<SettingCode>], person_id: PersonId) {
+        for setting_code in setting_codes
+            .iter()
+            .filter_map(|&setting_code| setting_code)
+        {
+            self.add_member(setting_code, person_id);
+        }
+    }
+
+    pub fn get_members(&self, setting_code: SettingCode) -> Option<&Vec<PersonId>> {
+        self.members.get(&setting_code)
+    }
+
+    pub fn get_members_mut(&mut self, setting_code: SettingCode) -> Option<&mut Vec<PersonId>> {
+        self.members.get_mut(&setting_code)
+    }
+
+    pub fn remove_member(&mut self, setting_code: SettingCode, person_id: PersonId) {
+        self.members
+            .entry(setting_code)
+            .and_modify(|members| members.retain(|id| *id != person_id));
+    }
+
+    pub fn member_count(&self, setting_code: SettingCode) -> usize {
+        self.members
+            .get(&setting_code)
+            .map(|members| members.len())
+            .unwrap_or(0)
+    }
+}
+
+define_data_plugin!(SettingMembershipPlugin, SettingMembership, |context| {
+    let mut membership = SettingMembership::default();
+    let person_iter = context.get_entity_iterator::<Person>();
+
+    for person_id in person_iter {
+        let settings: SettingIds = context.get_property(person_id);
+        membership.add_members(&settings.setting_ids, person_id);
+    }
+
+    membership
+});
 
 #[derive(
     Serialize, Deserialize, PartialEq, Debug, Clone, Copy, Hash, Eq, EnumCountMacro, EnumIter,
@@ -29,7 +92,6 @@ pub enum SettingCategory {
     Community,
 }
 
-// Implement immutable indexing
 impl<T> Index<SettingCategory> for [T; SETTING_COUNT] {
     type Output = T;
     fn index(&self, index: SettingCategory) -> &Self::Output {
@@ -37,7 +99,6 @@ impl<T> Index<SettingCategory> for [T; SETTING_COUNT] {
     }
 }
 
-// Implement mutable indexing
 impl<T> IndexMut<SettingCategory> for [T; SETTING_COUNT] {
     fn index_mut(&mut self, index: SettingCategory) -> &mut Self::Output {
         &mut self[index as usize]
@@ -46,24 +107,11 @@ impl<T> IndexMut<SettingCategory> for [T; SETTING_COUNT] {
 
 pub const SETTING_COUNT: usize = SettingCategory::COUNT;
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
-pub struct SettingCode(pub FIPSCode);
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Hash)]
-pub struct Size(pub usize);
-
-impl_property!(Size, Setting, default_const = Size(0));
-
-impl_property!(SettingCode, Setting);
-
-impl_property!(SettingCategory, Setting);
-
-define_multi_property!((SettingCategory, SettingCode), Setting);
-
 define_global_property!(SettingAlphas, [f64; SETTING_COUNT]);
 define_global_property!(SettingRatios, [f64; SETTING_COUNT]);
 
 trait ContextSettingExtPrivate: PluginContext + ContextEntitiesExt + ContextParametersExt {
+    #[allow(dead_code)]
     fn get_setting_ratio(&self, setting_category: SettingCategory) -> Result<f64, ModelError> {
         let ratios = self.get_global_property_value(SettingRatios).unwrap();
         Ok(ratios[setting_category])
@@ -72,23 +120,6 @@ trait ContextSettingExtPrivate: PluginContext + ContextEntitiesExt + ContextPara
     fn get_setting_alpha(&self, setting_category: SettingCategory) -> Result<f64, ModelError> {
         let alphas = self.get_global_property_value(SettingAlphas).unwrap();
         Ok(alphas[setting_category])
-    }
-
-    fn sample_person_from_setting_internal<T>(&self, setting: T) -> Result<PersonId, ModelError>
-    where
-        T: Property<Person> + Debug,
-    {
-        self.sample_entity::<Person, _, _>(SettingRng, (setting,))
-            .ok_or_else(|| {
-                ModelError::ModelError(format!("No members found for setting: {:?}", setting))
-            })
-    }
-
-    fn set_setting_size_internal<T>(&mut self, setting: T) -> Result<usize, ModelError>
-    where
-        T: Property<Person> + Debug,
-    {
-        Ok(self.query_entity_count::<Person, _>((setting,)))
     }
 }
 impl ContextSettingExtPrivate for Context {}
@@ -137,46 +168,23 @@ pub trait ContextSettingExt:
         .unwrap();
     }
 
-    fn initialize_setting_size(&mut self) -> Result<(), ModelError> {
-        for setting in self.get_entity_iterator::<Setting>() {
-            let setting_category = self.get_property::<Setting, SettingCategory>(setting);
-            match setting_category {
-                SettingCategory::Home => {
-                    let size = self.set_setting_size_internal(HomeId(Some(setting)))?;
-                    self.set_property::<Setting, Size>(setting, Size(size));
-                }
-                SettingCategory::School => {
-                    let size = self.set_setting_size_internal(SchoolId(Some(setting)))?;
-                    self.set_property::<Setting, Size>(setting, Size(size));
-                }
-                SettingCategory::Work => {
-                    let size = self.set_setting_size_internal(WorkId(Some(setting)))?;
-                    self.set_property::<Setting, Size>(setting, Size(size));
-                }
-                SettingCategory::Community => {
-                    let size = self.set_setting_size_internal(CommunityId(Some(setting)))?;
-                    self.set_property::<Setting, Size>(setting, Size(size));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn get_setting_size(&self, setting: SettingId) -> Result<usize, ModelError> {
-        Ok(self.get_property::<Setting, Size>(setting).0)
+    fn get_setting_size(&self, setting: SettingCode) -> usize {
+        let membership = self.get_data(SettingMembershipPlugin);
+        membership.member_count(setting)
     }
 
     fn get_active_settings_for_person(
         &self,
         person_id: PersonId,
-    ) -> Result<Vec<(SettingId, f64, f64)>, ModelError> {
+    ) -> Result<Vec<(SettingCode, f64, f64)>, ModelError> {
         let mut active_settings = Vec::new();
         let setting_ids = self.get_property::<Person, SettingIds>(person_id);
         let itinerary_ratios = self.get_property::<Person, ItineraryRatios>(person_id);
+
         for category in SettingCategory::iter() {
             if let Some(id) = setting_ids.setting_ids[category] {
                 let ratio = itinerary_ratios.itinerary_ratios[category];
-                let multiplier = self.calculate_multiplier(id, category)?;
+                let multiplier = self.calculate_multiplier(id)?;
                 active_settings.push((id, ratio, multiplier));
             }
         }
@@ -191,17 +199,14 @@ pub trait ContextSettingExt:
         let mut current_inf = 0.0;
         let mut sum_ratio = 0.0;
         // we calculate sum of ratios to normalize weights
-        for setting in active_settings.iter() {
-            let ratio = setting.1;
+        for (_, ratio, _) in active_settings.iter() {
             sum_ratio += ratio;
         }
         // Current infectiousness multiplier is the weighted average of the setting specific multipliers
         // where weights are given by the ratio of time spent in each setting normalized by the sum of ratios
         // across active settings.
         if sum_ratio > 0.0 {
-            for setting in active_settings.iter() {
-                let ratio = setting.1;
-                let multiplier = setting.2;
+            for (_, ratio, multiplier) in active_settings.iter() {
                 current_inf += multiplier * (ratio / sum_ratio);
             }
         }
@@ -214,37 +219,27 @@ pub trait ContextSettingExt:
         // and s.2 refers to the multiplier for that setting based on its size and alpha.
         let active_settings = self.get_active_settings_for_person(person_id).unwrap();
         let mut max_inf = 0.0;
-        for setting in active_settings.iter() {
-            let multiplier = setting.2;
-            max_inf = f64::max(max_inf, multiplier);
+        for (_, _, multiplier) in active_settings.iter() {
+            max_inf = f64::max(max_inf, *multiplier);
         }
         max_inf
     }
 
-    fn sample_person_from_setting(&self, setting: SettingId) -> Result<PersonId, ModelError> {
-        let setting_category = self.get_property::<Setting, SettingCategory>(setting);
-        match setting_category {
-            SettingCategory::Home => {
-                self.sample_person_from_setting_internal(HomeId(Some(setting)))
-            }
-            SettingCategory::School => {
-                self.sample_person_from_setting_internal(SchoolId(Some(setting)))
-            }
-            SettingCategory::Work => {
-                self.sample_person_from_setting_internal(WorkId(Some(setting)))
-            }
-            SettingCategory::Community => {
-                self.sample_person_from_setting_internal(CommunityId(Some(setting)))
-            }
-        }
+    fn sample_person_from_setting(&self, setting: SettingCode) -> Result<PersonId, ModelError> {
+        let membership = self.get_data(SettingMembershipPlugin);
+        let members = membership.get_members(setting).ok_or_else(|| {
+            ModelError::ModelError(format!("No members found for setting: {:?}", setting))
+        })?;
+        let idx = self.sample_range(SettingRng, 0..members.len());
+        Ok(members[idx])
     }
 
     fn sample_from_setting_with_exclusion(
         &self,
         person_id: PersonId,
-        setting: SettingId,
+        setting: SettingCode,
     ) -> Result<Option<PersonId>, ModelError> {
-        if self.get_setting_size(setting)? == 1 {
+        if self.get_setting_size(setting) == 1 {
             return Ok(None);
         }
         loop {
@@ -255,17 +250,13 @@ pub trait ContextSettingExt:
         }
     }
 
-    fn calculate_multiplier(
-        &self,
-        setting: SettingId,
-        setting_category: SettingCategory,
-    ) -> Result<f64, ModelError> {
-        let size = self.get_setting_size(setting)? as f64 - 1.0;
-        let alpha = self.get_setting_alpha(setting_category)?;
+    fn calculate_multiplier(&self, setting: SettingCode) -> Result<f64, ModelError> {
+        let size = self.get_setting_size(setting) as f64 - 1.0;
+        let alpha = self.get_setting_alpha(setting.category())?;
         Ok(size.powf(alpha))
     }
 
-    fn sample_active_setting(&self, person_id: PersonId) -> Result<SettingId, ModelError> {
+    fn sample_active_setting(&self, person_id: PersonId) -> Result<SettingCode, ModelError> {
         let active_settings = self.get_active_settings_for_person(person_id)?;
         let mut weights_vec = vec![];
         for setting in active_settings.iter() {
@@ -283,24 +274,6 @@ pub trait ContextSettingExt:
         }
     }
 
-    fn add_person_to_setting(
-        &mut self,
-        setting_ids: &mut [Option<SettingId>; SETTING_COUNT],
-        itinerary_ratios: &mut [f64; SETTING_COUNT],
-        setting_code: Option<SettingCode>,
-        setting_category: SettingCategory,
-    ) {
-        let Some(setting_code) = setting_code else {
-            // Nothing to do.
-            return;
-        };
-        let setting_id = self
-            .add_index_setting(setting_category, setting_code)
-            .unwrap();
-        setting_ids[setting_category] = Some(setting_id);
-        itinerary_ratios[setting_category] = self.get_setting_ratio(setting_category).unwrap();
-    }
-
     fn add_person_to_settings(
         &mut self,
         person_id: PersonId,
@@ -308,69 +281,48 @@ pub trait ContextSettingExt:
         work_id: Option<SettingCode>,
         school_id: Option<SettingCode>,
         community_id: Option<SettingCode>,
-    ) -> Result<(), ModelError> {
-        let mut setting_ids = [None; SETTING_COUNT];
-        let mut itinerary_ratios = [0.0; SETTING_COUNT];
-        self.add_person_to_setting(
-            &mut setting_ids,
-            &mut itinerary_ratios,
+    ) {
+        let setting_ids = [
+            // Keep this ordering in sync with the SettingCategory enum, which is used to index into
+            // this array.
             home_id,
-            SettingCategory::Home,
-        );
-        self.add_person_to_setting(
-            &mut setting_ids,
-            &mut itinerary_ratios,
             work_id,
-            SettingCategory::Work,
-        );
-        self.add_person_to_setting(
-            &mut setting_ids,
-            &mut itinerary_ratios,
             school_id,
-            SettingCategory::School,
-        );
-        self.add_person_to_setting(
-            &mut setting_ids,
-            &mut itinerary_ratios,
             community_id,
-            SettingCategory::Community,
-        );
-        let sum_ratio = itinerary_ratios.iter().sum::<f64>();
+        ];
+
+        // The default itinerary ratios.
+        let default_itinerary_ratios = *self.get_global_property_value(SettingRatios).unwrap();
+
+        let itinerary_ratios = std::array::from_fn(|i| {
+            if setting_ids[i].is_some() {
+                default_itinerary_ratios[i]
+            } else {
+                0.0
+            }
+        });
+
+        let sum_ratio = itinerary_ratios.iter().copied().sum::<f64>();
+
         let normalized_itinerary_ratios = itinerary_ratios.map(|ratio| ratio / sum_ratio);
+
         self.set_property::<Person, SettingIds>(person_id, SettingIds { setting_ids });
         self.set_property::<Person, ItineraryRatios>(
             person_id,
             ItineraryRatios {
+                // This field is a `[f64; 4]`
                 itinerary_ratios: normalized_itinerary_ratios,
             },
         );
-        Ok(())
-    }
-    fn add_index_setting(
-        &mut self,
-        setting_category: SettingCategory,
-        setting_code: SettingCode,
-    ) -> Result<SettingId, ModelError> {
-        if let Some(setting_id) = self
-            .query_result_iterator::<Setting, _>(((setting_category, setting_code),))
-            .next()
-        {
-            Ok(setting_id)
-        } else {
-            let setting_id = self
-                .add_entity::<Setting, _>((setting_category, setting_code))
-                .unwrap();
-            Ok(setting_id)
-        }
+        // Register setting membership for this person.
+        let membership = self.get_data_mut(SettingMembershipPlugin);
+        membership.add_members(&setting_ids, person_id);
     }
 }
 
 impl ContextSettingExt for Context {}
 
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
-    context.index_property::<Setting, SettingCode>();
-    context.index_property::<Setting, SettingCategory>();
-    context.index_property::<Setting, (SettingCategory, SettingCode)>();
     context.register_setting_global_properties();
     Ok(())
 }
@@ -378,6 +330,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::population_loader::{CommunityId, HomeId, SchoolId, WorkId};
     use crate::{
         Age, Params,
         parameters::{GlobalParams, SettingProperties},
@@ -413,7 +366,7 @@ mod test {
         )
     }
 
-    fn setup(alpha: f64) -> Context {
+    fn setup_test_context(alpha: f64) -> Context {
         let mut context = Context::new();
         let parameters = Params {
             // We need to specify an itinerary split here even though we don't draw people from
@@ -447,12 +400,12 @@ mod test {
     fn assign_person_settings(
         context: &mut Context,
         person_id: PersonId,
-        assignments: &[(SettingCategory, SettingId)],
+        assignments: &[SettingCode],
         itinerary_ratios: [f64; SETTING_COUNT],
     ) {
         let mut setting_ids = [None; SETTING_COUNT];
-        for (category, setting_id) in assignments {
-            setting_ids[*category] = Some(*setting_id);
+        for setting_code in assignments {
+            setting_ids[setting_code.category()] = Some(*setting_code);
         }
         context.set_property::<Person, SettingIds>(person_id, SettingIds { setting_ids });
         context.set_property::<Person, ItineraryRatios>(
@@ -463,108 +416,46 @@ mod test {
 
     #[test]
     fn test_get_setting_size_empty() {
-        let mut context = setup(0.0);
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000001"), SettingCategory::Home))
-            .unwrap();
+        let context = setup_test_context(0.0);
+        let home_id = SettingCode::arbitrary_home_code();
         // No persons assigned yet
-        let size = context.get_setting_size(home_id).unwrap();
+        let size = context.get_setting_size(home_id);
         assert_eq!(size, 0);
     }
 
     #[test]
     fn test_get_setting_size_multiple_categories() {
-        let mut context = setup(0.0);
-        let home_code = make_home_id(b"160379602000002");
-        let community_code = make_community_id(b"160379602000002");
-        let work_code = make_workplace_id(b"1603796020000220");
-        context
-            .add_entity::<Setting, _>((home_code, SettingCategory::Home))
-            .unwrap();
-        context
-            .add_entity::<Setting, _>((work_code, SettingCategory::Work))
-            .unwrap();
+        let mut context = setup_test_context(0.0);
+        let home_code = SettingCode::arbitrary_home_code();
+        let community_code = home_code.extract_community();
+        let work_code = SettingCode::arbitrary_workplace_code();
+
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
         let person3 = context.add_entity::<Person, _>((Age(22),)).unwrap();
-        context
-            .add_person_to_settings(person1, Some(home_code), None, None, Some(community_code))
-            .unwrap();
-        context
-            .add_person_to_settings(person2, Some(home_code), None, None, Some(community_code))
-            .unwrap();
-        context
-            .add_person_to_settings(person3, None, Some(work_code), None, None)
-            .unwrap();
+        context.add_person_to_settings(person1, Some(home_code), None, None, Some(community_code));
+        context.add_person_to_settings(person2, Some(home_code), None, None, Some(community_code));
+        context.add_person_to_settings(person3, None, Some(work_code), None, None);
+
         let home_id = context.get_property::<Person, HomeId>(person1).0.unwrap();
         let work_id = context.get_property::<Person, WorkId>(person3).0.unwrap();
-        context.initialize_setting_size().unwrap();
-        let home_size = context.get_setting_size(home_id).unwrap();
-        let work_size = context.get_setting_size(work_id).unwrap();
+        let home_size = context.get_setting_size(home_id);
+        let work_size = context.get_setting_size(work_id);
         assert_eq!(home_size, 2);
         assert_eq!(work_size, 1);
     }
 
     #[test]
-    fn test_get_setting_size_after_removal() {
-        let mut context = setup(0.0);
-        let original_home_code = make_home_id(b"160379602000003");
-        let original_community_code = make_community_id(b"160379602000003");
-        let new_home_code = make_home_id(b"160379602000004");
-        let _ = context.add_entity::<Setting, _>((original_home_code, SettingCategory::Home));
-        let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
-        let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
-        context
-            .add_person_to_settings(
-                person1,
-                Some(original_home_code),
-                None,
-                None,
-                Some(original_community_code),
-            )
-            .unwrap();
-        context
-            .add_person_to_settings(
-                person2,
-                Some(original_home_code),
-                None,
-                None,
-                Some(original_community_code),
-            )
-            .unwrap();
-        let home_id = context.get_property::<Person, HomeId>(person1).0.unwrap();
-        let community_id = context
-            .get_property::<Person, CommunityId>(person1)
-            .0
-            .unwrap();
-        context.initialize_setting_size().unwrap();
-        let home_size = context.get_setting_size(home_id).unwrap();
-        let community_size = context.get_setting_size(community_id).unwrap();
-        assert_eq!(home_size, 2);
-        assert_eq!(community_size, 2);
-        context
-            .add_person_to_settings(person1, Some(new_home_code), None, None, None)
-            .unwrap();
-        context.initialize_setting_size().unwrap();
-        let home_size_after = context.get_setting_size(home_id).unwrap();
-        let community_size_after = context.get_setting_size(community_id).unwrap();
-        assert_eq!(home_size_after, 1);
-        assert_eq!(community_size_after, 1);
-    }
-
-    #[test]
     fn test_sample_person_from_home() {
-        let mut context = setup(0.0);
+        let mut context = setup_test_context(0.0);
         let person_id = context.add_entity::<Person, _>((Age(20),)).unwrap();
-        context
-            .add_person_to_settings(
-                person_id,
-                Some(make_home_id(b"160379602000011")),
-                None,
-                None,
-                None,
-            )
-            .unwrap();
+        context.add_person_to_settings(
+            person_id,
+            Some(make_home_id(b"160379602000011")),
+            None,
+            None,
+            None,
+        );
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();
         let sampled = context.sample_person_from_setting(home_id).unwrap();
         assert_eq!(sampled, person_id);
@@ -572,17 +463,15 @@ mod test {
 
     #[test]
     fn test_sample_person_from_work() {
-        let mut context = setup(0.0);
+        let mut context = setup_test_context(0.0);
         let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
-        context
-            .add_person_to_settings(
-                person_id,
-                None,
-                Some(make_workplace_id(b"1603796020001332")),
-                None,
-                None,
-            )
-            .unwrap();
+        context.add_person_to_settings(
+            person_id,
+            None,
+            Some(make_workplace_id(b"1603796020001332")),
+            None,
+            None,
+        );
         let work_id = context.get_property::<Person, WorkId>(person_id).0.unwrap();
         let sampled = context.sample_person_from_setting(work_id).unwrap();
         assert_eq!(sampled, person_id);
@@ -590,17 +479,15 @@ mod test {
 
     #[test]
     fn test_sample_person_from_school() {
-        let mut context = setup(0.0);
+        let mut context = setup_test_context(0.0);
         let person_id = context.add_entity::<Person, _>((Age(10),)).unwrap();
-        context
-            .add_person_to_settings(
-                person_id,
-                None,
-                None,
-                Some(make_school_id(b"16037960200002")),
-                None,
-            )
-            .unwrap();
+        context.add_person_to_settings(
+            person_id,
+            None,
+            None,
+            Some(make_school_id(b"16037960200002")),
+            None,
+        );
         let school_id = context
             .get_property::<Person, SchoolId>(person_id)
             .0
@@ -611,17 +498,15 @@ mod test {
 
     #[test]
     fn test_sample_person_from_community() {
-        let mut context = setup(0.0);
+        let mut context = setup_test_context(0.0);
         let person_id = context.add_entity::<Person, _>((Age(40),)).unwrap();
-        context
-            .add_person_to_settings(
-                person_id,
-                None,
-                None,
-                None,
-                Some(make_community_id(b"160379602000011")),
-            )
-            .unwrap();
+        context.add_person_to_settings(
+            person_id,
+            None,
+            None,
+            None,
+            Some(make_community_id(b"160379602000011")),
+        );
         let community_id = context
             .get_property::<Person, CommunityId>(person_id)
             .0
@@ -632,50 +517,29 @@ mod test {
 
     #[test]
     fn test_get_setting_size() {
-        let mut context = setup(0.0);
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000005"), SettingCategory::Home))
-            .unwrap();
+        let mut context = setup_test_context(0.0);
+        let home_id = SettingCode::arbitrary_home_code();
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            person1,
-            &[(SettingCategory::Home, home_id)],
-            [1.0, 0.0, 0.0, 0.0],
-        );
-        assign_person_settings(
-            &mut context,
-            person2,
-            &[(SettingCategory::Home, home_id)],
-            [1.0, 0.0, 0.0, 0.0],
-        );
-        context.initialize_setting_size().unwrap();
-        let size = context.get_setting_size(home_id).unwrap();
+        assign_person_settings(&mut context, person1, &[home_id], [1.0, 0.0, 0.0, 0.0]);
+        assign_person_settings(&mut context, person2, &[home_id], [1.0, 0.0, 0.0, 0.0]);
+        let size = context.get_setting_size(home_id);
         assert_eq!(size, 2);
     }
 
     #[test]
     fn test_get_setting_ratio() {
-        let context = setup(0.0);
+        let context = setup_test_context(0.0);
         let ratio = context.get_setting_ratio(SettingCategory::School).unwrap();
         assert_eq!(ratio, 0.25);
     }
 
     #[test]
     fn test_get_active_settings_for_person() {
-        let mut context = setup(0.5);
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000006"), SettingCategory::Home))
-            .unwrap();
+        let mut context = setup_test_context(0.5);
+        let home_id = SettingCode::arbitrary_home_code();
         let person_id = context.add_entity::<Person, _>((Age(22),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            person_id,
-            &[(SettingCategory::Home, home_id)],
-            [0.25, 0.0, 0.0, 0.0],
-        );
-        context.initialize_setting_size().unwrap();
+        assign_person_settings(&mut context, person_id, &[home_id], [0.25, 0.0, 0.0, 0.0]);
         let active = context.get_active_settings_for_person(person_id).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].0, home_id);
@@ -686,44 +550,15 @@ mod test {
     #[test]
     fn test_calculate_current_infectiousness_multiplier_for_person() {
         let alpha = 0.5;
-        let mut context = setup(alpha);
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000007"), SettingCategory::Home))
-            .unwrap();
-        let work_id = context
-            .add_entity::<Setting, _>((
-                make_workplace_id(b"1603796020000042"),
-                SettingCategory::Work,
-            ))
-            .unwrap();
+        let mut context = setup_test_context(alpha);
+        let home_id = SettingCode::arbitrary_home_code();
+        let work_id = home_id.as_arbitrary_workplace_code();
         let p1 = context.add_entity::<Person, _>((Age(23),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(23),)).unwrap();
         let p3 = context.add_entity::<Person, _>((Age(23),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            p1,
-            &[
-                (SettingCategory::Home, home_id),
-                (SettingCategory::Work, work_id),
-            ],
-            [0.5, 0.5, 0.0, 0.0],
-        );
-        assign_person_settings(
-            &mut context,
-            p2,
-            &[
-                (SettingCategory::Home, home_id),
-                (SettingCategory::Work, work_id),
-            ],
-            [0.5, 0.5, 0.0, 0.0],
-        );
-        assign_person_settings(
-            &mut context,
-            p3,
-            &[(SettingCategory::Home, home_id)],
-            [1.0, 0.0, 0.0, 0.0],
-        );
-        context.initialize_setting_size().unwrap();
+        assign_person_settings(&mut context, p1, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
+        assign_person_settings(&mut context, p2, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
+        assign_person_settings(&mut context, p3, &[home_id], [1.0, 0.0, 0.0, 0.0]);
 
         let val = context.calculate_current_infectiousness_multiplier_for_person(p1);
         // home size = 3, alpha = 0.5, so multiplier = (3-1)^0.5 = 2^0.5 = 1.41 * 0.5 = 0.707
@@ -734,34 +569,13 @@ mod test {
     #[test]
     fn test_calculate_max_infectiousness_multiplier_for_person() {
         let alpha = 1.0;
-        let mut context = setup(alpha);
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000008"), SettingCategory::Home))
-            .unwrap();
-        let work_id = context
-            .add_entity::<Setting, _>((
-                make_workplace_id(b"1603796020000709"),
-                SettingCategory::Work,
-            ))
-            .unwrap();
+        let mut context = setup_test_context(alpha);
+        let home_id = SettingCode::arbitrary_home_code();
+        let work_id = home_id.as_arbitrary_workplace_code();
         let p1 = context.add_entity::<Person, _>((Age(24),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(24),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            p1,
-            &[
-                (SettingCategory::Home, home_id),
-                (SettingCategory::Work, work_id),
-            ],
-            [0.5, 0.5, 0.0, 0.0],
-        );
-        assign_person_settings(
-            &mut context,
-            p2,
-            &[(SettingCategory::Home, home_id)],
-            [1.0, 0.0, 0.0, 0.0],
-        );
-        context.initialize_setting_size().unwrap();
+        assign_person_settings(&mut context, p1, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
+        assign_person_settings(&mut context, p2, &[home_id], [1.0, 0.0, 0.0, 0.0]);
         let val = context.calculate_max_infectiousness_multiplier_for_person(p1);
         // size = 2, alpha = 1.0, so multiplier = (2-1)^1 = 1
         assert_eq!(val, 1.0);
@@ -769,48 +583,22 @@ mod test {
 
     #[test]
     fn test_sample_person_from_setting() {
-        let mut context = setup(0.0);
-        let comm_id = context
-            .add_entity::<Setting, _>((
-                make_community_id(b"160379602000008"),
-                SettingCategory::Community,
-            ))
-            .unwrap();
+        let mut context = setup_test_context(0.0);
+        let comm_id = SettingCode::arbitrary_home_code().extract_community();
         let person_id = context.add_entity::<Person, _>((Age(25),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            person_id,
-            &[(SettingCategory::Community, comm_id)],
-            [0.0, 0.0, 0.0, 1.0],
-        );
+        assign_person_settings(&mut context, person_id, &[comm_id], [0.0, 0.0, 0.0, 1.0]);
         let sampled = context.sample_person_from_setting(comm_id).unwrap();
         assert_eq!(sampled, person_id);
     }
 
     #[test]
     fn test_sample_from_setting_with_exclusion() {
-        let mut context = setup(0.0);
-        let work_id = context
-            .add_entity::<Setting, _>((
-                make_workplace_id(b"1603796020000121"),
-                SettingCategory::Work,
-            ))
-            .unwrap();
+        let mut context = setup_test_context(0.0);
+        let work_id = SettingCode::arbitrary_workplace_code();
         let p1 = context.add_entity::<Person, _>((Age(26),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(27),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            p1,
-            &[(SettingCategory::Work, work_id)],
-            [0.0, 1.0, 0.0, 0.0],
-        );
-        assign_person_settings(
-            &mut context,
-            p2,
-            &[(SettingCategory::Work, work_id)],
-            [0.0, 1.0, 0.0, 0.0],
-        );
-        context.initialize_setting_size().unwrap();
+        assign_person_settings(&mut context, p1, &[work_id], [0.0, 1.0, 0.0, 0.0]);
+        assign_person_settings(&mut context, p2, &[work_id], [0.0, 1.0, 0.0, 0.0]);
         let sampled = context
             .sample_from_setting_with_exclusion(p1, work_id)
             .unwrap();
@@ -819,30 +607,20 @@ mod test {
 
     #[test]
     fn test_sample_active_setting() {
-        let mut context = setup(0.0);
-        let home_id = context
-            .add_entity::<Setting, _>((make_home_id(b"160379602000009"), SettingCategory::Home))
-            .unwrap();
+        let mut context = setup_test_context(0.0);
+        let home_id = SettingCode::arbitrary_home_code();
         let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
-        assign_person_settings(
-            &mut context,
-            person_id,
-            &[(SettingCategory::Home, home_id)],
-            [1.0, 0.0, 0.0, 0.0],
-        );
-        context.initialize_setting_size().unwrap();
+        assign_person_settings(&mut context, person_id, &[home_id], [1.0, 0.0, 0.0, 0.0]);
         let sampled = context.sample_active_setting(person_id).unwrap();
         assert_eq!(sampled, home_id);
     }
 
     #[test]
     fn test_add_person_to_setting_and_add_index_setting() {
-        let mut context = setup(0.0);
+        let mut context = setup_test_context(0.0);
         let person_id = context.add_entity::<Person, _>((Age(31),)).unwrap();
         let setting_code = make_home_id(b"160379602000010");
-        context
-            .add_person_to_settings(person_id, Some(setting_code), None, None, None)
-            .unwrap();
+        context.add_person_to_settings(person_id, Some(setting_code), None, None, None);
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();
         let setting_ids = context
             .get_property::<Person, SettingIds>(person_id)


### PR DESCRIPTION
This PR is stacked on top of #84. The major contributions of the PR are:

- Replaces the `Setting` entity with a `SettingMembership` data plugin. 
  - The derived properties for `HomeId`, `SchoolId`, etc., still exist so you can get them with `context.get_property()`. But the data plugin is used for sampling from a setting and for getting the size of a setting. Thus, the derived properties are not indexed.
  - The `SettingMembership` initializes its index upon first access. No need to explicitly call `context.initialize_setting_size()`.
- Many operations no longer require a `SettingCategory` parameter, either because `SettingCode` knows its category, or because the settings are treated uniformly (don't require category-specific treatment).
- Adds convenience methods on `SettingCode` specificaly for constructing dummy values for unit tests (conditionally compiled with `#[cfg(test)]`) and fixes up the unit tests to uses these methods, fixing an annoyance introduced by #84


Minor housekeeping tasks:

- removed or modified obsolete unit tests
- removed `--no-stats` flag in the `run` command of `Makefile`

Local benchmark results:

```
======================================================================
  RobertJacobsonCDC_aspr_reader (2ef36cc) vs RobertJacobsonCDC_setting_code_value
======================================================================

  Benchmark                                      Base         Current  Change
  ---                                             ---             ---  ---
  init/population/10k                       10.704 ms       3.6282 ms  -66.1% faster ✓
  init/population/100k                      134.54 ms       51.878 ms  -61.4% faster ✓
  execute/population/10k                    90.659 ms       83.706 ms  -7.7% faster ✓
  execute/population/100k                    1.3253 s        1.2449 s  -6.1% faster ✓

======================================================================
```