### PR TITLE
feat: Optimizations for itinerary locality and `SmallVec` for active settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "smallvec",
  "strum",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "smallvec",
  "strum",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ memchr = "2.7.6"
 zip = { version = "8.5" }
 once_cell = { version = "1" }
 ouroboros = { version = "0.18.5" }
+smallvec = "1.15.1"
 strum = { version = "0.28.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -22,26 +22,16 @@ impl_property!(Age, Person);
 pub struct Alive(pub bool);
 impl_property!(Alive, Person, default_const = Alive(true));
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct SettingIds {
-    pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
-}
-impl_property!(
-    SettingIds,
-    Person,
-    default_const = SettingIds {
-        setting_ids: [None; SETTING_COUNT]
-    }
-);
-
 #[derive(Debug, PartialEq, Clone, Copy, Serialize)]
-pub struct ItineraryRatios {
+pub struct Itinerary {
+    pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
     pub itinerary_ratios: [f64; SETTING_COUNT],
 }
 impl_property!(
-    ItineraryRatios,
+    Itinerary,
     Person,
-    default_const = ItineraryRatios {
+    default_const = Itinerary {
+        setting_ids: [None; SETTING_COUNT],
         itinerary_ratios: [0.0; SETTING_COUNT]
     }
 );
@@ -55,20 +45,20 @@ pub struct WorkId(pub Option<SettingCode>);
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
 pub struct CommunityId(pub Option<SettingCode>);
 
-impl_derived_property!(HomeId, Person, [SettingIds], [], |setting_ids| HomeId(
-    setting_ids.setting_ids[SettingCategory::Home]
+impl_derived_property!(HomeId, Person, [Itinerary], [], |itinerary| HomeId(
+    itinerary.setting_ids[SettingCategory::Home]
 ));
 
-impl_derived_property!(SchoolId, Person, [SettingIds], [], |setting_ids| SchoolId(
-    setting_ids.setting_ids[SettingCategory::School]
+impl_derived_property!(SchoolId, Person, [Itinerary], [], |itinerary| SchoolId(
+    itinerary.setting_ids[SettingCategory::School]
 ));
 
-impl_derived_property!(WorkId, Person, [SettingIds], [], |setting_ids| WorkId(
-    setting_ids.setting_ids[SettingCategory::Work]
+impl_derived_property!(WorkId, Person, [Itinerary], [], |itinerary| WorkId(
+    itinerary.setting_ids[SettingCategory::Work]
 ));
 
-impl_derived_property!(CommunityId, Person, [SettingIds], [], |setting_ids| {
-    CommunityId(setting_ids.setting_ids[SettingCategory::Community])
+impl_derived_property!(CommunityId, Person, [Itinerary], [], |itinerary| {
+    CommunityId(itinerary.setting_ids[SettingCategory::Community])
 });
 
 fn create_person_from_record(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use ixa::HashMap;
 use ixa::prelude::*;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use std::{
     fmt::Debug,
     ops::{Index, IndexMut},
@@ -10,7 +11,7 @@ use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 pub(crate) use crate::{
     ContextParametersExt, Params,
     error::ModelError,
-    population_loader::{ItineraryRatios, Person, PersonId, SettingIds},
+    population_loader::{Itinerary, Person, PersonId},
     setting_code::SettingCode,
 };
 
@@ -74,8 +75,8 @@ define_data_plugin!(SettingMembershipPlugin, SettingMembership, |context| {
     let person_iter = context.get_entity_iterator::<Person>();
 
     for person_id in person_iter {
-        let settings: SettingIds = context.get_property(person_id);
-        membership.add_members(&settings.setting_ids, person_id);
+        let itinerary: Itinerary = context.get_property(person_id);
+        membership.add_members(&itinerary.setting_ids, person_id);
     }
 
     membership
@@ -173,17 +174,17 @@ pub trait ContextSettingExt:
         membership.member_count(setting)
     }
 
+    #[allow(clippy::type_complexity)]
     fn get_active_settings_for_person(
         &self,
         person_id: PersonId,
-    ) -> Result<Vec<(SettingCode, f64, f64)>, ModelError> {
-        let mut active_settings = Vec::new();
-        let setting_ids = self.get_property::<Person, SettingIds>(person_id);
-        let itinerary_ratios = self.get_property::<Person, ItineraryRatios>(person_id);
+    ) -> Result<SmallVec<[(SettingCode, f64, f64); SETTING_COUNT]>, ModelError> {
+        let mut active_settings = SmallVec::<[(SettingCode, f64, f64); SETTING_COUNT]>::new();
+        let itinerary = self.get_property::<Person, Itinerary>(person_id);
 
         for category in SettingCategory::iter() {
-            if let Some(id) = setting_ids.setting_ids[category] {
-                let ratio = itinerary_ratios.itinerary_ratios[category];
+            if let Some(id) = itinerary.setting_ids[category] {
+                let ratio = itinerary.itinerary_ratios[category];
                 let multiplier = self.calculate_multiplier(id)?;
                 active_settings.push((id, ratio, multiplier));
             }
@@ -306,11 +307,10 @@ pub trait ContextSettingExt:
 
         let normalized_itinerary_ratios = itinerary_ratios.map(|ratio| ratio / sum_ratio);
 
-        self.set_property::<Person, SettingIds>(person_id, SettingIds { setting_ids });
-        self.set_property::<Person, ItineraryRatios>(
+        self.set_property::<Person, Itinerary>(
             person_id,
-            ItineraryRatios {
-                // This field is a `[f64; 4]`
+            Itinerary {
+                setting_ids,
                 itinerary_ratios: normalized_itinerary_ratios,
             },
         );
@@ -407,10 +407,12 @@ mod test {
         for setting_code in assignments {
             setting_ids[setting_code.category()] = Some(*setting_code);
         }
-        context.set_property::<Person, SettingIds>(person_id, SettingIds { setting_ids });
-        context.set_property::<Person, ItineraryRatios>(
+        context.set_property::<Person, Itinerary>(
             person_id,
-            ItineraryRatios { itinerary_ratios },
+            Itinerary {
+                setting_ids,
+                itinerary_ratios,
+            },
         );
     }
 
@@ -622,12 +624,9 @@ mod test {
         let setting_code = make_home_id(b"160379602000010");
         context.add_person_to_settings(person_id, Some(setting_code), None, None, None);
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();
-        let setting_ids = context
-            .get_property::<Person, SettingIds>(person_id)
-            .setting_ids;
-        let itinerary_ratios = context
-            .get_property::<Person, ItineraryRatios>(person_id)
-            .itinerary_ratios;
+        let itinerary = context.get_property::<Person, Itinerary>(person_id);
+        let setting_ids = itinerary.setting_ids;
+        let itinerary_ratios = itinerary.itinerary_ratios;
         assert_eq!(setting_ids[SettingCategory::Home], Some(home_id));
         println!("itinerary_ratios: {:?}", itinerary_ratios);
         assert_eq!(itinerary_ratios[SettingCategory::Home], 1.0);


### PR DESCRIPTION
This PR is stacked on top of #89. It introduces two optimizations:

1. It stores a person's `SettingIds` and `ItineraryRatios` in a single property instead of in two separate properties. These are often fetched together. This improves data locality.
2. It uses `SmallVec` for `get_active_settings_for_person`, avoiding allocating a vector on the heap for this common operation.

# Local benchmark results

```
======================================================================
  RobertJacobsonCDC_setting_code_value (e364888) vs RobertJacobsonCDC_itinerary_locality
======================================================================

  Benchmark                                      Base         Current  Change
  ---                                             ---             ---  ---
  init/population/10k                       3.3204 ms       2.9560 ms  -11.0% faster ✓
  init/population/100k                      40.452 ms       37.420 ms  -7.5% faster ✓
  execute/population/10k                    71.617 ms       70.163 ms  -2.0% faster ✓
  execute/population/100k                    1.2048 s        1.1222 s  -6.9% faster ✓

======================================================================
```

Keep in mind this is comparing against `RobertJacobsonCDC_setting_code_value`, not the current `main` branch. Here's a comparison to the current `main`:

``` 
======================================================================
  main (9132b89) vs RobertJacobsonCDC_itinerary_locality
======================================================================

  Benchmark                                      Base         Current  Change
  ---                                             ---             ---  ---
  init/population/10k                       10.994 ms       2.8994 ms  -73.6% faster ✓
  init/population/100k                      113.70 ms       38.173 ms  -66.4% faster ✓
  execute/population/10k                    76.380 ms       70.111 ms  -8.2% faster ✓
  execute/population/100k                    1.1755 s        1.1251 s  -4.3% faster ✓

======================================================================
```

