### PR TITLE
feat: Implement `Eq` and `Hash` for `Property`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "smallvec",
  "strum",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,16 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +155,35 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"
@@ -777,10 +796,8 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "ixa"
 version = "2.0.0-beta2.1"
-source = "git+https://github.com/CDCgov/ixa?branch=main#5ee076a5f4a215b9521258814285344eae507548"
 dependencies = [
  "approx",
- "bincode",
  "bytesize",
  "clap",
  "csv",
@@ -796,7 +813,8 @@ dependencies = [
  "log4rs",
  "ouroboros",
  "paste",
- "rand",
+ "rand 0.9.4",
+ "rkyv",
  "rustc-hash",
  "seq-macro",
  "serde",
@@ -814,7 +832,6 @@ dependencies = [
 [[package]]
 name = "ixa-derive"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/CDCgov/ixa?branch=main#5ee076a5f4a215b9521258814285344eae507548"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -831,6 +848,7 @@ dependencies = [
  "ixa",
  "memchr",
  "once_cell",
+ "ordered-float",
  "ouroboros",
  "rand_distr",
  "serde",
@@ -957,6 +975,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1055,17 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+]
 
 [[package]]
 name = "ouroboros"
@@ -1155,6 +1204,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,13 +1245,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1192,7 +1280,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1211,7 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1262,6 +1359,45 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1400,6 +1536,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallbox"
@@ -1551,6 +1693,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,16 +1768,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-ixa = { git = "https://github.com/CDCgov/ixa", branch = "main", default-features = false, features = ["logging"] }
+ixa = { path = "../ixa", default-features = false, features = ["logging"] }
 rand_distr = "0.5.1"
 serde = "1.0.217"
 serde_json = "1.0.139"
@@ -22,6 +22,7 @@ once_cell = { version = "1" }
 ouroboros = { version = "0.18.5" }
 smallvec = "1.15.1"
 strum = { version = "0.28.0", features = ["derive"] }
+ordered-float = { version = "5.3.0", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ memchr = "2.7.6"
 zip = { version = "8.5" }
 once_cell = { version = "1" }
 ouroboros = { version = "0.18.5" }
+smallvec = "1.15.1"
 strum = { version = "0.28.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -71,7 +71,7 @@ mod test {
 
     use ixa::{HashMap, assert_almost_eq};
 
-    use crate::Age;
+    use crate::{Age, Float};
     use crate::infection_propagation_loop::InfectionRng;
     use crate::infectiousness_manager::InfectionData;
     use crate::pop_reader::{
@@ -364,19 +364,19 @@ mod test {
         context.infect_person(person, None, None);
         // For later, we need to get the recovery time from the rate function.
         context.execute();
-        let recovery_time = context.get_person_rate_fn(person).infection_duration();
+        let recovery_time: Float = context.get_person_rate_fn(person).infection_duration().into();
         schedule_recovery(&mut context, person);
         context.execute();
         // Make sure person is recovered.
         assert_eq!(
             context.get_property::<Person, InfectionData>(person),
             InfectionData::Recovered {
-                infection_time: 0.0,
+                infection_time: 0.0.into(),
                 recovery_time
             }
         );
         // Make sure nothing has happened after person is recovered.
-        assert_almost_eq!(context.get_current_time(), recovery_time, 0.0);
+        assert_almost_eq!(context.get_current_time(), *recovery_time, 0.0);
     }
 
     #[test]

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -6,23 +6,24 @@ use crate::{
     population_loader::PersonId,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, ScaledRateFn},
     settings::{ContextSettingExt, SettingCode},
+    Float
 };
 
 use crate::population_loader::Person;
 
 use ixa::profiling::{increment_named_count, open_span};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Clone, Copy)]
 pub enum InfectionData {
     Susceptible,
     Infectious {
-        infection_time: f64,
+        infection_time: Float,
         infected_by: Option<PersonId>,
         infection_setting_id: Option<SettingCode>,
     },
     Recovered {
-        infection_time: f64,
-        recovery_time: f64,
+        infection_time: Float,
+        recovery_time: Float,
     },
 }
 
@@ -178,7 +179,7 @@ pub trait InfectionContextExt: PluginContext + InfectiousnessRateExt {
         self.set_property::<Person, InfectionData>(
             target_id,
             InfectionData::Infectious {
-                infection_time,
+                infection_time: infection_time.into(),
                 infected_by: source_id,
                 infection_setting_id: setting_id,
             },
@@ -194,7 +195,7 @@ pub trait InfectionContextExt: PluginContext + InfectiousnessRateExt {
         self.set_property::<Person, InfectionData>(
             person_id,
             InfectionData::Recovered {
-                recovery_time,
+                recovery_time: recovery_time.into(),
                 infection_time,
             },
         );
@@ -205,7 +206,7 @@ pub trait InfectionContextExt: PluginContext + InfectiousnessRateExt {
         else {
             panic!("Person {person_id} is not infectious")
         };
-        self.get_current_time() - infection_time
+        self.get_current_time() - infection_time.0
     }
 }
 impl InfectionContextExt for Context {}
@@ -283,7 +284,7 @@ mod test {
         else {
             panic!("Person {p1} is not infectious")
         };
-        assert_almost_eq!(infection_time, 2.0, 0.0);
+        assert_almost_eq!(infection_time.0, 2.0, 0.0);
         context.get_person_rate_fn(p1);
     }
 
@@ -305,8 +306,8 @@ mod test {
         else {
             panic!("Person {p1} is not recovered")
         };
-        assert_almost_eq!(infection_time, 2.0, 0.0);
-        assert_almost_eq!(recovery_time, 3.0, 0.0);
+        assert_almost_eq!(infection_time.0, 2.0, 0.0);
+        assert_almost_eq!(recovery_time.0, 3.0, 0.0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,11 @@ mod setting_code;
 pub mod settings;
 pub mod symptom_status_manager;
 
+use ordered_float::OrderedFloat;
 pub use model::initialize_model;
 pub use parameters::ContextParametersExt;
 pub use parameters::Params;
 pub use population_loader::Age;
 pub use rate_fns::{ConstantRate, RateFn, load_rate_fns};
+
+pub type Float = OrderedFloat<f64>;

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,9 +1,10 @@
-use ixa::{impl_derived_property, prelude::*, profiling::open_span};
+use ixa::{prelude::*, profiling::open_span};
 
 use serde::Serialize;
 use std::path::PathBuf;
 
 use crate::error::ModelError;
+use crate::Float;
 use crate::parameters::ContextParametersExt;
 use crate::pop_reader::{
     PersonRecord,
@@ -22,44 +23,56 @@ impl_property!(Age, Person);
 pub struct Alive(pub bool);
 impl_property!(Alive, Person, default_const = Alive(true));
 
-#[derive(Debug, PartialEq, Clone, Copy, Serialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize)]
 pub struct Itinerary {
     pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
-    pub itinerary_ratios: [f64; SETTING_COUNT],
+    pub itinerary_ratios: [Float; SETTING_COUNT],
 }
 impl_property!(
     Itinerary,
     Person,
     default_const = Itinerary {
         setting_ids: [None; SETTING_COUNT],
-        itinerary_ratios: [0.0; SETTING_COUNT]
+        itinerary_ratios: [0.0.into(); SETTING_COUNT]
     }
 );
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct HomeId(pub Option<SettingCode>);
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct SchoolId(pub Option<SettingCode>);
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct WorkId(pub Option<SettingCode>);
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct CommunityId(pub Option<SettingCode>);
+// #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
+// pub struct HomeId(pub Option<SettingCode>);
+// #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
+// pub struct SchoolId(pub Option<SettingCode>);
+// #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
+// pub struct WorkId(pub Option<SettingCode>);
+// #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
+// pub struct CommunityId(pub Option<SettingCode>);
 
-impl_derived_property!(HomeId, Person, [Itinerary], [], |itinerary| HomeId(
-    itinerary.setting_ids[SettingCategory::Home]
-));
+define_derived_property!(
+    struct HomeId(pub Option<SettingCode>),
+    Person,
+    [Itinerary],
+    |itinerary| HomeId(itinerary.setting_ids[SettingCategory::Home])
+);
 
-impl_derived_property!(SchoolId, Person, [Itinerary], [], |itinerary| SchoolId(
-    itinerary.setting_ids[SettingCategory::School]
-));
+define_derived_property!(
+    struct SchoolId(pub Option<SettingCode>),
+    Person,
+    [Itinerary],
+    |itinerary| SchoolId(itinerary.setting_ids[SettingCategory::School])
+);
 
-impl_derived_property!(WorkId, Person, [Itinerary], [], |itinerary| WorkId(
-    itinerary.setting_ids[SettingCategory::Work]
-));
+define_derived_property!(
+    struct WorkId(pub Option<SettingCode>),
+    Person,
+    [Itinerary],
+    |itinerary| WorkId(itinerary.setting_ids[SettingCategory::Work])
+);
 
-impl_derived_property!(CommunityId, Person, [Itinerary], [], |itinerary| {
-    CommunityId(itinerary.setting_ids[SettingCategory::Community])
-});
+define_derived_property!(
+    struct CommunityId(pub Option<SettingCode>),
+    Person,
+    [Itinerary],
+    |itinerary| CommunityId(itinerary.setting_ids[SettingCategory::Community])
+);
 
 fn create_person_from_record(
     context: &mut Context,

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -22,26 +22,16 @@ impl_property!(Age, Person);
 pub struct Alive(pub bool);
 impl_property!(Alive, Person, default_const = Alive(true));
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct SettingIds {
-    pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
-}
-impl_property!(
-    SettingIds,
-    Person,
-    default_const = SettingIds {
-        setting_ids: [None; SETTING_COUNT]
-    }
-);
-
 #[derive(Debug, PartialEq, Clone, Copy, Serialize)]
-pub struct ItineraryRatios {
+pub struct Itinerary {
+    pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
     pub itinerary_ratios: [f64; SETTING_COUNT],
 }
 impl_property!(
-    ItineraryRatios,
+    Itinerary,
     Person,
-    default_const = ItineraryRatios {
+    default_const = Itinerary {
+        setting_ids: [None; SETTING_COUNT],
         itinerary_ratios: [0.0; SETTING_COUNT]
     }
 );
@@ -55,20 +45,20 @@ pub struct WorkId(pub Option<SettingCode>);
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
 pub struct CommunityId(pub Option<SettingCode>);
 
-impl_derived_property!(HomeId, Person, [SettingIds], [], |setting_ids| HomeId(
-    setting_ids.setting_ids[SettingCategory::Home]
+impl_derived_property!(HomeId, Person, [Itinerary], [], |itinerary| HomeId(
+    itinerary.setting_ids[SettingCategory::Home]
 ));
 
-impl_derived_property!(SchoolId, Person, [SettingIds], [], |setting_ids| SchoolId(
-    setting_ids.setting_ids[SettingCategory::School]
+impl_derived_property!(SchoolId, Person, [Itinerary], [], |itinerary| SchoolId(
+    itinerary.setting_ids[SettingCategory::School]
 ));
 
-impl_derived_property!(WorkId, Person, [SettingIds], [], |setting_ids| WorkId(
-    setting_ids.setting_ids[SettingCategory::Work]
+impl_derived_property!(WorkId, Person, [Itinerary], [], |itinerary| WorkId(
+    itinerary.setting_ids[SettingCategory::Work]
 ));
 
-impl_derived_property!(CommunityId, Person, [SettingIds], [], |setting_ids| {
-    CommunityId(setting_ids.setting_ids[SettingCategory::Community])
+impl_derived_property!(CommunityId, Person, [Itinerary], [], |itinerary| {
+    CommunityId(itinerary.setting_ids[SettingCategory::Community])
 });
 
 fn create_person_from_record(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,7 @@ pub(crate) use crate::{
     population_loader::{Itinerary, Person, PersonId},
     setting_code::SettingCode,
 };
+use crate::Float;
 
 define_rng!(SettingRng);
 
@@ -186,7 +187,7 @@ pub trait ContextSettingExt:
             if let Some(id) = itinerary.setting_ids[category] {
                 let ratio = itinerary.itinerary_ratios[category];
                 let multiplier = self.calculate_multiplier(id)?;
-                active_settings.push((id, ratio, multiplier));
+                active_settings.push((id, ratio.0, multiplier));
             }
         }
         Ok(active_settings)
@@ -305,7 +306,7 @@ pub trait ContextSettingExt:
 
         let sum_ratio = itinerary_ratios.iter().copied().sum::<f64>();
 
-        let normalized_itinerary_ratios = itinerary_ratios.map(|ratio| ratio / sum_ratio);
+        let normalized_itinerary_ratios = itinerary_ratios.map(|ratio| Float::from(ratio / sum_ratio));
 
         self.set_property::<Person, Itinerary>(
             person_id,
@@ -401,7 +402,7 @@ mod test {
         context: &mut Context,
         person_id: PersonId,
         assignments: &[SettingCode],
-        itinerary_ratios: [f64; SETTING_COUNT],
+        itinerary_ratios: [Float; SETTING_COUNT],
     ) {
         let mut setting_ids = [None; SETTING_COUNT];
         for setting_code in assignments {
@@ -523,8 +524,18 @@ mod test {
         let home_id = SettingCode::arbitrary_home_code();
         let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
         let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
-        assign_person_settings(&mut context, person1, &[home_id], [1.0, 0.0, 0.0, 0.0]);
-        assign_person_settings(&mut context, person2, &[home_id], [1.0, 0.0, 0.0, 0.0]);
+        assign_person_settings(
+            &mut context,
+            person1,
+            &[home_id],
+            [1.0, 0.0, 0.0, 0.0].map(Float::from)
+        );
+        assign_person_settings(
+            &mut context,
+            person2,
+            &[home_id],
+            [1.0, 0.0, 0.0, 0.0].map(Float::from)
+        );
         let size = context.get_setting_size(home_id);
         assert_eq!(size, 2);
     }
@@ -541,7 +552,12 @@ mod test {
         let mut context = setup_test_context(0.5);
         let home_id = SettingCode::arbitrary_home_code();
         let person_id = context.add_entity::<Person, _>((Age(22),)).unwrap();
-        assign_person_settings(&mut context, person_id, &[home_id], [0.25, 0.0, 0.0, 0.0]);
+        assign_person_settings(
+            &mut context,
+            person_id,
+            &[home_id],
+            [0.25, 0.0, 0.0, 0.0].map(Float::from)
+        );
         let active = context.get_active_settings_for_person(person_id).unwrap();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].0, home_id);
@@ -558,9 +574,24 @@ mod test {
         let p1 = context.add_entity::<Person, _>((Age(23),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(23),)).unwrap();
         let p3 = context.add_entity::<Person, _>((Age(23),)).unwrap();
-        assign_person_settings(&mut context, p1, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
-        assign_person_settings(&mut context, p2, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
-        assign_person_settings(&mut context, p3, &[home_id], [1.0, 0.0, 0.0, 0.0]);
+        assign_person_settings(
+            &mut context,
+            p1,
+            &[home_id, work_id],
+            [0.5, 0.5, 0.0, 0.0].map(Float::from)
+        );
+        assign_person_settings(
+            &mut context,
+            p2,
+            &[home_id, work_id],
+            [0.5, 0.5, 0.0, 0.0].map(Float::from)
+        );
+        assign_person_settings(
+            &mut context,
+            p3,
+            &[home_id],
+            [1.0, 0.0, 0.0, 0.0].map(Float::from)
+        );
 
         let val = context.calculate_current_infectiousness_multiplier_for_person(p1);
         // home size = 3, alpha = 0.5, so multiplier = (3-1)^0.5 = 2^0.5 = 1.41 * 0.5 = 0.707
@@ -576,8 +607,18 @@ mod test {
         let work_id = home_id.as_arbitrary_workplace_code();
         let p1 = context.add_entity::<Person, _>((Age(24),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(24),)).unwrap();
-        assign_person_settings(&mut context, p1, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
-        assign_person_settings(&mut context, p2, &[home_id], [1.0, 0.0, 0.0, 0.0]);
+        assign_person_settings(
+            &mut context,
+            p1,
+            &[home_id, work_id],
+            [0.5, 0.5, 0.0, 0.0].map(Float::from)
+        );
+        assign_person_settings(
+            &mut context,
+            p2,
+            &[home_id],
+            [1.0, 0.0, 0.0, 0.0].map(Float::from)
+        );
         let val = context.calculate_max_infectiousness_multiplier_for_person(p1);
         // size = 2, alpha = 1.0, so multiplier = (2-1)^1 = 1
         assert_eq!(val, 1.0);
@@ -588,7 +629,12 @@ mod test {
         let mut context = setup_test_context(0.0);
         let comm_id = SettingCode::arbitrary_home_code().extract_community();
         let person_id = context.add_entity::<Person, _>((Age(25),)).unwrap();
-        assign_person_settings(&mut context, person_id, &[comm_id], [0.0, 0.0, 0.0, 1.0]);
+        assign_person_settings(
+            &mut context,
+            person_id,
+            &[comm_id],
+            [0.0, 0.0, 0.0, 1.0].map(Float::from)
+        );
         let sampled = context.sample_person_from_setting(comm_id).unwrap();
         assert_eq!(sampled, person_id);
     }
@@ -599,8 +645,18 @@ mod test {
         let work_id = SettingCode::arbitrary_workplace_code();
         let p1 = context.add_entity::<Person, _>((Age(26),)).unwrap();
         let p2 = context.add_entity::<Person, _>((Age(27),)).unwrap();
-        assign_person_settings(&mut context, p1, &[work_id], [0.0, 1.0, 0.0, 0.0]);
-        assign_person_settings(&mut context, p2, &[work_id], [0.0, 1.0, 0.0, 0.0]);
+        assign_person_settings(
+            &mut context,
+            p1,
+            &[work_id],
+            [0.0, 1.0, 0.0, 0.0].map(Float::from)
+        );
+        assign_person_settings(
+            &mut context,
+            p2,
+            &[work_id],
+            [0.0, 1.0, 0.0, 0.0].map(Float::from)
+        );
         let sampled = context
             .sample_from_setting_with_exclusion(p1, work_id)
             .unwrap();
@@ -612,7 +668,12 @@ mod test {
         let mut context = setup_test_context(0.0);
         let home_id = SettingCode::arbitrary_home_code();
         let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
-        assign_person_settings(&mut context, person_id, &[home_id], [1.0, 0.0, 0.0, 0.0]);
+        assign_person_settings(
+            &mut context,
+            person_id,
+            &[home_id],
+            [1.0, 0.0, 0.0, 0.0].map(Float::from)
+        );
         let sampled = context.sample_active_setting(person_id).unwrap();
         assert_eq!(sampled, home_id);
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use ixa::HashMap;
 use ixa::prelude::*;
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use std::{
     fmt::Debug,
     ops::{Index, IndexMut},
@@ -10,7 +11,7 @@ use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 pub(crate) use crate::{
     ContextParametersExt, Params,
     error::ModelError,
-    population_loader::{ItineraryRatios, Person, PersonId, SettingIds},
+    population_loader::{Itinerary, Person, PersonId},
     setting_code::SettingCode,
 };
 
@@ -74,8 +75,8 @@ define_data_plugin!(SettingMembershipPlugin, SettingMembership, |context| {
     let person_iter = context.get_entity_iterator::<Person>();
 
     for person_id in person_iter {
-        let settings: SettingIds = context.get_property(person_id);
-        membership.add_members(&settings.setting_ids, person_id);
+        let itinerary: Itinerary = context.get_property(person_id);
+        membership.add_members(&itinerary.setting_ids, person_id);
     }
 
     membership
@@ -173,17 +174,17 @@ pub trait ContextSettingExt:
         membership.member_count(setting)
     }
 
+    #[allow(clippy::type_complexity)]
     fn get_active_settings_for_person(
         &self,
         person_id: PersonId,
-    ) -> Result<Vec<(SettingCode, f64, f64)>, ModelError> {
-        let mut active_settings = Vec::new();
-        let setting_ids = self.get_property::<Person, SettingIds>(person_id);
-        let itinerary_ratios = self.get_property::<Person, ItineraryRatios>(person_id);
+    ) -> Result<SmallVec<[(SettingCode, f64, f64); SETTING_COUNT]>, ModelError> {
+        let mut active_settings = SmallVec::<[(SettingCode, f64, f64); SETTING_COUNT]>::new();
+        let itinerary = self.get_property::<Person, Itinerary>(person_id);
 
         for category in SettingCategory::iter() {
-            if let Some(id) = setting_ids.setting_ids[category] {
-                let ratio = itinerary_ratios.itinerary_ratios[category];
+            if let Some(id) = itinerary.setting_ids[category] {
+                let ratio = itinerary.itinerary_ratios[category];
                 let multiplier = self.calculate_multiplier(id)?;
                 active_settings.push((id, ratio, multiplier));
             }
@@ -306,11 +307,10 @@ pub trait ContextSettingExt:
 
         let normalized_itinerary_ratios = itinerary_ratios.map(|ratio| ratio / sum_ratio);
 
-        self.set_property::<Person, SettingIds>(person_id, SettingIds { setting_ids });
-        self.set_property::<Person, ItineraryRatios>(
+        self.set_property::<Person, Itinerary>(
             person_id,
-            ItineraryRatios {
-                // This field is a `[f64; 4]`
+            Itinerary {
+                setting_ids,
                 itinerary_ratios: normalized_itinerary_ratios,
             },
         );
@@ -407,10 +407,12 @@ mod test {
         for setting_code in assignments {
             setting_ids[setting_code.category()] = Some(*setting_code);
         }
-        context.set_property::<Person, SettingIds>(person_id, SettingIds { setting_ids });
-        context.set_property::<Person, ItineraryRatios>(
+        context.set_property::<Person, Itinerary>(
             person_id,
-            ItineraryRatios { itinerary_ratios },
+            Itinerary {
+                setting_ids,
+                itinerary_ratios,
+            },
         );
     }
 
@@ -622,12 +624,9 @@ mod test {
         let setting_code = make_home_id(b"160379602000010");
         context.add_person_to_settings(person_id, Some(setting_code), None, None, None);
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();
-        let setting_ids = context
-            .get_property::<Person, SettingIds>(person_id)
-            .setting_ids;
-        let itinerary_ratios = context
-            .get_property::<Person, ItineraryRatios>(person_id)
-            .itinerary_ratios;
+        let itinerary = context.get_property::<Person, Itinerary>(person_id);
+        let setting_ids = itinerary.setting_ids;
+        let itinerary_ratios = itinerary.itinerary_ratios;
         assert_eq!(setting_ids[SettingCategory::Home], Some(home_id));
         println!("itinerary_ratios: {:?}", itinerary_ratios);
         assert_eq!(itinerary_ratios[SettingCategory::Home], 1.0);

--- a/src/symptom_status_manager.rs
+++ b/src/symptom_status_manager.rs
@@ -6,39 +6,37 @@ use rand_distr::LogNormal;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ordering, PartialOrd};
 
-use crate::{
-    Age, ContextParametersExt, Params, error::ModelError, infectiousness_manager::InfectionStatus,
-    parameters::OrderedAgeGroupsParam, population_loader::Person,
-};
+
+use crate::{Age, ContextParametersExt, Params, error::ModelError, infectiousness_manager::InfectionStatus, parameters::OrderedAgeGroupsParam, population_loader::Person, Float};
 
 define_rng!(SymptomsRng);
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug, Copy, Clone)]
 pub enum SymptomData {
     NoSymptoms,
     Mild {
-        mild_time: f64,
+        mild_time: Float,
     },
     Severe {
-        mild_time: f64,
-        severe_time: f64,
+        mild_time: Float,
+        severe_time: Float,
     },
     Critical {
-        mild_time: f64,
-        severe_time: f64,
-        critical_time: f64,
+        mild_time: Float,
+        severe_time: Float,
+        critical_time: Float,
     },
     Resolved {
-        mild_time: f64,
-        severe_time: Option<f64>,
-        critical_time: Option<f64>,
-        resolved_time: f64,
+        mild_time: Float,
+        severe_time: Option<Float>,
+        critical_time: Option<Float>,
+        resolved_time: Float,
     },
     Dead {
-        mild_time: f64,
-        severe_time: f64,
-        critical_time: f64,
-        dead_time: f64,
+        mild_time: Float,
+        severe_time: Float,
+        critical_time: Float,
+        dead_time: Float,
     },
 }
 
@@ -88,7 +86,7 @@ impl PartialOrd for SymptomAgeGroup {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq, Copy, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq, Hash, Copy, Clone)]
 pub struct AgeGroupIndex(pub usize);
 
 impl_derived_property!(
@@ -180,7 +178,7 @@ fn process_symptom_change_event(
                         event.entity_id,
                         SymptomData::Severe {
                             mild_time,
-                            severe_time: transition_time,
+                            severe_time: transition_time.into(),
                         },
                     );
                 });
@@ -198,7 +196,7 @@ fn process_symptom_change_event(
                             mild_time,
                             severe_time: None,
                             critical_time: None,
-                            resolved_time: transition_time,
+                            resolved_time: transition_time.into(),
                         },
                     );
                 });
@@ -225,7 +223,7 @@ fn process_symptom_change_event(
                         SymptomData::Critical {
                             mild_time,
                             severe_time,
-                            critical_time: transition_time,
+                            critical_time: transition_time.into(),
                         },
                     );
                 });
@@ -245,7 +243,7 @@ fn process_symptom_change_event(
                             mild_time,
                             severe_time: Some(severe_time),
                             critical_time: None,
-                            resolved_time: transition_time,
+                            resolved_time: transition_time.into(),
                         },
                     );
                 });
@@ -274,7 +272,7 @@ fn process_symptom_change_event(
                             mild_time,
                             severe_time,
                             critical_time,
-                            dead_time: transition_time,
+                            dead_time: transition_time.into(),
                         },
                     );
                 });
@@ -295,7 +293,7 @@ fn process_symptom_change_event(
                             mild_time,
                             severe_time: Some(severe_time),
                             critical_time: Some(critical_time),
-                            resolved_time: transition_time,
+                            resolved_time: transition_time.into(),
                         },
                     );
                 });
@@ -322,7 +320,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
                     context.set_property::<Person, SymptomData>(
                         event.entity_id,
                         SymptomData::Mild {
-                            mild_time: transition_time,
+                            mild_time: transition_time.into(),
                         },
                     );
                 });
@@ -572,7 +570,7 @@ mod test {
             context.set_property::<Person, SymptomData>(
                 person,
                 SymptomData::Mild {
-                    mild_time: context.get_current_time(),
+                    mild_time: context.get_current_time().into(),
                 },
             );
         }
@@ -582,46 +580,46 @@ mod test {
             // mild -> resolved
             context.get_property::<Person, SymptomData>(p1),
             SymptomData::Resolved {
-                mild_time: 0.0,
+                mild_time: 0.0.into(),
                 severe_time: None,
                 critical_time: None,
-                resolved_time: 0.0 + mild_to_resolved_duration,
+                resolved_time: (0.0 + mild_to_resolved_duration).into(),
             }
         );
         assert_eq!(
             // mild -> severe -> resolved
             context.get_property::<Person, SymptomData>(p2),
             SymptomData::Resolved {
-                mild_time: 0.0,
-                severe_time: Some(0.0 + mild_to_severe_duration),
+                mild_time: 0.0.into(),
+                severe_time: Some((0.0 + mild_to_severe_duration).into()),
                 critical_time: None,
-                resolved_time: 0.0 + mild_to_severe_duration + severe_to_resolved_duration,
+                resolved_time: (0.0 + mild_to_severe_duration + severe_to_resolved_duration).into(),
             }
         );
         assert_eq!(
             // mild -> severe -> critical -> resolved
             context.get_property::<Person, SymptomData>(p3),
             SymptomData::Resolved {
-                mild_time: 0.0,
-                severe_time: Some(0.0 + mild_to_severe_duration),
-                critical_time: Some(0.0 + mild_to_severe_duration + severe_to_critical_duration),
-                resolved_time: 0.0
+                mild_time: 0.0.into(),
+                severe_time: Some((0.0 + mild_to_severe_duration).into()),
+                critical_time: Some((0.0 + mild_to_severe_duration + severe_to_critical_duration).into()),
+                resolved_time: (0.0
                     + mild_to_severe_duration
                     + severe_to_critical_duration
-                    + critical_to_resolved_duration,
+                    + critical_to_resolved_duration).into(),
             }
         );
         assert_eq!(
             // mild -> severe -> critical -> dead
             context.get_property::<Person, SymptomData>(p4),
             SymptomData::Dead {
-                mild_time: 0.0,
-                severe_time: 0.0 + mild_to_severe_duration,
-                critical_time: 0.0 + mild_to_severe_duration + severe_to_critical_duration,
-                dead_time: 0.0
+                mild_time: 0.0.into(),
+                severe_time: (0.0 + mild_to_severe_duration).into(),
+                critical_time: (0.0 + mild_to_severe_duration + severe_to_critical_duration).into(),
+                dead_time: (0.0
                     + mild_to_severe_duration
                     + severe_to_critical_duration
-                    + critical_to_dead_duration,
+                    + critical_to_dead_duration).into(),
             }
         );
     }
@@ -677,7 +675,7 @@ mod test {
             // no symptoms -> mild -> resolved
             context.get_property::<Person, SymptomData>(p1),
             SymptomData::Mild {
-                mild_time: infect_to_mild_duration
+                mild_time: infect_to_mild_duration.into(),
             }
         );
     }


### PR DESCRIPTION
This is an experimental branch that is compatible with [this ixa branch](https://github.com/CDCgov/ixa/pull/848). It changes all instances of `f64` to use `OrderedFloat<f64>`.

This PR only exists for visibility. We won't merge this.

---

It turns out that using `OrderedFloat<f64>` is really obnoxious. Even though `OrderedFloat<f64>` implements all the usual operations, you still can't mix `f64` and `OrderedFloat<f64>` for comparisons, for example. `OrderedFloat<f64>` implements `Deref<f64>` / `DerefMut<f64>`, but that's not a silver bullet. You end up either calling into to upcast your `f64` values to `OrderedFloat<f64>`, or you downcast your `OrderedFloat<f64>` values to `f64`. And both ways of downcasting are obnoxious in mathematical code! You have your choice of a deref operator, an `*`, which looks like multiplication, or using the tuple field accessor syntax, `ordered_float.0`, which just as gross when you use it in a mathematical formula. You could try to only ever use `OrderedFloat<f64>`, avoiding naked `f64` entirely. But you don't always have that option. Both the standard library and ixa uses `f64` for various things like time for example. The `ordered-float` crate does have a feature flag for `rand` support, though.

## Local Benchmark Results

**main (33ab8db) vs RobertJacobsonCDC_eq_hash**

| Benchmark               | Base      | Current   | Change         |
| ----------------------- | --------- | --------- | -------------- |
| init/population/10k     | 3.4157 ms | 3.1341 ms | -8.2% faster ✓ |
| init/population/100k    | 44.433 ms | 41.496 ms | -6.6% faster ✓ |
| execute/population/10k  | 81.324 ms | 78.589 ms | -3.4% faster ✓ |
| execute/population/100k | 1.2189 s  | 1.1451 s  | -6.1% faster ✓ |

