### PR TITLE
fix: Use an ixa release instead of git's main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,8 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "ixa"
 version = "2.0.0-beta2.1"
-source = "git+https://github.com/CDCgov/ixa?branch=main#5ee076a5f4a215b9521258814285344eae507548"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7514f8a567d03a2cc8bb684fa96c072b415d657f5eb8108da33ae57cfb8d656"
 dependencies = [
  "approx",
  "bincode",
@@ -814,7 +815,8 @@ dependencies = [
 [[package]]
 name = "ixa-derive"
 version = "2.0.0-beta.1"
-source = "git+https://github.com/CDCgov/ixa?branch=main#5ee076a5f4a215b9521258814285344eae507548"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2377d465cd9978c98d2b6e51722ed70d2da5aef31d0e97a83bbaf638ad75497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-ixa = { git = "https://github.com/CDCgov/ixa", branch = "main", default-features = false, features = ["logging"] }
+ixa = { version = "2.0.0-beta2.1", default-features = false, features = ["logging"] }
 rand_distr = "0.5.1"
 serde = "1.0.217"
 serde_json = "1.0.139"


### PR DESCRIPTION
I accidentally merged a change to the `Cargo.toml` of `ixa-epi-covid` so it uses the `main` branch of `ixa` from git instead of `version = "2.0.0-beta2.1"`.  It doesn't seem to matter at the moment, but it makes more sense for us to use a (pre)release version. Oops!

Just an FYI in case someone notices and is confused: the `default-features = false, features = ["logging"]` is just temporary—we are removing the debugger and progress bar, which we previously had as default features, and since we don't use them anyway, I just turn them off with these flags. Once we land the PRs in an `ixa` release that removes them, I'll revert this back so `ixa-epi-covid` uses `ixa`'s default features. 