### PR TITLE
chore: Bump ixa to beta2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,9 +776,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixa"
-version = "2.0.0-beta2.1"
+version = "2.0.0-beta2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7514f8a567d03a2cc8bb684fa96c072b415d657f5eb8108da33ae57cfb8d656"
+checksum = "233991a063d0373a2d5dbe3ee7ae6c3f725542c3317d053bdce5a7ead712e3fd"
 dependencies = [
  "approx",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-ixa = { version = "2.0.0-beta2.1", default-features = false, features = ["logging"] }
+ixa = { version = "2.0.0-beta2.2", default-features = false, features = ["logging"] }
 rand_distr = "0.5.1"
 serde = "1.0.217"
 serde_json = "1.0.139"


### PR DESCRIPTION
Bump the `ixa` dependency version to `2.0.0-beta2.2`.

This version improves model performance up to 7% (20% for just population init) on my local benchmarks depending on population size.