### PR TITLE
Connecting itinerary manager to settings

### DIFF
--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -1,0 +1,211 @@
+use ixa::{
+    prelude::*,
+};
+use serde::Serialize;
+use std::{any::{TypeId}, collections::HashMap};
+
+use crate::{Age, settings::ItineraryRatios};
+use crate::population_loader::{Person, PersonId};
+
+define_rng!(DummyRng);
+
+#[derive(Debug, PartialEq, Clone, Serialize, Copy)]
+pub struct ItineraryModifier{
+    ranking: usize,
+    itinerary_ratios: ItineraryRatios
+}
+
+// pub trait ItineraryModifiers: std::fmt::Debug + Any {
+//     /// Return the itinerary of a person based on their properties and the current context.
+//     #[allow(dead_code)]
+//     fn get_itinerary(
+//         &self,
+//         context: &Context,
+//         person_id: PersonId,
+//     ) -> Option<ItineraryModifier>;
+
+//     /// For debugging purposes. The name of the itinerary modifier. The default implementation
+//     /// returns the `Debug` representation of the itinerary modifier struct on which this trait
+//     /// is implemented.
+//     fn get_name(&self) -> String {
+//         format!("{self:?}")
+//     }
+// }
+
+// A newtype wrapper for the itinerary modifiers specified via a hashmap of person
+// property values and itinerary -- i.e., `modifier_key: &[(P::Value, Vec<ItineraryEntry>)]`
+#[allow(dead_code)]
+#[derive(Debug)]
+struct PersonPropertyModifier<'a, P>
+where
+    P: Property<Person> + std::fmt::Debug,
+    P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug,
+{
+    property: P,
+    modifiers: HashMap<<P as Property<Person>>::CanonicalValue, ItineraryModifier>,
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+#[allow(dead_code)]
+impl<'a, P> PersonPropertyModifier<'a, P>
+where
+    P: Property<Person> + std::fmt::Debug,
+    P::CanonicalValue: std::hash::Hash + Eq,
+{
+    fn get(&self, key: &P::CanonicalValue) -> Option<&ItineraryModifier> {
+        self.modifiers.get(key)
+    }
+}
+
+// #[allow(dead_code)]
+// impl<P> ItineraryModifiers for PersonPropertyModifier<'_, P>
+// where
+//     P: Property<Person, CanonicalValue = P> + std::fmt::Debug + 'static,
+//     P::CanonicalValue: std::hash::Hash + Eq,
+// {
+//     fn get_itinerary(
+//         &self,
+//         context: &Context,
+//         person_id: PersonId,
+//     ) -> Option<ItineraryModifier> {
+//         let (_person_property, modifier_map) = self;
+//         let property_val = context.get_property::<Person, P>(person_id);
+//         match modifier_map.get(&property_val) {
+//             Some(value) => Some(*value),
+//             None => None,
+//         }
+//     }
+    
+//     fn get_name(&self) -> String {
+//         format!("{:?}", self.0)
+//     }
+// }
+
+#[derive(Default)]
+struct ItineraryModifierContainer {
+    itinerary_modifier_map: HashMap<TypeId, Box<dyn std::any::Any>>,
+}
+
+define_data_plugin!(
+    ItineraryModifierPlugin,
+    ItineraryModifierContainer,
+    ItineraryModifierContainer::default()
+);
+
+pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
+    /// Register a generic itinerary modifier.
+    fn register_itinerary_modifier<P: Property<Person> + std::fmt::Debug + 'static>(
+        &mut self,
+        person_property: P,
+        person_property_value: P::CanonicalValue,
+        itinerary_modifier: ItineraryModifier,
+    )
+    where
+        P::CanonicalValue: std::hash::Hash + Eq,
+    {
+        // Box the itinerary modifier to store it in the map
+        // Itinerary modifiers must implement debug so that we can more easily log their addition
+        let person_property_modifier = PersonPropertyModifier {
+            property: person_property,
+            modifiers: HashMap::from([(person_property_value, itinerary_modifier)]),
+            _phantom: std::marker::PhantomData,
+        };
+        // Insert the boxed function into the itinerary modifier map, using entry to handle unititialized keys
+        if let Some(_modifier_fxn) = self
+            .get_data_mut(ItineraryModifierPlugin)
+            .itinerary_modifier_map
+            .insert(TypeId::of::<P>(), Box::new(person_property_modifier))
+        {
+            trace!("Overwriting existing itinerary modifier function for and itinerary modifier");
+        }
+    }
+
+    fn remove_itinerary_modifier_fn<P: Property<Person> + 'static>(&mut self) {
+        self.get_data_mut(ItineraryModifierPlugin)
+            .itinerary_modifier_map
+            .remove(&TypeId::of::<P>());
+    }
+
+    // fn store_itinerary_modifier_values<
+    //     P: Property<Person, CanonicalValue = P> + std::fmt::Debug + 'static,
+    // >(
+    //     &mut self,
+    //     person_property: P,
+    //     person_property_value: P::CanonicalValue,
+    //     itinerary_modifier: ItineraryModifier,
+    // ) -> Result<(), ModelError>
+    // where
+    //     P::CanonicalValue: std::hash::Hash + Eq,
+    // {
+    //     // Convert modifiers to HashMap
+    //     let mut modifier_map = HashMap::new();
+    //     if let Some(old_value) = modifier_map.insert(person_property_value, itinerary_modifier) {
+    //         return Err(ModelError::ModelError(
+    //             "Duplicate values provided in modifier key ".to_string()
+    //                 + &format!("Values {old_value:?} and {itinerary_modifier:?} were both attempted to be registered to key {person_property:?}::{person_property_value:?}"),
+    //         ));
+    //     }
+    //     self.register_itinerary_modifier_fn((person_property, modifier_map.clone()));
+    //     Ok(())
+    // }
+
+    fn get_itinerary<P: Property<Person> + std::fmt::Debug + 'static>(&self, person_id: PersonId, person_property: P) 
+    where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
+        let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
+        println!("itinerary modifier map: {:?}", itinerary_modifier_container.itinerary_modifier_map);
+        let modifier_key = TypeId::of::<P>();
+        let modifier = itinerary_modifier_container.itinerary_modifier_map.get(&modifier_key).unwrap();
+        println!("Getting itinerary modifier for person {person_id} and property {person_property:?}");
+        println!("Modifier: {:?}", modifier);
+        let temp = modifier.downcast_ref::<PersonPropertyModifier<'_, P>>().unwrap();
+        let property = temp.property;
+        let property_val = temp.modifiers.keys().next().unwrap();
+        println!("Property: {:?}", property);
+        println!("Property value: {:?}", property_val);
+        let age = self.get_property::<Person, P>(person_id);
+        println!("Person property value: {:?}", age);
+        println!("property == age {}", property == age);
+        // match modifier.get(&property_val) {
+        //     Some(value) => Some(*value),
+        //     None => None,
+        // }
+    }
+
+    // fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
+    //     println!("Getting dominant itinerary modifier for person {person_id}");
+    //     let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
+    //     let mut dominant_itinerary_modifier: Option<ItineraryModifier> = None;
+    //     for itinerary_modifier in itinerary_modifier_container.itinerary_modifier_map.values() {
+    //         println!("Checking itinerary modifier: {:?}", itinerary_modifier);
+    //         if let Some(modifier) = itinerary_modifier.get_itinerary(self, person_id) {
+    //             if let Some(current_dominant) = dominant_itinerary_modifier {
+    //                 if modifier.ranking > current_dominant.ranking {
+    //                     dominant_itinerary_modifier = Some(modifier);
+    //                 }
+    //             } else {
+    //                 dominant_itinerary_modifier = Some(modifier);
+    //             }
+    //         }
+    //     }
+    //     dominant_itinerary_modifier
+    // }
+
+}
+impl ContextItineraryModifierExt for Context {}
+
+pub fn init(context: &mut Context) {
+    let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            }
+        };
+    context
+        .register_itinerary_modifier(
+            Age(0),
+            Age(10),
+            school_closure_modifier,
+        );
+    let p1 = context.sample_entity(DummyRng, (Age(11),)).unwrap();
+    println!("dominant modifier {:?}", context.get_itinerary(p1, Age(11)));
+    context.shutdown();
+}

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -4,15 +4,21 @@ use ixa::{
 use serde::Serialize;
 use std::{any::{Any, TypeId}, collections::HashMap};
 
-use crate::{Age, settings::ItineraryRatios};
+use crate::{settings::ItineraryRatios};
 use crate::population_loader::{Person, PersonId};
 
-define_rng!(DummyRng);
+#[derive(Debug, PartialEq, Clone, Serialize, Copy, Eq, Hash)]
+pub enum ItineraryModifierType{
+    SchoolClosure,
+    WorkClosure,
+    Weekend,
+}
 
 #[derive(Debug, PartialEq, Clone, Serialize, Copy)]
 pub struct ItineraryModifier{
     ranking: usize,
-    itinerary_ratios: ItineraryRatios
+    itinerary_ratios: ItineraryRatios,
+    modifier_type: ItineraryModifierType,
 }
 
 impl Ord for ItineraryModifier {
@@ -30,18 +36,18 @@ impl PartialOrd for ItineraryModifier {
 impl Eq for ItineraryModifier {}
 
 pub trait ItineraryModifierTrait: std::fmt::Debug  + Any{
-    fn get_itinerary(
+    fn get_itineraries(
         &self,
         context: &Context,
         person_id: PersonId,
-    ) -> Option<ItineraryModifier>;
+    ) -> Option<Vec<ItineraryModifier>>;
     fn as_any(&self) -> &dyn Any;
 }
 
 type PersonPropertyItineraryModifier<'a, P> = (
     P,
     // Use fully qualified syntax for the associated type because type aliases do not have type checking
-    HashMap<<P as Property<Person>>::CanonicalValue, ItineraryModifier>,
+    HashMap<<P as Property<Person>>::CanonicalValue, Vec<ItineraryModifier>>,
 );
 
 impl<P> ItineraryModifierTrait for PersonPropertyItineraryModifier<'static, P> 
@@ -49,15 +55,15 @@ where
     P: Property<Person> + std::fmt::Debug, 
     P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug {
     
-    fn get_itinerary(
+    fn get_itineraries(
         &self,
         context: &Context,
         person_id: PersonId,
-    ) -> Option<ItineraryModifier> {
+    ) -> Option<Vec<ItineraryModifier>> {
         let (_person_property, modifier_map) = self;
         let property_val = context.get_property::<Person, P>(person_id);
         match modifier_map.get(&property_val.make_canonical()) {
-            Some(value) => Some(*value),
+            Some(value) => Some(value.clone()),
             None => None,
         }
     }
@@ -89,19 +95,15 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
     where
         P::CanonicalValue: std::hash::Hash + Eq,
     {
-    
         if let Some(modifier_map) = self.get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
             .get(&TypeId::of::<P>()){
 
-            if let Some(modifier_map) = modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
-                let mut new_modifier_map = modifier_map.1.clone();
-                println!("Adding modifier for property value {:?} with modifier {:?} to existing modifier map for property {:?}", person_property.make_canonical(), itinerary_modifier, person_property);
-                println!("Modifier map before addition: {:?}", new_modifier_map);
-                new_modifier_map.insert(person_property.make_canonical(), itinerary_modifier);
-                println!("Modifier map after addition: {:?}", new_modifier_map);
+            if let Some(downcast_modifier_map) = modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
+                let mut new_modifier_map = downcast_modifier_map.1.clone();
+                new_modifier_map.entry(person_property.make_canonical()).or_insert_with(Vec::new).push(itinerary_modifier);
                 let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
-                    modifier_map.0,
+                    downcast_modifier_map.0,
                     new_modifier_map,
                 );
                 self.get_data_mut(ItineraryModifierPlugin)
@@ -111,7 +113,7 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
         } else {
             let person_property_modifier: PersonPropertyItineraryModifier<P> = (
                 person_property,
-                HashMap::from_iter([(person_property.make_canonical(), itinerary_modifier)]),
+                HashMap::from_iter([(person_property.make_canonical(), Vec::from([itinerary_modifier]))]),
             );
             // Insert the boxed modifier into the itinerary modifier map
              let _ = self
@@ -120,22 +122,19 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
                 .insert(TypeId::of::<P>(), Box::new(person_property_modifier));
             
         }
-
-
-        
     }
 
-    fn remove_itinerary_modifier<P: Property<Person> + 'static>(&mut self, property_value: P::CanonicalValue) 
+    fn remove_itinerary_modifier_by_property<P: Property<Person> + 'static>(&mut self, property_value: P::CanonicalValue) 
     where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
         let modifier_map = self.get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
             .get(&TypeId::of::<P>());
         if let Some(property_modifier_map) = modifier_map {
-            if let Some(property_modifier_map) = property_modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
-                let mut new_property_modifier_map = property_modifier_map.1.clone();
+            if let Some(downcast_property_modifier_map) = property_modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
+                let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
                 new_property_modifier_map.remove(&property_value);
                 let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
-                    property_modifier_map.0,
+                    downcast_property_modifier_map.0,
                     new_property_modifier_map,
                 );
                 self.get_data_mut(ItineraryModifierPlugin)
@@ -145,55 +144,63 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
         }
     }
 
+    fn remove_itinerary_modifier_by_property_and_type<P: Property<Person> + 'static>(&mut self, property_value: P::CanonicalValue, modifier_type: ItineraryModifierType) 
+    where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
+        let modifier_map = self.get_data_mut(ItineraryModifierPlugin)
+            .itinerary_modifier_map
+            .get(&TypeId::of::<P>());
+        if let Some(property_modifier_map) = modifier_map {
+            if let Some(downcast_property_modifier_map) = property_modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
+                let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
+                if let Some(modifiers) = new_property_modifier_map.get_mut(&property_value) {
+                    modifiers.retain(|modifier| modifier.modifier_type != modifier_type);
+                    if modifiers.is_empty() {
+                        new_property_modifier_map.remove(&property_value);
+                    }
+                }
+                let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
+                    downcast_property_modifier_map.0,
+                    new_property_modifier_map,
+                );
+                self.get_data_mut(ItineraryModifierPlugin)
+                    .itinerary_modifier_map
+                    .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
+            }
+        }
+    }
+
+    fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier>;
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier>;
 
 }
 impl ContextItineraryModifierExt for Context {
+    
+    
+    // This needs to be here to have access to the concrete context type for the get_itinerary trait method
+    fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier> {
+        let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
+        let mut modifiers: Vec<ItineraryModifier> = Vec::new();
+        for modifier in itinerary_modifier_container.itinerary_modifier_map.values() {
+            let itinerary_modifier_vec = modifier.get_itineraries(self, person_id);
+            if let Some(itinerary_modifier_vec) = itinerary_modifier_vec {
+                modifiers.extend(itinerary_modifier_vec);
+            }
+        }
+        modifiers
+    }
+
     // This needs to be here to have access to the concrete context type for the get_itinerary trait method
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
-            let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
-            let mut dominant_modifier: Option<ItineraryModifier> = None;
-            for modifier in itinerary_modifier_container.itinerary_modifier_map.values() {
-                let itinerary_modifier = modifier.get_itinerary(self, person_id);
-                if let Some(temp) = itinerary_modifier {
-                    if let Some(dominant_modifier_temp) = dominant_modifier {
-                        if temp > dominant_modifier_temp {
-                            dominant_modifier = Some(temp);
-                        }
-                    } else {
-                        dominant_modifier = Some(temp);
-                    }
-                }
-            }
-            dominant_modifier      
-        }
-}
-
-pub fn init(context: &mut Context) {
-    let school_closure_modifier = ItineraryModifier {
-            ranking: 1,
-            itinerary_ratios: ItineraryRatios {
-                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
-            }
-        };
-    context
-        .register_itinerary_modifier(
-            Age(11),
-            school_closure_modifier,
-        );
-    context
-        .register_itinerary_modifier(
-            Age(10),
-            school_closure_modifier,
-        );
-    let p1 = context.sample_entity(DummyRng, (Age(10),)).unwrap();
-    println!("dominant modifier {:?}", context.get_dominant_itinerary_modifier(p1));
-    context.shutdown();
+        self.get_itinerary_modifiers(person_id)
+            .into_iter()
+            .max()
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::Age;
     use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::population_loader::Alive;
     use crate::settings::SettingCategory;
@@ -239,7 +246,8 @@ mod test {
             ranking: 1,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
-            }
+            },
+            modifier_type: ItineraryModifierType::SchoolClosure,
         };
         context
             .register_itinerary_modifier(
@@ -264,13 +272,48 @@ mod test {
     }
 
     #[test]
-    fn test_itinerary_modifier_removal() {
+    fn test_register_multiple_itinerary_modifiers() {
         let mut context = setup(0.25, 0.25, 0.25, 0.25);
         let school_closure_modifier = ItineraryModifier {
             ranking: 1,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
-            }
+            },
+            modifier_type: ItineraryModifierType::SchoolClosure,
+        };
+        let work_closure_modifier = ItineraryModifier {
+            ranking: 2,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.25, 0.0],
+            },
+            modifier_type: ItineraryModifierType::WorkClosure,
+        };
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                school_closure_modifier,
+            );
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                work_closure_modifier,
+            );
+        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        let modifiers = context.get_itinerary_modifiers(p1);
+        assert_eq!(modifiers.len(), 2);
+        assert!(modifiers.contains(&school_closure_modifier));
+        assert!(modifiers.contains(&work_closure_modifier));
+    }
+
+    #[test]
+    fn test_itinerary_modifier_removal_by_property() {
+        let mut context = setup(0.25, 0.25, 0.25, 0.25);
+        let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            },            
+            modifier_type: ItineraryModifierType::SchoolClosure,
         };
         context
             .register_itinerary_modifier(
@@ -287,9 +330,42 @@ mod test {
         assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
         assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
         // This would remove all age based itinerary modifiers that is not ideal.
-        context.remove_itinerary_modifier::<Age>(Age(11));
+        context.remove_itinerary_modifier_by_property::<Age>(Age(11));
         assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
         assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
+    }
+
+    #[test]
+    fn test_itinerary_modifier_removal_by_property_and_type() {
+        let mut context = setup(0.25, 0.25, 0.25, 0.25);
+        let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            },
+            modifier_type: ItineraryModifierType::SchoolClosure,
+        };
+        let weekend_modifier = ItineraryModifier {
+            ranking: 2,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.5, 0.0, 0.0, 0.5],
+            },
+            modifier_type: ItineraryModifierType::Weekend,
+        };
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                school_closure_modifier,
+            );
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                weekend_modifier,
+            );
+        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(weekend_modifier));
+        context.remove_itinerary_modifier_by_property_and_type::<Age>(Age(11), ItineraryModifierType::Weekend);
+        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
     }
 
     #[test]
@@ -299,13 +375,15 @@ mod test {
             ranking: 1,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
-            }
+            },
+            modifier_type: ItineraryModifierType::SchoolClosure,
         };
         let work_closure_modifier = ItineraryModifier {
             ranking: 2,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.75, 0.0, 0.25, 0.0],
-            }
+            },
+            modifier_type: ItineraryModifierType::WorkClosure,
         };
         context
             .register_itinerary_modifier(
@@ -328,14 +406,16 @@ mod test {
             ranking: 1,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
-            }
+            },
+            modifier_type: ItineraryModifierType::SchoolClosure,
         };
 
         let weekend_modifier = ItineraryModifier {
             ranking: 2,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.5, 0.0, 0.0, 0.5],
-            }
+            },
+            modifier_type: ItineraryModifierType::Weekend,
         };
 
         let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
@@ -358,12 +438,12 @@ mod test {
             assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(weekend_modifier));
         });
         context.add_plan(6.0, move |context| {
-            context.remove_itinerary_modifier::<Alive>(Alive(true));
+            context.remove_itinerary_modifier_by_property::<Alive>(Alive(true));
             assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
         });
 
         context.add_plan(8.0, move |context| {
-            context.remove_itinerary_modifier::<Age>(Age(11));
+            context.remove_itinerary_modifier_by_property::<Age>(Age(11));
             assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
         });
         context.execute();    

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -4,7 +4,7 @@ use ixa::{
 use serde::Serialize;
 use std::{any::{TypeId}, collections::HashMap};
 
-use crate::{Age, settings::ItineraryRatios};
+use crate::{Age, population_loader::SchoolId, settings::ItineraryRatios, symptom_status_manager::SymptomStatus};
 use crate::population_loader::{Person, PersonId};
 
 define_rng!(DummyRng);
@@ -14,6 +14,20 @@ pub struct ItineraryModifier{
     ranking: usize,
     itinerary_ratios: ItineraryRatios
 }
+
+impl Ord for ItineraryModifier {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.ranking.cmp(&other.ranking)
+    }
+}
+
+impl PartialOrd for ItineraryModifier {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for ItineraryModifier {}
 
 // pub trait ItineraryModifiers: std::fmt::Debug + Any {
 //     /// Return the itinerary of a person based on their properties and the current context.
@@ -32,6 +46,8 @@ pub struct ItineraryModifier{
 //     }
 // }
 
+pub trait DummyTrait: std::fmt::Debug + 'static{}
+
 // A newtype wrapper for the itinerary modifiers specified via a hashmap of person
 // property values and itinerary -- i.e., `modifier_key: &[(P::Value, Vec<ItineraryEntry>)]`
 #[allow(dead_code)]
@@ -42,43 +58,9 @@ where
     P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug,
 {
     property: P,
-    modifiers: HashMap<<P as Property<Person>>::CanonicalValue, ItineraryModifier>,
+    modifiers: ItineraryModifier,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
-#[allow(dead_code)]
-impl<'a, P> PersonPropertyModifier<'a, P>
-where
-    P: Property<Person> + std::fmt::Debug,
-    P::CanonicalValue: std::hash::Hash + Eq,
-{
-    fn get(&self, key: &P::CanonicalValue) -> Option<&ItineraryModifier> {
-        self.modifiers.get(key)
-    }
-}
-
-// #[allow(dead_code)]
-// impl<P> ItineraryModifiers for PersonPropertyModifier<'_, P>
-// where
-//     P: Property<Person, CanonicalValue = P> + std::fmt::Debug + 'static,
-//     P::CanonicalValue: std::hash::Hash + Eq,
-// {
-//     fn get_itinerary(
-//         &self,
-//         context: &Context,
-//         person_id: PersonId,
-//     ) -> Option<ItineraryModifier> {
-//         let (_person_property, modifier_map) = self;
-//         let property_val = context.get_property::<Person, P>(person_id);
-//         match modifier_map.get(&property_val) {
-//             Some(value) => Some(*value),
-//             None => None,
-//         }
-//     }
-    
-//     fn get_name(&self) -> String {
-//         format!("{:?}", self.0)
-//     }
-// }
 
 #[derive(Default)]
 struct ItineraryModifierContainer {
@@ -96,7 +78,6 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
     fn register_itinerary_modifier<P: Property<Person> + std::fmt::Debug + 'static>(
         &mut self,
         person_property: P,
-        person_property_value: P::CanonicalValue,
         itinerary_modifier: ItineraryModifier,
     )
     where
@@ -106,7 +87,7 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
         // Itinerary modifiers must implement debug so that we can more easily log their addition
         let person_property_modifier = PersonPropertyModifier {
             property: person_property,
-            modifiers: HashMap::from([(person_property_value, itinerary_modifier)]),
+            modifiers: itinerary_modifier,
             _phantom: std::marker::PhantomData,
         };
         // Insert the boxed function into the itinerary modifier map, using entry to handle unititialized keys
@@ -125,69 +106,31 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
             .remove(&TypeId::of::<P>());
     }
 
-    // fn store_itinerary_modifier_values<
-    //     P: Property<Person, CanonicalValue = P> + std::fmt::Debug + 'static,
-    // >(
-    //     &mut self,
-    //     person_property: P,
-    //     person_property_value: P::CanonicalValue,
-    //     itinerary_modifier: ItineraryModifier,
-    // ) -> Result<(), ModelError>
-    // where
-    //     P::CanonicalValue: std::hash::Hash + Eq,
-    // {
-    //     // Convert modifiers to HashMap
-    //     let mut modifier_map = HashMap::new();
-    //     if let Some(old_value) = modifier_map.insert(person_property_value, itinerary_modifier) {
-    //         return Err(ModelError::ModelError(
-    //             "Duplicate values provided in modifier key ".to_string()
-    //                 + &format!("Values {old_value:?} and {itinerary_modifier:?} were both attempted to be registered to key {person_property:?}::{person_property_value:?}"),
-    //         ));
-    //     }
-    //     self.register_itinerary_modifier_fn((person_property, modifier_map.clone()));
-    //     Ok(())
-    // }
-
-    fn get_itinerary<P: Property<Person> + std::fmt::Debug + 'static>(&self, person_id: PersonId, person_property: P) 
-    where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
+    fn get_itinerary<P: Property<Person> + std::fmt::Debug + 'static>(&self, person_property: P) -> Option<ItineraryModifier>
+    where 
+        <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq 
+    {
         let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
-        println!("itinerary modifier map: {:?}", itinerary_modifier_container.itinerary_modifier_map);
         let modifier_key = TypeId::of::<P>();
         let modifier = itinerary_modifier_container.itinerary_modifier_map.get(&modifier_key).unwrap();
-        println!("Getting itinerary modifier for person {person_id} and property {person_property:?}");
-        println!("Modifier: {:?}", modifier);
-        let temp = modifier.downcast_ref::<PersonPropertyModifier<'_, P>>().unwrap();
-        let property = temp.property;
-        let property_val = temp.modifiers.keys().next().unwrap();
-        println!("Property: {:?}", property);
-        println!("Property value: {:?}", property_val);
-        let age = self.get_property::<Person, P>(person_id);
-        println!("Person property value: {:?}", age);
-        println!("property == age {}", property == age);
-        // match modifier.get(&property_val) {
-        //     Some(value) => Some(*value),
-        //     None => None,
-        // }
+        let modifier = modifier.downcast_ref::<PersonPropertyModifier<'_, P>>().unwrap();
+        if modifier.property == person_property {
+            Some(modifier.modifiers)
+        } else {
+            None
+        }
     }
 
-    // fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
-    //     println!("Getting dominant itinerary modifier for person {person_id}");
-    //     let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
-    //     let mut dominant_itinerary_modifier: Option<ItineraryModifier> = None;
-    //     for itinerary_modifier in itinerary_modifier_container.itinerary_modifier_map.values() {
-    //         println!("Checking itinerary modifier: {:?}", itinerary_modifier);
-    //         if let Some(modifier) = itinerary_modifier.get_itinerary(self, person_id) {
-    //             if let Some(current_dominant) = dominant_itinerary_modifier {
-    //                 if modifier.ranking > current_dominant.ranking {
-    //                     dominant_itinerary_modifier = Some(modifier);
-    //                 }
-    //             } else {
-    //                 dominant_itinerary_modifier = Some(modifier);
-    //             }
-    //         }
-    //     }
-    //     dominant_itinerary_modifier
-    // }
+    fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
+        println!("Getting dominant itinerary modifier for person {person_id}");
+        let age_modifier = self.get_itinerary(self.get_property::<Person, Age>(person_id));
+        let symp_modifier = self.get_itinerary(self.get_property::<Person, SymptomStatus>(person_id));
+        let school_modifier = self.get_itinerary(self.get_property::<Person, SchoolId>(person_id));
+        let modifiers = [age_modifier, symp_modifier, school_modifier];
+        let mut sorted_modifiers: Vec<_> = modifiers.into_iter().flatten().collect();
+        sorted_modifiers.sort(); 
+        sorted_modifiers.pop()
+    }
 
 }
 impl ContextItineraryModifierExt for Context {}
@@ -201,11 +144,10 @@ pub fn init(context: &mut Context) {
         };
     context
         .register_itinerary_modifier(
-            Age(0),
-            Age(10),
+            Age(11),
             school_closure_modifier,
         );
     let p1 = context.sample_entity(DummyRng, (Age(11),)).unwrap();
-    println!("dominant modifier {:?}", context.get_itinerary(p1, Age(11)));
+    println!("dominant modifier {:?}", context.get_itinerary(context.get_property::<Person, Age>(p1)));
     context.shutdown();
 }

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -2,9 +2,9 @@ use ixa::{
     prelude::*,
 };
 use serde::Serialize;
-use std::{any::{TypeId}, collections::HashMap};
+use std::{any::{Any, TypeId}, collections::HashMap};
 
-use crate::{Age, population_loader::SchoolId, settings::ItineraryRatios, symptom_status_manager::SymptomStatus};
+use crate::{Age, settings::ItineraryRatios};
 use crate::population_loader::{Person, PersonId};
 
 define_rng!(DummyRng);
@@ -46,7 +46,14 @@ impl Eq for ItineraryModifier {}
 //     }
 // }
 
-pub trait DummyTrait: std::fmt::Debug + 'static{}
+pub trait DummyTrait: std::fmt::Debug  + Any{
+    fn as_any(&self) -> &dyn std::any::Any;
+    fn get_itinerary(
+        &self,
+        context: &Context,
+        person_id: PersonId,
+    ) -> Option<ItineraryModifier>;
+}
 
 // A newtype wrapper for the itinerary modifiers specified via a hashmap of person
 // property values and itinerary -- i.e., `modifier_key: &[(P::Value, Vec<ItineraryEntry>)]`
@@ -62,9 +69,29 @@ where
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
+impl<P> DummyTrait for PersonPropertyModifier<'static, P> 
+where 
+    P: Property<Person> + std::fmt::Debug, 
+    P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn get_itinerary(
+        &self,
+        context: &Context,
+        person_id: PersonId,
+    ) -> Option<ItineraryModifier> {
+        if self.property == context.get_property::<Person, P>(person_id){
+            Some(self.modifiers)
+        } else {
+            None
+        }        
+    }
+}
+
 #[derive(Default)]
 struct ItineraryModifierContainer {
-    itinerary_modifier_map: HashMap<TypeId, Box<dyn std::any::Any>>,
+    itinerary_modifier_map: HashMap<TypeId, Box<dyn DummyTrait>>,
 }
 
 define_data_plugin!(
@@ -74,6 +101,7 @@ define_data_plugin!(
 );
 
 pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
+    
     /// Register a generic itinerary modifier.
     fn register_itinerary_modifier<P: Property<Person> + std::fmt::Debug + 'static>(
         &mut self,
@@ -106,34 +134,45 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
             .remove(&TypeId::of::<P>());
     }
 
-    fn get_itinerary<P: Property<Person> + std::fmt::Debug + 'static>(&self, person_property: P) -> Option<ItineraryModifier>
-    where 
-        <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq 
-    {
-        let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
-        let modifier_key = TypeId::of::<P>();
-        let modifier = itinerary_modifier_container.itinerary_modifier_map.get(&modifier_key).unwrap();
-        let modifier = modifier.downcast_ref::<PersonPropertyModifier<'_, P>>().unwrap();
-        if modifier.property == person_property {
-            Some(modifier.modifiers)
-        } else {
-            None
-        }
-    }
+    // fn get_itinerary<P: Property<Person> + std::fmt::Debug + 'static>(&self, person_property: P) -> Option<ItineraryModifier>
+    // where 
+    //     <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq 
+    // {
+    //     let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
+    //     let modifier_key = TypeId::of::<P>();
+    //     let modifier = itinerary_modifier_container.itinerary_modifier_map.get(&modifier_key).unwrap();
+    //     let modifier = modifier.as_any();
+    //     let modifier = modifier.downcast_ref::<PersonPropertyModifier<'_, P>>().unwrap();
+    //     if modifier.property == person_property {
+    //         Some(modifier.modifiers)
+    //     } else {
+    //         None
+    //     }
+    // }
 
-    fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
-        println!("Getting dominant itinerary modifier for person {person_id}");
-        let age_modifier = self.get_itinerary(self.get_property::<Person, Age>(person_id));
-        let symp_modifier = self.get_itinerary(self.get_property::<Person, SymptomStatus>(person_id));
-        let school_modifier = self.get_itinerary(self.get_property::<Person, SchoolId>(person_id));
-        let modifiers = [age_modifier, symp_modifier, school_modifier];
-        let mut sorted_modifiers: Vec<_> = modifiers.into_iter().flatten().collect();
-        sorted_modifiers.sort(); 
-        sorted_modifiers.pop()
-    }
+    fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier>;
 
 }
-impl ContextItineraryModifierExt for Context {}
+impl ContextItineraryModifierExt for Context {
+    // This needs to be here to have access to the concrete context type for the get_itinerary trait method
+    fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
+            let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
+            let mut dominant_modifier: Option<ItineraryModifier> = None;
+            for modifier in itinerary_modifier_container.itinerary_modifier_map.values() {
+                let itinerary_modifier = modifier.get_itinerary(self, person_id);
+                if let Some(temp) = itinerary_modifier {
+                    if let Some(dominant_modifier_temp) = dominant_modifier {
+                        if temp > dominant_modifier_temp {
+                            dominant_modifier = Some(temp);
+                        }
+                    } else {
+                        dominant_modifier = Some(temp);
+                    }
+                }
+            }
+            dominant_modifier      
+        }
+}
 
 pub fn init(context: &mut Context) {
     let school_closure_modifier = ItineraryModifier {
@@ -148,6 +187,6 @@ pub fn init(context: &mut Context) {
             school_closure_modifier,
         );
     let p1 = context.sample_entity(DummyRng, (Age(11),)).unwrap();
-    println!("dominant modifier {:?}", context.get_itinerary(context.get_property::<Person, Age>(p1)));
+    println!("dominant modifier {:?}", context.get_dominant_itinerary_modifier(p1));
     context.shutdown();
 }

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
 };
 
-use crate::population_loader::{Person, PersonId};
+use crate::{Age, error::ModelError, population_loader::{Alive, Person, PersonId}};
 use crate::settings::ItineraryRatios;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Copy, Eq, Hash)]
@@ -187,6 +187,7 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
 
     fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier>;
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier>;
+    fn get_dominant_itinerary_modifier_ratios(&self, person_id: PersonId) -> ItineraryRatios;
 }
 impl ContextItineraryModifierExt for Context {
     // This needs to be here to have access to the concrete context type for the get_itinerary trait method
@@ -206,6 +207,51 @@ impl ContextItineraryModifierExt for Context {
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
         self.get_itinerary_modifiers(person_id).into_iter().max()
     }
+
+    fn get_dominant_itinerary_modifier_ratios(&self, person_id: PersonId) -> ItineraryRatios {
+        self.get_dominant_itinerary_modifier(person_id)
+            .map(|modifier| modifier.itinerary_ratios)
+            .unwrap_or(self.get_property::<Person, ItineraryRatios>(person_id))
+    }
+
+}
+
+pub fn init(context: &mut Context) -> Result<(), ModelError> {
+    let weekend_modifier = ItineraryModifier {
+        ranking: 2,
+        itinerary_ratios: ItineraryRatios {
+            itinerary_ratios: [0.5, 0.0, 0.0, 0.5],
+        },
+        modifier_type: ItineraryModifierType::Weekend,
+    };
+
+    let school_closure_modifier = ItineraryModifier {
+        ranking: 1,
+        itinerary_ratios: ItineraryRatios {
+            itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+        },
+        modifier_type: ItineraryModifierType::SchoolClosure,
+    }; 
+    
+    for i in (0..=100).step_by(7) {
+        context.add_plan(i as f64, move |context| {
+            context.register_itinerary_modifier(Alive(true), weekend_modifier);
+        });
+        context.add_plan(i as f64 + 2.0, move |context| {
+            context.remove_itinerary_modifier_by_property::<Alive>(Alive(true));
+        });
+    }
+
+    for age in 5..=18 {
+        context.add_plan(3.0, move |context| {
+            context.register_itinerary_modifier(Age(age), school_closure_modifier);
+        });
+        context.add_plan(30.0, move |context| {
+            context.remove_itinerary_modifier_by_property::<Age>(Age(age));
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -35,21 +35,14 @@ pub trait ItineraryModifierTrait: std::fmt::Debug  + Any{
         context: &Context,
         person_id: PersonId,
     ) -> Option<ItineraryModifier>;
+    fn as_any(&self) -> &dyn Any;
 }
 
-// A newtype wrapper for the itinerary modifiers specified via a hashmap of person
-// property values and itinerary -- i.e., `modifier_key: &[(P::Value, Vec<ItineraryEntry>)]`
-#[allow(dead_code)]
-#[derive(Debug)]
-struct PersonPropertyItineraryModifier<'a, P>
-where
-    P: Property<Person> + std::fmt::Debug,
-    P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug,
-{
-    property: P,
-    modifiers: ItineraryModifier,
-    _phantom: std::marker::PhantomData<&'a ()>,
-}
+type PersonPropertyItineraryModifier<'a, P> = (
+    P,
+    // Use fully qualified syntax for the associated type because type aliases do not have type checking
+    HashMap<<P as Property<Person>>::CanonicalValue, ItineraryModifier>,
+);
 
 impl<P> ItineraryModifierTrait for PersonPropertyItineraryModifier<'static, P> 
 where 
@@ -61,11 +54,16 @@ where
         context: &Context,
         person_id: PersonId,
     ) -> Option<ItineraryModifier> {
-        if self.property == context.get_property::<Person, P>(person_id){
-            Some(self.modifiers)
-        } else {
-            None
-        }        
+        let (_person_property, modifier_map) = self;
+        let property_val = context.get_property::<Person, P>(person_id);
+        match modifier_map.get(&property_val.make_canonical()) {
+            Some(value) => Some(*value),
+            None => None,
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -91,27 +89,60 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
     where
         P::CanonicalValue: std::hash::Hash + Eq,
     {
-        // Box the itinerary modifier to store it in the map
-        // Itinerary modifiers must implement debug so that we can more easily log their addition
-        let person_property_modifier = PersonPropertyItineraryModifier {
-            property: person_property,
-            modifiers: itinerary_modifier,
-            _phantom: std::marker::PhantomData,
-        };
-        // Insert the boxed function into the itinerary modifier map, using entry to handle unititialized keys
-        if let Some(_modifier_fxn) = self
-            .get_data_mut(ItineraryModifierPlugin)
+    
+        if let Some(modifier_map) = self.get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
-            .insert(TypeId::of::<P>(), Box::new(person_property_modifier))
-        {
-            trace!("Overwriting existing itinerary modifier function for and itinerary modifier");
+            .get(&TypeId::of::<P>()){
+
+            if let Some(modifier_map) = modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
+                let mut new_modifier_map = modifier_map.1.clone();
+                println!("Adding modifier for property value {:?} with modifier {:?} to existing modifier map for property {:?}", person_property.make_canonical(), itinerary_modifier, person_property);
+                println!("Modifier map before addition: {:?}", new_modifier_map);
+                new_modifier_map.insert(person_property.make_canonical(), itinerary_modifier);
+                println!("Modifier map after addition: {:?}", new_modifier_map);
+                let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
+                    modifier_map.0,
+                    new_modifier_map,
+                );
+                self.get_data_mut(ItineraryModifierPlugin)
+                    .itinerary_modifier_map
+                    .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
+            }
+        } else {
+            let person_property_modifier: PersonPropertyItineraryModifier<P> = (
+                person_property,
+                HashMap::from_iter([(person_property.make_canonical(), itinerary_modifier)]),
+            );
+            // Insert the boxed modifier into the itinerary modifier map
+             let _ = self
+                .get_data_mut(ItineraryModifierPlugin)
+                .itinerary_modifier_map
+                .insert(TypeId::of::<P>(), Box::new(person_property_modifier));
+            
         }
+
+
+        
     }
 
-    fn remove_itinerary_modifier<P: Property<Person> + 'static>(&mut self) {
-        self.get_data_mut(ItineraryModifierPlugin)
+    fn remove_itinerary_modifier<P: Property<Person> + 'static>(&mut self, property_value: P::CanonicalValue) 
+    where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
+        let modifier_map = self.get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
-            .remove(&TypeId::of::<P>());
+            .get(&TypeId::of::<P>());
+        if let Some(property_modifier_map) = modifier_map {
+            if let Some(property_modifier_map) = property_modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
+                let mut new_property_modifier_map = property_modifier_map.1.clone();
+                new_property_modifier_map.remove(&property_value);
+                let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
+                    property_modifier_map.0,
+                    new_property_modifier_map,
+                );
+                self.get_data_mut(ItineraryModifierPlugin)
+                    .itinerary_modifier_map
+                    .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
+            }
+        }
     }
 
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier>;
@@ -148,6 +179,11 @@ pub fn init(context: &mut Context) {
     context
         .register_itinerary_modifier(
             Age(11),
+            school_closure_modifier,
+        );
+    context
+        .register_itinerary_modifier(
+            Age(10),
             school_closure_modifier,
         );
     let p1 = context.sample_entity(DummyRng, (Age(10),)).unwrap();
@@ -216,7 +252,15 @@ mod test {
         let dominant_modifier_p2 = context.get_dominant_itinerary_modifier(p2);
         assert_eq!(dominant_modifier_p1, None);
         assert_eq!(dominant_modifier_p2, Some(school_closure_modifier));
-        println!("dominant modifier {:?}", context.get_dominant_itinerary_modifier(p1));
+
+        context
+            .register_itinerary_modifier(
+                Age(10),
+                school_closure_modifier,
+            );
+        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+        assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
+
     }
 
     #[test]
@@ -230,14 +274,22 @@ mod test {
         };
         context
             .register_itinerary_modifier(
+                Age(10),
+                school_closure_modifier,
+            );
+        context
+            .register_itinerary_modifier(
                 Age(11),
                 school_closure_modifier,
             );
         let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        let p2 = context.add_entity::<Person,_>((Age(10),)).unwrap();
         assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+        assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
         // This would remove all age based itinerary modifiers that is not ideal.
-        context.remove_itinerary_modifier::<Age>();
+        context.remove_itinerary_modifier::<Age>(Age(11));
         assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
+        assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
     }
 
     #[test]
@@ -285,7 +337,7 @@ mod test {
                 itinerary_ratios: [0.5, 0.0, 0.0, 0.5],
             }
         };
-        
+
         let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
         context.add_plan(2.0, move |context| {
             assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
@@ -306,12 +358,12 @@ mod test {
             assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(weekend_modifier));
         });
         context.add_plan(6.0, move |context| {
-            context.remove_itinerary_modifier::<Alive>();
+            context.remove_itinerary_modifier::<Alive>(Alive(true));
             assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
         });
 
         context.add_plan(8.0, move |context| {
-            context.remove_itinerary_modifier::<Age>();
+            context.remove_itinerary_modifier::<Age>(Age(11));
             assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
         });
         context.execute();    

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -1,21 +1,22 @@
-use ixa::{
-    prelude::*,
-};
+use ixa::prelude::*;
 use serde::Serialize;
-use std::{any::{Any, TypeId}, collections::HashMap};
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+};
 
-use crate::{settings::ItineraryRatios};
 use crate::population_loader::{Person, PersonId};
+use crate::settings::ItineraryRatios;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Copy, Eq, Hash)]
-pub enum ItineraryModifierType{
+pub enum ItineraryModifierType {
     SchoolClosure,
     WorkClosure,
     Weekend,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Copy)]
-pub struct ItineraryModifier{
+pub struct ItineraryModifier {
     ranking: usize,
     itinerary_ratios: ItineraryRatios,
     modifier_type: ItineraryModifierType,
@@ -35,7 +36,7 @@ impl PartialOrd for ItineraryModifier {
 
 impl Eq for ItineraryModifier {}
 
-pub trait ItineraryModifierTrait: std::fmt::Debug  + Any{
+pub trait ItineraryModifierTrait: std::fmt::Debug + Any {
     fn get_itineraries(
         &self,
         context: &Context,
@@ -50,11 +51,11 @@ type PersonPropertyItineraryModifier<'a, P> = (
     HashMap<<P as Property<Person>>::CanonicalValue, Vec<ItineraryModifier>>,
 );
 
-impl<P> ItineraryModifierTrait for PersonPropertyItineraryModifier<'static, P> 
-where 
-    P: Property<Person> + std::fmt::Debug, 
-    P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug {
-    
+impl<P> ItineraryModifierTrait for PersonPropertyItineraryModifier<'static, P>
+where
+    P: Property<Person> + std::fmt::Debug,
+    P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug,
+{
     fn get_itineraries(
         &self,
         context: &Context,
@@ -62,10 +63,7 @@ where
     ) -> Option<Vec<ItineraryModifier>> {
         let (_person_property, modifier_map) = self;
         let property_val = context.get_property::<Person, P>(person_id);
-        match modifier_map.get(&property_val.make_canonical()) {
-            Some(value) => Some(value.clone()),
-            None => None,
-        }
+        modifier_map.get(&property_val.make_canonical()).cloned()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -85,27 +83,30 @@ define_data_plugin!(
 );
 
 pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
-    
     /// Register a generic itinerary modifier.
     fn register_itinerary_modifier<P: Property<Person> + std::fmt::Debug + 'static>(
         &mut self,
         person_property: P,
         itinerary_modifier: ItineraryModifier,
-    )
-    where
+    ) where
         P::CanonicalValue: std::hash::Hash + Eq,
     {
-        if let Some(modifier_map) = self.get_data_mut(ItineraryModifierPlugin)
+        if let Some(modifier_map) = self
+            .get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
-            .get(&TypeId::of::<P>()){
-
-            if let Some(downcast_modifier_map) = modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
+            .get(&TypeId::of::<P>())
+        {
+            if let Some(downcast_modifier_map) = modifier_map
+                .as_any()
+                .downcast_ref::<PersonPropertyItineraryModifier<P>>(
+            ) {
                 let mut new_modifier_map = downcast_modifier_map.1.clone();
-                new_modifier_map.entry(person_property.make_canonical()).or_insert_with(Vec::new).push(itinerary_modifier);
-                let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
-                    downcast_modifier_map.0,
-                    new_modifier_map,
-                );
+                new_modifier_map
+                    .entry(person_property.make_canonical())
+                    .or_insert_with(Vec::new)
+                    .push(itinerary_modifier);
+                let new_person_property_modifier: PersonPropertyItineraryModifier<P> =
+                    (downcast_modifier_map.0, new_modifier_map);
                 self.get_data_mut(ItineraryModifierPlugin)
                     .itinerary_modifier_map
                     .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
@@ -113,69 +114,81 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
         } else {
             let person_property_modifier: PersonPropertyItineraryModifier<P> = (
                 person_property,
-                HashMap::from_iter([(person_property.make_canonical(), Vec::from([itinerary_modifier]))]),
+                HashMap::from_iter([(
+                    person_property.make_canonical(),
+                    Vec::from([itinerary_modifier]),
+                )]),
             );
             // Insert the boxed modifier into the itinerary modifier map
-             let _ = self
+            let _ = self
                 .get_data_mut(ItineraryModifierPlugin)
                 .itinerary_modifier_map
                 .insert(TypeId::of::<P>(), Box::new(person_property_modifier));
-            
         }
     }
 
-    fn remove_itinerary_modifier_by_property<P: Property<Person> + 'static>(&mut self, property_value: P::CanonicalValue) 
-    where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
-        let modifier_map = self.get_data_mut(ItineraryModifierPlugin)
+    fn remove_itinerary_modifier_by_property<P: Property<Person> + 'static>(
+        &mut self,
+        property_value: P::CanonicalValue,
+    ) where
+        <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq,
+    {
+        let modifier_map = self
+            .get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
             .get(&TypeId::of::<P>());
-        if let Some(property_modifier_map) = modifier_map {
-            if let Some(downcast_property_modifier_map) = property_modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
-                let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
-                new_property_modifier_map.remove(&property_value);
-                let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
-                    downcast_property_modifier_map.0,
-                    new_property_modifier_map,
-                );
-                self.get_data_mut(ItineraryModifierPlugin)
-                    .itinerary_modifier_map
-                    .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
-            }
+        if let Some(property_modifier_map) = modifier_map
+            && let Some(downcast_property_modifier_map) = property_modifier_map
+                .as_any()
+                .downcast_ref::<PersonPropertyItineraryModifier<P>>(
+            )
+        {
+            let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
+            new_property_modifier_map.remove(&property_value);
+            let new_person_property_modifier: PersonPropertyItineraryModifier<P> =
+                (downcast_property_modifier_map.0, new_property_modifier_map);
+            self.get_data_mut(ItineraryModifierPlugin)
+                .itinerary_modifier_map
+                .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
         }
     }
 
-    fn remove_itinerary_modifier_by_property_and_type<P: Property<Person> + 'static>(&mut self, property_value: P::CanonicalValue, modifier_type: ItineraryModifierType) 
-    where <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq {
-        let modifier_map = self.get_data_mut(ItineraryModifierPlugin)
+    fn remove_itinerary_modifier_by_property_and_type<P: Property<Person> + 'static>(
+        &mut self,
+        property_value: P::CanonicalValue,
+        modifier_type: ItineraryModifierType,
+    ) where
+        <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq,
+    {
+        let modifier_map = self
+            .get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
             .get(&TypeId::of::<P>());
-        if let Some(property_modifier_map) = modifier_map {
-            if let Some(downcast_property_modifier_map) = property_modifier_map.as_any().downcast_ref::<PersonPropertyItineraryModifier<P>>() {
-                let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
-                if let Some(modifiers) = new_property_modifier_map.get_mut(&property_value) {
-                    modifiers.retain(|modifier| modifier.modifier_type != modifier_type);
-                    if modifiers.is_empty() {
-                        new_property_modifier_map.remove(&property_value);
-                    }
+        if let Some(property_modifier_map) = modifier_map
+            && let Some(downcast_property_modifier_map) = property_modifier_map
+                .as_any()
+                .downcast_ref::<PersonPropertyItineraryModifier<P>>(
+            )
+        {
+            let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
+            if let Some(modifiers) = new_property_modifier_map.get_mut(&property_value) {
+                modifiers.retain(|modifier| modifier.modifier_type != modifier_type);
+                if modifiers.is_empty() {
+                    new_property_modifier_map.remove(&property_value);
                 }
-                let new_person_property_modifier: PersonPropertyItineraryModifier<P> = (
-                    downcast_property_modifier_map.0,
-                    new_property_modifier_map,
-                );
-                self.get_data_mut(ItineraryModifierPlugin)
-                    .itinerary_modifier_map
-                    .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
             }
+            let new_person_property_modifier: PersonPropertyItineraryModifier<P> =
+                (downcast_property_modifier_map.0, new_property_modifier_map);
+            self.get_data_mut(ItineraryModifierPlugin)
+                .itinerary_modifier_map
+                .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
         }
     }
 
     fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier>;
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier>;
-
 }
 impl ContextItineraryModifierExt for Context {
-    
-    
     // This needs to be here to have access to the concrete context type for the get_itinerary trait method
     fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier> {
         let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
@@ -191,9 +204,7 @@ impl ContextItineraryModifierExt for Context {
 
     // This needs to be here to have access to the concrete context type for the get_itinerary trait method
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier> {
-        self.get_itinerary_modifiers(person_id)
-            .into_iter()
-            .max()
+        self.get_itinerary_modifiers(person_id).into_iter().max()
     }
 }
 
@@ -206,12 +217,7 @@ mod test {
     use crate::settings::SettingCategory;
     use ixa::HashMap;
 
-    fn setup(
-        home_ratio: f64,
-        school_ratio: f64,
-        work_ratio: f64,
-        community_ratio: f64,
-    ) -> Context {
+    fn setup(home_ratio: f64, school_ratio: f64, work_ratio: f64, community_ratio: f64) -> Context {
         let mut context = Context::new();
         let parameters = Params {
             settings_properties: HashMap::from_iter(
@@ -249,26 +255,23 @@ mod test {
             },
             modifier_type: ItineraryModifierType::SchoolClosure,
         };
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                school_closure_modifier,
-            );
-        let p1 = context.add_entity::<Person,_>((Age(10),)).unwrap();
-        let p2 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        context.register_itinerary_modifier(Age(11), school_closure_modifier);
+        let p1 = context.add_entity::<Person, _>((Age(10),)).unwrap();
+        let p2 = context.add_entity::<Person, _>((Age(11),)).unwrap();
         let dominant_modifier_p1 = context.get_dominant_itinerary_modifier(p1);
         let dominant_modifier_p2 = context.get_dominant_itinerary_modifier(p2);
         assert_eq!(dominant_modifier_p1, None);
         assert_eq!(dominant_modifier_p2, Some(school_closure_modifier));
 
-        context
-            .register_itinerary_modifier(
-                Age(10),
-                school_closure_modifier,
-            );
-        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
-        assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
-
+        context.register_itinerary_modifier(Age(10), school_closure_modifier);
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p1),
+            Some(school_closure_modifier)
+        );
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p2),
+            Some(school_closure_modifier)
+        );
     }
 
     #[test]
@@ -288,17 +291,9 @@ mod test {
             },
             modifier_type: ItineraryModifierType::WorkClosure,
         };
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                school_closure_modifier,
-            );
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                work_closure_modifier,
-            );
-        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        context.register_itinerary_modifier(Age(11), school_closure_modifier);
+        context.register_itinerary_modifier(Age(11), work_closure_modifier);
+        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
         let modifiers = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers.len(), 2);
         assert!(modifiers.contains(&school_closure_modifier));
@@ -312,27 +307,28 @@ mod test {
             ranking: 1,
             itinerary_ratios: ItineraryRatios {
                 itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
-            },            
+            },
             modifier_type: ItineraryModifierType::SchoolClosure,
         };
-        context
-            .register_itinerary_modifier(
-                Age(10),
-                school_closure_modifier,
-            );
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                school_closure_modifier,
-            );
-        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
-        let p2 = context.add_entity::<Person,_>((Age(10),)).unwrap();
-        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
-        assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
+        context.register_itinerary_modifier(Age(10), school_closure_modifier);
+        context.register_itinerary_modifier(Age(11), school_closure_modifier);
+        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        let p2 = context.add_entity::<Person, _>((Age(10),)).unwrap();
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p1),
+            Some(school_closure_modifier)
+        );
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p2),
+            Some(school_closure_modifier)
+        );
         // This would remove all age based itinerary modifiers that is not ideal.
         context.remove_itinerary_modifier_by_property::<Age>(Age(11));
         assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
-        assert_eq!(context.get_dominant_itinerary_modifier(p2), Some(school_closure_modifier));
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p2),
+            Some(school_closure_modifier)
+        );
     }
 
     #[test]
@@ -352,20 +348,21 @@ mod test {
             },
             modifier_type: ItineraryModifierType::Weekend,
         };
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                school_closure_modifier,
-            );
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                weekend_modifier,
-            );
-        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
-        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(weekend_modifier));
-        context.remove_itinerary_modifier_by_property_and_type::<Age>(Age(11), ItineraryModifierType::Weekend);
-        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+        context.register_itinerary_modifier(Age(11), school_closure_modifier);
+        context.register_itinerary_modifier(Age(11), weekend_modifier);
+        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p1),
+            Some(weekend_modifier)
+        );
+        context.remove_itinerary_modifier_by_property_and_type::<Age>(
+            Age(11),
+            ItineraryModifierType::Weekend,
+        );
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p1),
+            Some(school_closure_modifier)
+        );
     }
 
     #[test]
@@ -385,18 +382,13 @@ mod test {
             },
             modifier_type: ItineraryModifierType::WorkClosure,
         };
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                school_closure_modifier,
-            );
-        context
-            .register_itinerary_modifier(
-                Age(11),
-                work_closure_modifier,
-            );
-        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
-        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(work_closure_modifier));
+        context.register_itinerary_modifier(Age(11), school_closure_modifier);
+        context.register_itinerary_modifier(Age(11), work_closure_modifier);
+        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        assert_eq!(
+            context.get_dominant_itinerary_modifier(p1),
+            Some(work_closure_modifier)
+        );
     }
 
     #[test]
@@ -418,34 +410,35 @@ mod test {
             modifier_type: ItineraryModifierType::Weekend,
         };
 
-        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
         context.add_plan(2.0, move |context| {
             assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
-            context
-            .register_itinerary_modifier(
-                Age(11),
-                school_closure_modifier,
+            context.register_itinerary_modifier(Age(11), school_closure_modifier);
+            assert_eq!(
+                context.get_dominant_itinerary_modifier(p1),
+                Some(school_closure_modifier)
             );
-            assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
         });
 
         context.add_plan(4.0, move |context| {
-            context
-            .register_itinerary_modifier(
-                Alive(true),
-                weekend_modifier,
+            context.register_itinerary_modifier(Alive(true), weekend_modifier);
+            assert_eq!(
+                context.get_dominant_itinerary_modifier(p1),
+                Some(weekend_modifier)
             );
-            assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(weekend_modifier));
         });
         context.add_plan(6.0, move |context| {
             context.remove_itinerary_modifier_by_property::<Alive>(Alive(true));
-            assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+            assert_eq!(
+                context.get_dominant_itinerary_modifier(p1),
+                Some(school_closure_modifier)
+            );
         });
 
         context.add_plan(8.0, move |context| {
             context.remove_itinerary_modifier_by_property::<Age>(Age(11));
             assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
         });
-        context.execute();    
+        context.execute();
     }
 }

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -29,25 +29,7 @@ impl PartialOrd for ItineraryModifier {
 
 impl Eq for ItineraryModifier {}
 
-// pub trait ItineraryModifiers: std::fmt::Debug + Any {
-//     /// Return the itinerary of a person based on their properties and the current context.
-//     #[allow(dead_code)]
-//     fn get_itinerary(
-//         &self,
-//         context: &Context,
-//         person_id: PersonId,
-//     ) -> Option<ItineraryModifier>;
-
-//     /// For debugging purposes. The name of the itinerary modifier. The default implementation
-//     /// returns the `Debug` representation of the itinerary modifier struct on which this trait
-//     /// is implemented.
-//     fn get_name(&self) -> String {
-//         format!("{self:?}")
-//     }
-// }
-
-pub trait DummyTrait: std::fmt::Debug  + Any{
-    fn as_any(&self) -> &dyn std::any::Any;
+pub trait ItineraryModifierTrait: std::fmt::Debug  + Any{
     fn get_itinerary(
         &self,
         context: &Context,
@@ -59,7 +41,7 @@ pub trait DummyTrait: std::fmt::Debug  + Any{
 // property values and itinerary -- i.e., `modifier_key: &[(P::Value, Vec<ItineraryEntry>)]`
 #[allow(dead_code)]
 #[derive(Debug)]
-struct PersonPropertyModifier<'a, P>
+struct PersonPropertyItineraryModifier<'a, P>
 where
     P: Property<Person> + std::fmt::Debug,
     P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug,
@@ -69,13 +51,11 @@ where
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<P> DummyTrait for PersonPropertyModifier<'static, P> 
+impl<P> ItineraryModifierTrait for PersonPropertyItineraryModifier<'static, P> 
 where 
     P: Property<Person> + std::fmt::Debug, 
     P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
+    
     fn get_itinerary(
         &self,
         context: &Context,
@@ -91,7 +71,7 @@ where
 
 #[derive(Default)]
 struct ItineraryModifierContainer {
-    itinerary_modifier_map: HashMap<TypeId, Box<dyn DummyTrait>>,
+    itinerary_modifier_map: HashMap<TypeId, Box<dyn ItineraryModifierTrait>>,
 }
 
 define_data_plugin!(
@@ -113,7 +93,7 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
     {
         // Box the itinerary modifier to store it in the map
         // Itinerary modifiers must implement debug so that we can more easily log their addition
-        let person_property_modifier = PersonPropertyModifier {
+        let person_property_modifier = PersonPropertyItineraryModifier {
             property: person_property,
             modifiers: itinerary_modifier,
             _phantom: std::marker::PhantomData,
@@ -128,27 +108,11 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
         }
     }
 
-    fn remove_itinerary_modifier_fn<P: Property<Person> + 'static>(&mut self) {
+    fn remove_itinerary_modifier<P: Property<Person> + 'static>(&mut self) {
         self.get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
             .remove(&TypeId::of::<P>());
     }
-
-    // fn get_itinerary<P: Property<Person> + std::fmt::Debug + 'static>(&self, person_property: P) -> Option<ItineraryModifier>
-    // where 
-    //     <P as ixa::prelude::Property<Person>>::CanonicalValue: std::hash::Hash + Eq 
-    // {
-    //     let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
-    //     let modifier_key = TypeId::of::<P>();
-    //     let modifier = itinerary_modifier_container.itinerary_modifier_map.get(&modifier_key).unwrap();
-    //     let modifier = modifier.as_any();
-    //     let modifier = modifier.downcast_ref::<PersonPropertyModifier<'_, P>>().unwrap();
-    //     if modifier.property == person_property {
-    //         Some(modifier.modifiers)
-    //     } else {
-    //         None
-    //     }
-    // }
 
     fn get_dominant_itinerary_modifier(&self, person_id: PersonId) -> Option<ItineraryModifier>;
 
@@ -186,7 +150,170 @@ pub fn init(context: &mut Context) {
             Age(11),
             school_closure_modifier,
         );
-    let p1 = context.sample_entity(DummyRng, (Age(11),)).unwrap();
+    let p1 = context.sample_entity(DummyRng, (Age(10),)).unwrap();
     println!("dominant modifier {:?}", context.get_dominant_itinerary_modifier(p1));
     context.shutdown();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parameters::{GlobalParams, Params, SettingProperties};
+    use crate::population_loader::Alive;
+    use crate::settings::SettingCategory;
+    use ixa::HashMap;
+
+    fn setup(
+        home_ratio: f64,
+        school_ratio: f64,
+        work_ratio: f64,
+        community_ratio: f64,
+    ) -> Context {
+        let mut context = Context::new();
+        let parameters = Params {
+            settings_properties: HashMap::from_iter(
+                [
+                    (SettingCategory::Home, SettingProperties { alpha: 0.0 }),
+                    (SettingCategory::School, SettingProperties { alpha: 0.0 }),
+                    (SettingCategory::Work, SettingProperties { alpha: 0.0 }),
+                    (SettingCategory::Community, SettingProperties { alpha: 0.0 }),
+                ]
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+            ),
+            itinerary_ratios: HashMap::from_iter([
+                (SettingCategory::Home, home_ratio),
+                (SettingCategory::School, school_ratio),
+                (SettingCategory::Work, work_ratio),
+                (SettingCategory::Community, community_ratio),
+            ]),
+            ..Default::default()
+        };
+        context
+            .set_global_property_value(GlobalParams, parameters)
+            .unwrap();
+        crate::settings::init(&mut context).unwrap();
+        context
+    }
+
+    #[test]
+    fn test_itinerary_modifier_registration() {
+        let mut context = setup(0.25, 0.25, 0.25, 0.25);
+        let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            }
+        };
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                school_closure_modifier,
+            );
+        let p1 = context.add_entity::<Person,_>((Age(10),)).unwrap();
+        let p2 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        let dominant_modifier_p1 = context.get_dominant_itinerary_modifier(p1);
+        let dominant_modifier_p2 = context.get_dominant_itinerary_modifier(p2);
+        assert_eq!(dominant_modifier_p1, None);
+        assert_eq!(dominant_modifier_p2, Some(school_closure_modifier));
+        println!("dominant modifier {:?}", context.get_dominant_itinerary_modifier(p1));
+    }
+
+    #[test]
+    fn test_itinerary_modifier_removal() {
+        let mut context = setup(0.25, 0.25, 0.25, 0.25);
+        let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            }
+        };
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                school_closure_modifier,
+            );
+        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+        // This would remove all age based itinerary modifiers that is not ideal.
+        context.remove_itinerary_modifier::<Age>();
+        assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
+    }
+
+    #[test]
+    fn test_itinerary_modifier_dominance() {
+        let mut context = setup(0.25, 0.25, 0.25, 0.25);
+        let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            }
+        };
+        let work_closure_modifier = ItineraryModifier {
+            ranking: 2,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.25, 0.0],
+            }
+        };
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                school_closure_modifier,
+            );
+        context
+            .register_itinerary_modifier(
+                Age(11),
+                work_closure_modifier,
+            );
+        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(work_closure_modifier));
+    }
+
+    #[test]
+    fn example_with_schools_and_weekends() {
+        let mut context = setup(0.25, 0.25, 0.25, 0.25);
+        let school_closure_modifier = ItineraryModifier {
+            ranking: 1,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.75, 0.0, 0.0, 0.25],
+            }
+        };
+
+        let weekend_modifier = ItineraryModifier {
+            ranking: 2,
+            itinerary_ratios: ItineraryRatios {
+                itinerary_ratios: [0.5, 0.0, 0.0, 0.5],
+            }
+        };
+        
+        let p1 = context.add_entity::<Person,_>((Age(11),)).unwrap();
+        context.add_plan(2.0, move |context| {
+            assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
+            context
+            .register_itinerary_modifier(
+                Age(11),
+                school_closure_modifier,
+            );
+            assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+        });
+
+        context.add_plan(4.0, move |context| {
+            context
+            .register_itinerary_modifier(
+                Alive(true),
+                weekend_modifier,
+            );
+            assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(weekend_modifier));
+        });
+        context.add_plan(6.0, move |context| {
+            context.remove_itinerary_modifier::<Alive>();
+            assert_eq!(context.get_dominant_itinerary_modifier(p1), Some(school_closure_modifier));
+        });
+
+        context.add_plan(8.0, move |context| {
+            context.remove_itinerary_modifier::<Age>();
+            assert_eq!(context.get_dominant_itinerary_modifier(p1), None);
+        });
+        context.execute();    
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod infection_importation;
 pub mod infection_propagation_loop;
 pub mod infectiousness_manager;
+pub mod itinerary_manager;
 pub mod model;
 pub mod natural_history_parameter_manager;
 pub mod parameters;
@@ -13,7 +14,6 @@ pub mod reports;
 mod setting_code;
 pub mod settings;
 pub mod symptom_status_manager;
-pub mod itinerary_manager;
 
 pub use model::initialize_model;
 pub use parameters::ContextParametersExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod reports;
 mod setting_code;
 pub mod settings;
 pub mod symptom_status_manager;
+pub mod itinerary_manager;
 
 pub use model::initialize_model;
 pub use parameters::ContextParametersExt;

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
-    abort_run, error::ModelError, infection_importation, infection_propagation_loop, parameters,
-    population_loader, reports, settings, symptom_status_manager,
+    abort_run, error::ModelError, infection_importation, infection_propagation_loop, itinerary_manager, parameters, population_loader, reports, settings, symptom_status_manager
 };
 
 pub fn initialize_model(
@@ -37,6 +36,7 @@ pub fn initialize_model(
     info!("Infection propagation loop initialized");
     infection_importation::init(context)?;
     info!("Infection importation initialized");
+    itinerary_manager::init(context);
     reports::init(context)?;
     info!("Reports initialized");
     abort_run::init(context);

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
-    abort_run, error::ModelError, infection_importation, infection_propagation_loop, parameters, population_loader, reports, settings, symptom_status_manager
+    abort_run, error::ModelError, infection_importation, infection_propagation_loop, parameters,
+    population_loader, reports, settings, symptom_status_manager,
 };
 
 pub fn initialize_model(

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
-    abort_run, error::ModelError, infection_importation, infection_propagation_loop, parameters,
-    population_loader, reports, settings, symptom_status_manager,
+    abort_run, error::ModelError, infection_importation, infection_propagation_loop, itinerary_manager, parameters, population_loader, reports, settings, symptom_status_manager
 };
 
 pub fn initialize_model(
@@ -37,6 +36,8 @@ pub fn initialize_model(
     info!("Infection propagation loop initialized");
     infection_importation::init(context)?;
     info!("Infection importation initialized");
+    itinerary_manager::init(context)?;
+    info!("Itinerary manager initialized");
     reports::init(context)?;
     info!("Reports initialized");
     abort_run::init(context);

--- a/src/model.rs
+++ b/src/model.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
-    abort_run, error::ModelError, infection_importation, infection_propagation_loop, itinerary_manager, parameters, population_loader, reports, settings, symptom_status_manager
+    abort_run, error::ModelError, infection_importation, infection_propagation_loop, parameters, population_loader, reports, settings, symptom_status_manager
 };
 
 pub fn initialize_model(
@@ -36,7 +36,6 @@ pub fn initialize_model(
     info!("Infection propagation loop initialized");
     infection_importation::init(context)?;
     info!("Infection importation initialized");
-    itinerary_manager::init(context);
     reports::init(context)?;
     info!("Reports initialized");
     abort_run::init(context);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,7 @@ use std::{
 };
 use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 
+use crate::itinerary_manager::ContextItineraryModifierExt;
 pub(crate) use crate::{
     ContextParametersExt, Params,
     error::ModelError,
@@ -126,7 +127,7 @@ impl ContextSettingExtPrivate for Context {}
 
 #[allow(private_bounds)]
 pub trait ContextSettingExt:
-    PluginContext + ContextEntitiesExt + ContextSettingExtPrivate + ContextParametersExt
+    PluginContext + ContextEntitiesExt + ContextSettingExtPrivate + ContextParametersExt + ContextItineraryModifierExt
 {
     fn register_setting_global_properties(&mut self) {
         let Params {
@@ -179,7 +180,7 @@ pub trait ContextSettingExt:
     ) -> Result<Vec<(SettingCode, f64, f64)>, ModelError> {
         let mut active_settings = Vec::new();
         let setting_ids = self.get_property::<Person, SettingIds>(person_id);
-        let itinerary_ratios = self.get_property::<Person, ItineraryRatios>(person_id);
+        let itinerary_ratios = self.get_dominant_itinerary_modifier_ratios(person_id);
 
         for category in SettingCategory::iter() {
             if let Some(id) = setting_ids.setting_ids[category] {


### PR DESCRIPTION
This PR connects the registered itinerary modifiers to settings and the infection propagation loop. A context extension method is implemented for the itinerary manager that returns the itinerary ratios of a person's dominate itinerary modifier. If there are no itinerary modifiers registered the person default itinerary ratios are returned. This implementation does not modify persons itinerary ratios person properties. 