### PR TITLE
hotfix: cache proportion data always and set test caching to true

### DIFF
--- a/.cache/state_population_data_2020.csv
+++ b/.cache/state_population_data_2020.csv
@@ -1,0 +1,53 @@
+state_name,state,population
+Pennsylvania,42,12794885
+California,6,39346023
+West Virginia,54,1807426
+Utah,49,3151239
+New York,36,19514849
+District of Columbia,11,701974
+Alaska,2,736990
+Florida,12,21216924
+South Carolina,45,5091517
+North Dakota,38,760394
+Maine,23,1340825
+Georgia,13,10516579
+Alabama,1,4893186
+New Hampshire,33,1355244
+Oregon,41,4176346
+Wyoming,56,581348
+Arizona,4,7174064
+Louisiana,22,4664616
+Indiana,18,6696893
+Idaho,16,1754367
+Connecticut,9,3570549
+Hawaii,15,1420074
+Illinois,17,12716164
+Massachusetts,25,6873003
+Texas,48,28635442
+Montana,30,1061705
+Nebraska,31,1923826
+Ohio,39,11675275
+Colorado,8,5684926
+New Jersey,34,8885418
+Maryland,24,6037624
+Virginia,51,8509358
+Vermont,50,624340
+North Carolina,37,10386227
+Arkansas,5,3011873
+Washington,53,7512465
+Kansas,20,2912619
+Oklahoma,40,3949342
+Wisconsin,55,5806975
+Mississippi,28,2981835
+Missouri,29,6124160
+Michigan,26,9973907
+Rhode Island,44,1057798
+Minnesota,27,5600166
+Iowa,19,3150011
+New Mexico,35,2097021
+Nevada,32,3030281
+Delaware,10,967679
+Puerto Rico,72,3255642
+Kentucky,21,4461952
+South Dakota,46,879336
+Tennessee,47,6772268

--- a/packages/importation/src/importation/geographies.py
+++ b/packages/importation/src/importation/geographies.py
@@ -39,7 +39,14 @@ def get_total_state_population_data(
         - The function uses the Census API and requires a valid API key.
         - Cached files are stored in the ".cache" directory with filenames in the format
           "state_population_data_<year>.csv".
+    Raises:
+        NotImplementedError: If the year is not 2020 or if caching is disabled, as population data
+            is currently only available for the year 2020 with caching.
     """
+    if year is None or year != 2020 or cache is False:
+        raise NotImplementedError(
+            "Population data is currently only avaialble as a cache for the year 2020. "
+        )
     filename = f"state_population_data_{year if year else 'latest'}.csv"
     filepath = Path(".cache") / filename
     if filepath.exists() and cache:

--- a/packages/importation/src/importation/geographies.py
+++ b/packages/importation/src/importation/geographies.py
@@ -42,7 +42,7 @@ def get_total_state_population_data(
     """
     filename = f"state_population_data_{year if year else 'latest'}.csv"
     filepath = Path(".cache") / filename
-    if filepath.exists():
+    if filepath.exists() and cache:
         return pl.read_csv(filepath)
     else:
         api_key = get_api_key()

--- a/packages/importation/tests/test_geographies.py
+++ b/packages/importation/tests/test_geographies.py
@@ -6,13 +6,13 @@ def test_get_state_proportion_population_data():
     state = "Alabama"
     year = 2020
     result = get_state_proportion_population_data(
-        state=state, year=year, cache=False
+        state=state, year=year, cache=True
     )
 
     for entry in ["Alabama", "alabama", "01", "AL", "al"]:
         assert (
             get_state_proportion_population_data(
-                state=entry, year=year, cache=False
+                state=entry, year=year, cache=True
             )
             == result
         )


### PR DESCRIPTION
We currently have no way to get the census data automatically due to API change requests being incompatible with `census` python package. This hotfix caches the state proporiton data used throughout the repo to ensure tests that fail related to this bug can pass