### PR TITLE
chore: method for fips code for the transmission report

### DIFF
--- a/src/pop_reader/fips_code.rs
+++ b/src/pop_reader/fips_code.rs
@@ -105,6 +105,19 @@ const ID_OFFSET: usize = 8;
 pub struct FIPSCode(NonZero<u64>);
 
 impl FIPSCode {
+    /// Converts the FIPSCode to a string in the same format as the Debug implementation.
+    #[must_use]
+    pub fn to_report_string(&self) -> String {
+        format!(
+            "{:02}-{:03}-{:06}-{:01}-{:05}-{:02x}",
+            self.state_code(),
+            self.county_code(),
+            self.census_tract_code(),
+            self.category_code(),
+            self.id(),
+            self.data()
+        )
+    }
     // region Constructors
     /// Constructs a new [`FIPSCode`] from a [`USState`]. Unlike the other constructors, this constructor is infallible.
     #[must_use]

--- a/src/reports/transmission_report.rs
+++ b/src/reports/transmission_report.rs
@@ -11,7 +11,7 @@ struct TransmissionReport {
     time: f64,
     target_id: PersonId,
     infected_by: Option<PersonId>,
-    infection_setting_id: Option<SettingCode>,
+    infection_setting_id: Option<String>,
 }
 
 define_report!(TransmissionReport);
@@ -22,6 +22,7 @@ fn record_transmission_event(
     infected_by: Option<PersonId>,
     infection_setting_id: Option<SettingCode>,
 ) {
+    let infection_setting_id = infection_setting_id.map(|code| code.0.to_report_string());
     if infected_by.is_some() {
         context.send_report(TransmissionReport {
             time: context.get_current_time(),
@@ -134,7 +135,10 @@ mod test {
             assert_almost_eq!(record.time, infection_time, 0.0);
             assert_eq!(record.target_id, target);
             assert_eq!(record.infected_by.unwrap(), source);
-            assert_eq!(record.infection_setting_id, setting);
+            assert_eq!(
+                record.infection_setting_id,
+                setting.map(|code| code.0.to_report_string())
+            );
             line_count += 1;
         }
         assert_eq!(line_count, 1);


### PR DESCRIPTION
This PR adds a method to make SettingCodes more meaningful in the transmission report. An alternative approach would be rewriting the display implementation for FIPSCodes, but not sure if we want to overwrite the call to displaying the expanded FIPSCode. 