### PR TITLE
chore: Bump ixa to beta2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,10 +35,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
+name = "alloca"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "android_system_properties"
@@ -122,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -134,16 +137,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
 
 [[package]]
 name = "bitflags"
@@ -165,6 +158,35 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"
@@ -213,7 +235,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -331,25 +353,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -357,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -429,19 +450,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.5.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
 name = "deflate64"
@@ -501,21 +515,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "either"
@@ -583,12 +582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,11 +598,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -644,7 +635,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -652,11 +643,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -669,12 +661,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -703,7 +689,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -743,17 +729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,9 +736,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -776,20 +751,17 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixa"
-version = "2.0.0-beta2.2"
+version = "2.0.0-beta2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233991a063d0373a2d5dbe3ee7ae6c3f725542c3317d053bdce5a7ead712e3fd"
+checksum = "fba5534d21b64403857cc701d43e49c47676a1c6acb6270dfcc92a64cca513e4"
 dependencies = [
  "approx",
- "bincode",
  "bytesize",
  "clap",
  "csv",
  "ctor",
  "delegate",
  "fern",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
  "humantime",
  "indexmap",
  "ixa-derive",
@@ -798,6 +770,7 @@ dependencies = [
  "ouroboros",
  "paste",
  "rand",
+ "rkyv",
  "rustc-hash",
  "seq-macro",
  "serde",
@@ -814,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "ixa-derive"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2377d465cd9978c98d2b6e51722ed70d2da5aef31d0e97a83bbaf638ad75497"
+checksum = "e6701ef6d8ccd173ee6614bfd63a5bbc1ce26efb0f8a38589ff87a7aeaec61e5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -889,6 +862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linktime-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +936,26 @@ name = "mock_instant"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ntapi"
@@ -1042,6 +1041,16 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1157,6 +1166,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1205,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -1264,6 +1302,45 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.0",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1404,6 +1481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallbox"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
@@ -1553,6 +1636,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,16 +1711,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -1780,37 +1882,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1821,19 +1909,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -1861,33 +1949,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -1896,16 +1969,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1914,7 +1978,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1923,16 +1987,16 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-ixa = { version = "2.0.0-beta2.2", default-features = false, features = ["logging"] }
+ixa = "2.0.0-beta2.4"
 rand_distr = "0.5.1"
 serde = "1.0.217"
 serde_json = "1.0.139"
@@ -24,14 +24,14 @@ smallvec = "1.15.1"
 strum = { version = "0.28.0", features = ["derive"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 
 [[bench]]
 name = "infection_loop"
 harness = false
 
 [features]
-default = ["profiling", "pop_reader_archive"]
+default = ["pop_reader_archive"]
 
 profiling = ["ixa/profiling"]
 

--- a/src/abort_run.rs
+++ b/src/abort_run.rs
@@ -46,8 +46,8 @@ mod test {
     #[test]
     fn test_abort_run() {
         let mut context = setup(true);
-        let person1 = context.add_entity::<Person, _>((Age(21),)).unwrap();
-        let _ = context.add_entity::<Person, _>((Age(22),)).unwrap();
+        let person1 = context.add_entity(with!(Person, Age(21))).unwrap();
+        let _ = context.add_entity(with!(Person, Age(22))).unwrap();
         context.add_plan(1.0, move |context| {
             context.set_property::<Person, SymptomData>(
                 person1,
@@ -60,7 +60,7 @@ mod test {
             );
         });
         context.add_plan(3.0, move |context| {
-            let _ = context.add_entity::<Person, _>((Age(23),)).unwrap();
+            let _ = context.add_entity(with!(Person, Age(23))).unwrap();
         });
         context.execute();
         assert_eq!(context.get_entity_count::<Person>(), 2);
@@ -70,8 +70,8 @@ mod test {
     #[test]
     fn test_continue_run() {
         let mut context = setup(false);
-        let person1 = context.add_entity::<Person, _>((Age(21),)).unwrap();
-        let _ = context.add_entity::<Person, _>((Age(22),)).unwrap();
+        let person1 = context.add_entity(with!(Person, Age(21))).unwrap();
+        let _ = context.add_entity(with!(Person, Age(22))).unwrap();
         context.add_plan(1.0, move |context| {
             context.set_property::<Person, SymptomData>(
                 person1,
@@ -84,7 +84,7 @@ mod test {
             );
         });
         context.add_plan(3.0, move |context| {
-            let _ = context.add_entity::<Person, _>((Age(23),)).unwrap();
+            let _ = context.add_entity(with!(Person, Age(23))).unwrap();
         });
         context.execute();
         assert_eq!(context.get_entity_count::<Person>(), 3);

--- a/src/infection_importation.rs
+++ b/src/infection_importation.rs
@@ -63,9 +63,9 @@ fn load_initial_prevalence(context: &mut Context) {
         trace!(
             "Altering {k} susceptibles with a seeding function using proportion {initial_prevalence}."
         );
-        let susceptibles = context.sample_entities::<Person, _, _>(
+        let susceptibles = context.sample_entities(
             ImportationRng,
-            (InfectionStatus::Susceptible,),
+            with!(Person, InfectionStatus::Susceptible),
             k as usize,
         );
         for susceptible in susceptibles {
@@ -77,7 +77,7 @@ fn load_initial_prevalence(context: &mut Context) {
 /// Receives a single line ImportationRecord struct and attempts to infect the specified imported infections count at time.
 fn plan_importations(context: &mut Context, imported_infections: usize, time: f64) {
     context.add_plan(time, move |context| {
-        let attempted_targets = context.sample_entities::<Person, _, _>(ImportationRng, (), imported_infections);
+        let attempted_targets = context.sample_entities(ImportationRng, Person, imported_infections);
 
         for target_id in attempted_targets {
             if context.get_property::<Person, InfectionStatus>(target_id) == InfectionStatus::Susceptible {
@@ -191,7 +191,7 @@ mod test {
     #[test]
     fn test_load_initial_prevalence() {
         let mut context = setup_context(0, 1.0, None);
-        let initial_infected: PersonId = context.add_entity((Age(30),)).unwrap();
+        let initial_infected: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         load_initial_prevalence(&mut context);
         // we check at time 0 to since individuals infections begin before time 0
         context.add_plan(0.0, move |context| {
@@ -206,7 +206,7 @@ mod test {
     #[test]
     fn test_load_initial_prevalence_empty() {
         let mut context = setup_context(0, 0.0, None);
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         load_initial_prevalence(&mut context);
         context.execute();
         assert_eq!(
@@ -226,12 +226,12 @@ mod test {
                 Rc::clone(&num_initial_infections);
             let mut context = setup_context(rep, initial_prevalence, None);
             for _ in 0..pop_size {
-                context.add_entity::<Person, _>((Age(30),)).unwrap();
+                context.add_entity(with!(Person, Age(30))).unwrap();
             }
             load_initial_prevalence(&mut context);
             context.add_plan(0.0, move |context| {
                 *num_initial_infections_clone.borrow_mut() +=
-                    context.query_entity_count::<Person, _>((InfectionStatus::Infectious,));
+                    context.query_entity_count(with!(Person, InfectionStatus::Infectious));
             });
             context.execute();
         }
@@ -253,12 +253,12 @@ mod test {
         let mut context = setup_context(0, 0.0, Some(imported_infections_info));
 
         for _ in 0..100 {
-            context.add_entity::<Person, _>((Age(30),)).unwrap();
+            context.add_entity(with!(Person, Age(30))).unwrap();
         }
         init(&mut context).unwrap();
         context.execute();
 
-        let infecteds = context.query_entity_count::<Person, _>((InfectionStatus::Infectious,));
+        let infecteds = context.query_entity_count(with!(Person, InfectionStatus::Infectious));
         let whole_population = context.get_entity_count::<Person>();
         assert_eq!(infecteds, whole_population);
     }
@@ -275,7 +275,7 @@ mod test {
         let mut context = setup_context(0, 1.0, Some(imported_infections_info));
 
         for _ in 0..100 {
-            context.add_entity::<Person, _>((Age(30),)).unwrap();
+            context.add_entity(with!(Person, Age(30))).unwrap();
         }
         init(&mut context).unwrap();
         context.subscribe_to_event(move |context, event: PropertyChangeEvent<Person, InfectionStatus>| {
@@ -286,7 +286,7 @@ mod test {
         context.add_plan(0.0, move |context| {
             // Everyone should be infectious at time 0.0 from initial prevalence 1.0
             assert_eq!(
-                context.query_entity_count::<Person, _>((InfectionStatus::Infectious,)),
+                context.query_entity_count(with!(Person, InfectionStatus::Infectious)),
                 100
             );
         });
@@ -304,7 +304,7 @@ mod test {
         let mut context = setup_context(0, 0.0, Some(imported_infections_info));
 
         for _ in 0..1000 {
-            context.add_entity::<Person, _>((Age(30),)).unwrap();
+            context.add_entity(with!(Person, Age(30))).unwrap();
         }
         init(&mut context).unwrap();
 
@@ -324,7 +324,7 @@ mod test {
         context.add_plan(1.0, move |context| {
             // At time 1.0, we should have 2 infections from the import file
             assert_eq!(
-                context.query_entity_count::<Person, _>((InfectionStatus::Infectious,)),
+                context.query_entity_count(with!(Person, InfectionStatus::Infectious)),
                 2
             );
         });
@@ -332,7 +332,7 @@ mod test {
         context.add_plan(3.0, move |context| {
             // At time 3.0, we should have 3 additional infections from the import file (5 total)
             assert_eq!(
-                context.query_entity_count::<Person, _>((InfectionStatus::Infectious,)),
+                context.query_entity_count(with!(Person, InfectionStatus::Infectious)),
                 5
             );
         });

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -161,7 +161,7 @@ mod test {
     fn test_init_loop() {
         let mut context = setup_context(42, 1.0, 1.0, 5.0);
         for _ in 0..10 {
-            context.add_entity::<Person, _>((Age(30),)).unwrap();
+            context.add_entity(with!(Person, Age(30))).unwrap();
         }
 
         init(&mut context).unwrap();
@@ -171,11 +171,13 @@ mod test {
         context.add_plan_with_phase(
             0.0,
             move |context| {
-                assert!(
-                    !context.query_entity_count::<Person, _>((InfectionStatus::Infectious,)) == 0
+                assert_eq!(
+                    !context.query_entity_count(with!(Person, InfectionStatus::Infectious)),
+                    0
                 );
-                assert!(
-                    !context.query_entity_count::<Person, _>((InfectionStatus::Recovered,)) == 0
+                assert_eq!(
+                    !context.query_entity_count(with!(Person, InfectionStatus::Recovered)),
+                    0
                 );
             },
             ExecutionPhase::Last,
@@ -187,7 +189,7 @@ mod test {
         let mut context = setup_context(0, 0.0, 1.0, 5.0);
         // Add people -- a lot so we can show that no new infections are added
         for _ in 0..1000 {
-            context.add_entity::<Person, _>((Age(30),)).unwrap();
+            context.add_entity(with!(Person, Age(30))).unwrap();
         }
 
         init(&mut context).unwrap();
@@ -197,9 +199,9 @@ mod test {
         let num_initial_infections_clone = Rc::clone(&num_initial_infections);
 
         context.add_plan(0.0, move |context| {
-            let susceptibles = context.sample_entities::<Person, _, _>(
+            let susceptibles = context.sample_entities(
                 InfectionRng,
-                (InfectionStatus::Susceptible,),
+                with!(Person, InfectionStatus::Susceptible),
                 *num_initial_infections_clone.borrow(),
             );
             for person in susceptibles {
@@ -208,7 +210,7 @@ mod test {
             // Count the number of initial infections and recovered actually created from the binomial
             // sampling
             *num_initial_infections_clone.borrow_mut() =
-                context.query_entity_count::<Person, _>((InfectionStatus::Infectious,));
+                context.query_entity_count(with!(Person, InfectionStatus::Infectious));
         });
 
         // We want to count the number of new infections that are created to ensure this is equal to
@@ -237,7 +239,7 @@ mod test {
 
         // And that recovereds is equal to the initial infectious (who have recovered) + recovered
         assert_eq!(
-            context.query_entity_count::<Person, _>((InfectionStatus::Recovered,)),
+            context.query_entity_count(with!(Person, InfectionStatus::Recovered)),
             *num_initial_infections.borrow(),
         );
     }
@@ -276,14 +278,14 @@ mod test {
             // We only run the simulation for 1.0 time units.
             context.add_plan_with_phase(1.0, ixa::Context::shutdown, ExecutionPhase::Last);
             // Add a a person who will get infected.
-            let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+            let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
             set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
             // We don't want infectious people beyond our index case to be able to transmit, so we
             // have to do setup on our own since just calling `init` will trigger a watcher for
             // people becoming infectious that lets them transmit.
             load_rate_fns(&mut context).unwrap();
             // Add our infectious fellow.
-            let infectious_person: PersonId = context.add_entity((Age(30),)).unwrap();
+            let infectious_person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
             set_homogeneous_mixing_itinerary(&mut context, infectious_person).unwrap();
 
             context.infect_person(infectious_person, None, None);
@@ -360,7 +362,7 @@ mod test {
         // Create a simulation with an infected person and schedule their recovery.
         let mut context = setup_context(0, 0.0, 1.0, 5.0);
         load_rate_fns(&mut context).unwrap();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context.infect_person(person, None, None);
         // For later, we need to get the recovery time from the rate function.
         context.execute();
@@ -418,10 +420,13 @@ mod test {
                 let mut context = setup_context(seed, rate, alpha, 5.0);
 
                 // Add a a person who will get infected.
-                let infectious_person: PersonId = context.add_entity((Age(30),)).unwrap();
-                let person_home: PersonId = context.add_entity((Age(30),)).unwrap();
-                let person_censustract: PersonId = context.add_entity((Age(30),)).unwrap();
-                let person_workplace: PersonId = context.add_entity((Age(30),)).unwrap();
+                let infectious_person: PersonId =
+                    context.add_entity(with!(Person, Age(30))).unwrap();
+                let person_home: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
+                let person_censustract: PersonId =
+                    context.add_entity(with!(Person, Age(30))).unwrap();
+                let person_workplace: PersonId =
+                    context.add_entity(with!(Person, Age(30))).unwrap();
 
                 context.add_person_to_settings(person_home, Some(home_code), None, None, None);
                 context.add_person_to_settings(
@@ -527,7 +532,7 @@ mod test {
             context.init_random(seed);
             // Add our people
             for _ in 0..num_people {
-                context.add_entity::<Person, _>((Age(30),)).unwrap();
+                context.add_entity(with!(Person, Age(30))).unwrap();
             }
             init(&mut context).unwrap();
             // Add a plan to shutdown after the seeding so we can count infected and recovereds
@@ -535,7 +540,7 @@ mod test {
             context.execute();
             // Count number of initial infections and recovereds
             num_initial_infections +=
-                context.query_entity_count::<Person, _>((InfectionStatus::Infectious,));
+                context.query_entity_count(with!(Person, InfectionStatus::Infectious));
         }
         // Check that the proportion of people is close to the expected proportion
         assert_almost_eq!(

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -1,6 +1,7 @@
-use ixa::{impl_derived_property, prelude::*};
+use ixa::prelude::*;
 use rand_distr::Exp;
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 use crate::{
     population_loader::PersonId,
@@ -12,7 +13,7 @@ use crate::population_loader::Person;
 
 use ixa::profiling::{increment_named_count, open_span};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum InfectionData {
     Susceptible,
     Infectious {
@@ -26,21 +27,83 @@ pub enum InfectionData {
     },
 }
 
+impl PartialEq for InfectionData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Susceptible, Self::Susceptible) => true,
+            (
+                Self::Infectious {
+                    infection_time,
+                    infected_by,
+                    infection_setting_id,
+                },
+                Self::Infectious {
+                    infection_time: other_infection_time,
+                    infected_by: other_infected_by,
+                    infection_setting_id: other_infection_setting_id,
+                },
+            ) => {
+                infection_time.to_bits() == other_infection_time.to_bits()
+                    && infected_by == other_infected_by
+                    && infection_setting_id == other_infection_setting_id
+            }
+            (
+                Self::Recovered {
+                    infection_time,
+                    recovery_time,
+                },
+                Self::Recovered {
+                    infection_time: other_infection_time,
+                    recovery_time: other_recovery_time,
+                },
+            ) => {
+                infection_time.to_bits() == other_infection_time.to_bits()
+                    && recovery_time.to_bits() == other_recovery_time.to_bits()
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for InfectionData {}
+
+impl Hash for InfectionData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Susceptible => {}
+            Self::Infectious {
+                infection_time,
+                infected_by,
+                infection_setting_id,
+            } => {
+                infection_time.to_bits().hash(state);
+                infected_by.hash(state);
+                infection_setting_id.hash(state);
+            }
+            Self::Recovered {
+                infection_time,
+                recovery_time,
+            } => {
+                infection_time.to_bits().hash(state);
+                recovery_time.to_bits().hash(state);
+            }
+        }
+    }
+}
+
 impl_property!(
     InfectionData,
     Person,
     default_const = InfectionData::Susceptible
 );
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy, Hash, Eq)]
-pub enum InfectionStatus {
-    Susceptible,
-    Infectious,
-    Recovered,
-}
-
-impl_derived_property!(
-    InfectionStatus,
+define_derived_property!(
+    enum InfectionStatus {
+        Susceptible,
+        Infectious,
+        Recovered,
+    },
     Person,
     [InfectionData],
     [],
@@ -273,7 +336,7 @@ mod test {
     #[test]
     fn test_infect_person() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context.add_plan(2.0, move |context| {
             context.infect_person(p1, None, None);
         });
@@ -290,7 +353,7 @@ mod test {
     #[test]
     fn test_recover_person() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context.add_plan(2.0, move |context| {
             context.infect_person(p1, None, None);
         });
@@ -312,7 +375,7 @@ mod test {
     #[test]
     fn test_get_elapsed_infection_time() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context.add_plan(2.0, move |context| {
             context.infect_person(p1, None, None);
         });
@@ -327,7 +390,7 @@ mod test {
     #[test]
     fn test_calc_total_infectiousness_multiplier() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
 
         assert_almost_eq!(max_total_infectiousness_multiplier(&context, p1), 0.0, 0.0);
     }
@@ -335,9 +398,9 @@ mod test {
     #[test]
     fn test_calc_total_infectiousness_multiplier_with_contact() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
-        let p2: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p2: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p2).unwrap();
 
         assert_almost_eq!(max_total_infectiousness_multiplier(&context, p1), 1.0, 0.0);
@@ -348,12 +411,12 @@ mod test {
     /// Test has potential to stochastically fail if exponential draw is longer than infectious duration
     fn test_forecast() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
         // Add two additional contacts, which should make the factor 2
-        let p2: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p2: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p2).unwrap();
-        let p3: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p3: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p3).unwrap();
 
         context.infect_person(p1, None, None);
@@ -367,11 +430,11 @@ mod test {
     #[should_panic = "Person 0: Forecasted infectiousness must always be greater than or equal to current infectiousness. Current: 1, Forecasted: 0.9"]
     fn test_assert_evaluate_fails_when_forecast_smaller() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
         context.infect_person(p1, None, None);
         // We need to add another person so that our total infectiousness is 1.
-        let p2: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p2: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p2).unwrap();
 
         let invalid_forecast = 1.0 - 0.1;
@@ -381,10 +444,10 @@ mod test {
     #[test]
     fn test_evaluate_still_succeeds_when_forecast_slightly_bigger() {
         let mut context = setup_context();
-        let p1: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p1: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p1).unwrap();
         context.infect_person(p1, None, None);
-        let p2: PersonId = context.add_entity((Age(30),)).unwrap();
+        let p2: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         set_homogeneous_mixing_itinerary(&mut context, p2).unwrap();
 
         let still_valid_forecast = 1.0 - 9e-11;
@@ -394,8 +457,8 @@ mod test {
     #[test]
     fn test_infected_options() {
         let mut context = setup_context();
-        let index: PersonId = context.add_entity((Age(30),)).unwrap();
-        let contact: PersonId = context.add_entity((Age(30),)).unwrap();
+        let index: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
+        let contact: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         let home_id = SettingCode::arbitrary_home_code();
         let infection_setting_id = Some(home_id);
         context.infect_person(contact, Some(index), infection_setting_id);

--- a/src/natural_history_parameter_manager.rs
+++ b/src/natural_history_parameter_manager.rs
@@ -143,11 +143,11 @@ mod test {
 
     use ixa::prelude::*;
 
-    use crate::{Age, error::ModelError, population_loader::PersonId};
-
     use super::{
         ContextNaturalHistoryParameterExt, NaturalHistoryParameterLibrary, NaturalHistoryParameters,
     };
+    use crate::population_loader::Person;
+    use crate::{Age, error::ModelError, population_loader::PersonId};
 
     struct ViralLoad;
 
@@ -166,7 +166,7 @@ mod test {
     #[test]
     fn test_register_vanilla_parameter_id_assignment() {
         let mut context = init_context();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context
             .register_parameter_id_assigner(ViralLoad, |_context, _person_id| 0)
             .unwrap();
@@ -217,7 +217,7 @@ mod test {
     #[test]
     fn test_error_register_assignment_after_querying() {
         let mut context = init_context();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         // We have to register something to make sure the data container exists.
         context
             .register_parameter_id_assigner(ViralLoad, |_context, _person_id| 0)
@@ -248,7 +248,7 @@ mod test {
     #[test]
     fn test_get_parameter_id_registered_assignment() {
         let mut context = init_context();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context
             .register_parameter_id_assigner(ViralLoad, |_context, _person_id| 0)
             .unwrap();
@@ -259,7 +259,7 @@ mod test {
     #[test]
     fn test_get_parameter_id_already_set() {
         let mut context = init_context();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         let container = context.get_data_mut(NaturalHistoryParameters);
         container.ids.borrow_mut().insert(
             TypeId::of::<ViralLoad>(),
@@ -288,7 +288,7 @@ mod test {
     #[test]
     fn test_get_parameter_id_assignment_has_dependencies() {
         let mut context = init_context();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         context
             .register_parameter_id_assigner(CulturePositivity, |context, person_id| {
                 context.get_parameter_id(TestingPatterns, person_id)

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -81,7 +81,7 @@ pub struct Params {
 }
 
 #[allow(clippy::too_many_lines)]
-fn validate_inputs(parameters: &Params) -> Result<(), Box<dyn std::error::Error>> {
+fn validate_inputs(parameters: &Params) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if parameters.max_time < 0.0 {
         return Err(Box::new(ModelError::ModelError(
             "The max simulation running time must be non-negative.".to_string(),

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,6 +1,7 @@
 use ixa::{impl_derived_property, prelude::*, profiling::open_span};
 
 use serde::Serialize;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use crate::error::ModelError;
@@ -22,11 +23,34 @@ impl_property!(Age, Person);
 pub struct Alive(pub bool);
 impl_property!(Alive, Person, default_const = Alive(true));
 
-#[derive(Debug, PartialEq, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub struct Itinerary {
     pub setting_ids: [Option<SettingCode>; SETTING_COUNT],
     pub itinerary_ratios: [f64; SETTING_COUNT],
 }
+
+impl PartialEq for Itinerary {
+    fn eq(&self, other: &Self) -> bool {
+        self.setting_ids == other.setting_ids
+            && self
+                .itinerary_ratios
+                .iter()
+                .zip(other.itinerary_ratios.iter())
+                .all(|(left, right)| left.to_bits() == right.to_bits())
+    }
+}
+
+impl Eq for Itinerary {}
+
+impl Hash for Itinerary {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.setting_ids.hash(state);
+        self.itinerary_ratios
+            .iter()
+            .for_each(|ratio| ratio.to_bits().hash(state));
+    }
+}
+
 impl_property!(
     Itinerary,
     Person,
@@ -71,7 +95,9 @@ fn create_person_from_record(
     let home_id = SettingCode(home_id);
     let community_id = home_id.extract_community();
 
-    let person_id: PersonId = context.add_entity((Age(person_record.age),)).unwrap();
+    let person_id: PersonId = context
+        .add_entity(with!(Person, Age(person_record.age)))
+        .unwrap();
     context.add_person_to_settings(
         person_id,
         Some(home_id),
@@ -191,8 +217,8 @@ mod test {
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
 
-        for item in age.iter().take(1) {
-            assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
+        for item in age.iter() {
+            assert_eq!(1, context.query_entity_count(with!(Person, Age(*item))));
         }
         let home_id1 = home_id[0];
         let home_id2 = home_id[1];
@@ -246,8 +272,8 @@ mod test {
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
 
-        for item in age.iter().take(1) {
-            assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
+        for item in age.iter() {
+            assert_eq!(1, context.query_entity_count(with!(Person, Age(*item))));
         }
         assert_eq!(1, context.get_setting_size(home_id[0]));
         assert_eq!(1, context.get_setting_size(home_id[1]));
@@ -280,8 +306,8 @@ mod test {
 
         assert_eq!(context.get_entity_count::<Person>(), 2);
 
-        for item in age.iter().take(1) {
-            assert_eq!(1, context.query_entity_count::<Person, _>((Age(*item),)));
+        for item in age.iter() {
+            assert_eq!(1, context.query_entity_count(with!(Person, Age(*item))));
         }
         assert_eq!(1, context.get_setting_size(home_id[0]));
         assert_eq!(1, context.get_setting_size(home_id[1]));

--- a/src/rate_fns/rate_fn_storage.rs
+++ b/src/rate_fns/rate_fn_storage.rs
@@ -73,7 +73,9 @@ mod test {
     };
 
     use super::*;
+    use crate::population_loader::Person;
     use ixa::assert_almost_eq;
+
     struct TestRateFn;
 
     impl InfectiousnessRateFn for TestRateFn {
@@ -107,7 +109,7 @@ mod test {
     #[test]
     fn test_add_rate_fn_and_get_random() {
         let mut context = init_context();
-        let person: PersonId = context.add_entity((Age(30),)).unwrap();
+        let person: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
 
         let rate_fn = TestRateFn {};
         context.add_rate_fn(rate_fn);

--- a/src/reports/aggregated_deaths_report.rs
+++ b/src/reports/aggregated_deaths_report.rs
@@ -117,8 +117,8 @@ mod test {
         config.directory(path.clone());
         crate::reports::init(&mut context).unwrap();
 
-        let _survivor: PersonId = context.add_entity((Age(42),)).unwrap();
-        let target: PersonId = context.add_entity((Age(43),)).unwrap();
+        let _survivor: PersonId = context.add_entity(with!(Person, Age(42))).unwrap();
+        let target: PersonId = context.add_entity(with!(Person, Age(43))).unwrap();
         let time_of_death = 1.0;
 
         context.add_plan(time_of_death, move |context| {

--- a/src/reports/incidence_report.rs
+++ b/src/reports/incidence_report.rs
@@ -224,8 +224,8 @@ mod test {
         let config = context.report_options();
         config.directory(path.clone());
 
-        let source: PersonId = context.add_entity((Age(42),)).unwrap();
-        let target: PersonId = context.add_entity((Age(43),)).unwrap();
+        let source: PersonId = context.add_entity(with!(Person, Age(42))).unwrap();
+        let target: PersonId = context.add_entity(with!(Person, Age(43))).unwrap();
         let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;
@@ -283,8 +283,8 @@ mod test {
         let config = context.report_options();
         config.directory(path.clone());
 
-        let source: PersonId = context.add_entity((Age(42),)).unwrap();
-        let target: PersonId = context.add_entity((Age(43),)).unwrap();
+        let source: PersonId = context.add_entity(with!(Person, Age(42))).unwrap();
+        let target: PersonId = context.add_entity(with!(Person, Age(43))).unwrap();
         let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;

--- a/src/reports/prevalence_report.rs
+++ b/src/reports/prevalence_report.rs
@@ -79,7 +79,7 @@ pub fn init(context: &mut Context, file_name: &str, period: f64) -> Result<(), M
 
     let mut map_counts = HashMap::default();
 
-    context.with_query_results::<Person, _>((Alive(true),), &mut |current_people| {
+    context.with_query_results(with!(Person, Alive(true)), &mut |current_people| {
         //current_people = results.to_owned_vec();
         for person in current_people {
             let value: (Age, InfectionStatus, SymptomStatus) = context.get_property(person);
@@ -109,6 +109,7 @@ pub fn init(context: &mut Context, file_name: &str, period: f64) -> Result<(), M
 
 #[cfg(test)]
 mod test {
+    use crate::population_loader::Person;
     use crate::{
         Age,
         infectiousness_manager::{InfectionContextExt, InfectionStatus},
@@ -152,8 +153,8 @@ mod test {
         let config = context.report_options();
         config.directory(path.clone());
 
-        let source: PersonId = context.add_entity((Age(42),)).unwrap();
-        let target: PersonId = context.add_entity((Age(43),)).unwrap();
+        let source: PersonId = context.add_entity(with!(Person, Age(42))).unwrap();
+        let target: PersonId = context.add_entity(with!(Person, Age(43))).unwrap();
         let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;

--- a/src/reports/transmission_report.rs
+++ b/src/reports/transmission_report.rs
@@ -53,6 +53,7 @@ pub fn init(context: &mut Context, file_name: &str) -> Result<(), ModelError> {
 
 #[cfg(test)]
 mod test {
+    use crate::population_loader::Person;
     use crate::{
         Age,
         infectiousness_manager::InfectionContextExt,
@@ -64,7 +65,7 @@ mod test {
     };
     use ixa::{
         Context, ContextEntitiesExt, ContextGlobalPropertiesExt, ContextRandomExt,
-        ContextReportExt, assert_almost_eq, csv,
+        ContextReportExt, assert_almost_eq, csv, with,
     };
     use std::path::PathBuf;
     use tempfile::tempdir;
@@ -99,8 +100,8 @@ mod test {
         let config = context.report_options();
         config.directory(path.clone());
 
-        let source: PersonId = context.add_entity((Age(30),)).unwrap();
-        let target: PersonId = context.add_entity((Age(30),)).unwrap();
+        let source: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
+        let target: PersonId = context.add_entity(with!(Person, Age(30))).unwrap();
         let home: SettingCode = SettingCode::arbitrary_home_code();
         let setting = Some(home);
         let infection_time = 1.0;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -252,9 +252,22 @@ pub trait ContextSettingExt:
     }
 
     fn calculate_multiplier(&self, setting: SettingCode) -> Result<f64, ModelError> {
-        let size = self.get_setting_size(setting) as f64 - 1.0;
         let alpha = self.get_setting_alpha(setting.category())?;
-        Ok(size.powf(alpha))
+        match alpha {
+            0.0 => {
+                // (n-1)^0 = 1
+                Ok(1.0)
+            }
+            1.0 => {
+                let size = self.get_setting_size(setting);
+                Ok((size - 1) as f64)
+            }
+            alpha => {
+                let size = self.get_setting_size(setting);
+                let size = (size - 1) as f64;
+                Ok(size.powf(alpha))
+            }
+        }
     }
 
     fn sample_active_setting(&self, person_id: PersonId) -> Result<SettingCode, ModelError> {
@@ -432,9 +445,9 @@ mod test {
         let community_code = home_code.extract_community();
         let work_code = SettingCode::arbitrary_workplace_code();
 
-        let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
-        let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
-        let person3 = context.add_entity::<Person, _>((Age(22),)).unwrap();
+        let person1 = context.add_entity(with!(Person, Age(20))).unwrap();
+        let person2 = context.add_entity(with!(Person, Age(21))).unwrap();
+        let person3 = context.add_entity(with!(Person, Age(22))).unwrap();
         context.add_person_to_settings(person1, Some(home_code), None, None, Some(community_code));
         context.add_person_to_settings(person2, Some(home_code), None, None, Some(community_code));
         context.add_person_to_settings(person3, None, Some(work_code), None, None);
@@ -450,7 +463,7 @@ mod test {
     #[test]
     fn test_sample_person_from_home() {
         let mut context = setup_test_context(0.0);
-        let person_id = context.add_entity::<Person, _>((Age(20),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(20))).unwrap();
         context.add_person_to_settings(
             person_id,
             Some(make_home_id(b"160379602000011")),
@@ -466,7 +479,7 @@ mod test {
     #[test]
     fn test_sample_person_from_work() {
         let mut context = setup_test_context(0.0);
-        let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(30))).unwrap();
         context.add_person_to_settings(
             person_id,
             None,
@@ -482,7 +495,7 @@ mod test {
     #[test]
     fn test_sample_person_from_school() {
         let mut context = setup_test_context(0.0);
-        let person_id = context.add_entity::<Person, _>((Age(10),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(10))).unwrap();
         context.add_person_to_settings(
             person_id,
             None,
@@ -501,7 +514,7 @@ mod test {
     #[test]
     fn test_sample_person_from_community() {
         let mut context = setup_test_context(0.0);
-        let person_id = context.add_entity::<Person, _>((Age(40),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(40))).unwrap();
         context.add_person_to_settings(
             person_id,
             None,
@@ -521,8 +534,8 @@ mod test {
     fn test_get_setting_size() {
         let mut context = setup_test_context(0.0);
         let home_id = SettingCode::arbitrary_home_code();
-        let person1 = context.add_entity::<Person, _>((Age(20),)).unwrap();
-        let person2 = context.add_entity::<Person, _>((Age(21),)).unwrap();
+        let person1 = context.add_entity(with!(Person, Age(20))).unwrap();
+        let person2 = context.add_entity(with!(Person, Age(21))).unwrap();
         assign_person_settings(&mut context, person1, &[home_id], [1.0, 0.0, 0.0, 0.0]);
         assign_person_settings(&mut context, person2, &[home_id], [1.0, 0.0, 0.0, 0.0]);
         let size = context.get_setting_size(home_id);
@@ -540,7 +553,7 @@ mod test {
     fn test_get_active_settings_for_person() {
         let mut context = setup_test_context(0.5);
         let home_id = SettingCode::arbitrary_home_code();
-        let person_id = context.add_entity::<Person, _>((Age(22),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(22))).unwrap();
         assign_person_settings(&mut context, person_id, &[home_id], [0.25, 0.0, 0.0, 0.0]);
         let active = context.get_active_settings_for_person(person_id).unwrap();
         assert_eq!(active.len(), 1);
@@ -555,9 +568,9 @@ mod test {
         let mut context = setup_test_context(alpha);
         let home_id = SettingCode::arbitrary_home_code();
         let work_id = home_id.as_arbitrary_workplace_code();
-        let p1 = context.add_entity::<Person, _>((Age(23),)).unwrap();
-        let p2 = context.add_entity::<Person, _>((Age(23),)).unwrap();
-        let p3 = context.add_entity::<Person, _>((Age(23),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(23))).unwrap();
+        let p2 = context.add_entity(with!(Person, Age(23))).unwrap();
+        let p3 = context.add_entity(with!(Person, Age(23))).unwrap();
         assign_person_settings(&mut context, p1, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
         assign_person_settings(&mut context, p2, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
         assign_person_settings(&mut context, p3, &[home_id], [1.0, 0.0, 0.0, 0.0]);
@@ -574,8 +587,8 @@ mod test {
         let mut context = setup_test_context(alpha);
         let home_id = SettingCode::arbitrary_home_code();
         let work_id = home_id.as_arbitrary_workplace_code();
-        let p1 = context.add_entity::<Person, _>((Age(24),)).unwrap();
-        let p2 = context.add_entity::<Person, _>((Age(24),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(24))).unwrap();
+        let p2 = context.add_entity(with!(Person, Age(24))).unwrap();
         assign_person_settings(&mut context, p1, &[home_id, work_id], [0.5, 0.5, 0.0, 0.0]);
         assign_person_settings(&mut context, p2, &[home_id], [1.0, 0.0, 0.0, 0.0]);
         let val = context.calculate_max_infectiousness_multiplier_for_person(p1);
@@ -587,7 +600,7 @@ mod test {
     fn test_sample_person_from_setting() {
         let mut context = setup_test_context(0.0);
         let comm_id = SettingCode::arbitrary_home_code().extract_community();
-        let person_id = context.add_entity::<Person, _>((Age(25),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(25))).unwrap();
         assign_person_settings(&mut context, person_id, &[comm_id], [0.0, 0.0, 0.0, 1.0]);
         let sampled = context.sample_person_from_setting(comm_id).unwrap();
         assert_eq!(sampled, person_id);
@@ -597,8 +610,8 @@ mod test {
     fn test_sample_from_setting_with_exclusion() {
         let mut context = setup_test_context(0.0);
         let work_id = SettingCode::arbitrary_workplace_code();
-        let p1 = context.add_entity::<Person, _>((Age(26),)).unwrap();
-        let p2 = context.add_entity::<Person, _>((Age(27),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(26))).unwrap();
+        let p2 = context.add_entity(with!(Person, Age(27))).unwrap();
         assign_person_settings(&mut context, p1, &[work_id], [0.0, 1.0, 0.0, 0.0]);
         assign_person_settings(&mut context, p2, &[work_id], [0.0, 1.0, 0.0, 0.0]);
         let sampled = context
@@ -611,7 +624,7 @@ mod test {
     fn test_sample_active_setting() {
         let mut context = setup_test_context(0.0);
         let home_id = SettingCode::arbitrary_home_code();
-        let person_id = context.add_entity::<Person, _>((Age(30),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(30))).unwrap();
         assign_person_settings(&mut context, person_id, &[home_id], [1.0, 0.0, 0.0, 0.0]);
         let sampled = context.sample_active_setting(person_id).unwrap();
         assert_eq!(sampled, home_id);
@@ -620,7 +633,7 @@ mod test {
     #[test]
     fn test_add_person_to_setting_and_add_index_setting() {
         let mut context = setup_test_context(0.0);
-        let person_id = context.add_entity::<Person, _>((Age(31),)).unwrap();
+        let person_id = context.add_entity(with!(Person, Age(31))).unwrap();
         let setting_code = make_home_id(b"160379602000010");
         context.add_person_to_settings(person_id, Some(setting_code), None, None, None);
         let home_id = context.get_property::<Person, HomeId>(person_id).0.unwrap();

--- a/src/symptom_status_manager.rs
+++ b/src/symptom_status_manager.rs
@@ -1,10 +1,11 @@
 use ixa::{
     Context, ContextEntitiesExt, ContextGlobalPropertiesExt, ContextRandomExt, IxaError,
-    define_rng, impl_derived_property, impl_property, prelude::PropertyChangeEvent,
+    define_derived_property, define_rng, impl_property, prelude::PropertyChangeEvent,
 };
 use rand_distr::LogNormal;
 use serde::{Deserialize, Serialize};
 use std::cmp::{Ordering, PartialOrd};
+use std::hash::{Hash, Hasher};
 
 use crate::{
     Age, ContextParametersExt, Params, error::ModelError, infectiousness_manager::InfectionStatus,
@@ -13,7 +14,8 @@ use crate::{
 
 define_rng!(SymptomsRng);
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+// The `SymptomData` enum type is
+#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 pub enum SymptomData {
     NoSymptoms,
     Mild {
@@ -42,20 +44,158 @@ pub enum SymptomData {
     },
 }
 
-impl_property!(SymptomData, Person, default_const = SymptomData::NoSymptoms);
-
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
-pub enum SymptomStatus {
-    NoSymptoms,
-    Mild,
-    Severe,
-    Critical,
-    Resolved,
-    Dead,
+impl PartialEq for SymptomData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::NoSymptoms, Self::NoSymptoms) => true,
+            (
+                Self::Mild { mild_time },
+                Self::Mild {
+                    mild_time: other_mild_time,
+                },
+            ) => mild_time.to_bits() == other_mild_time.to_bits(),
+            (
+                Self::Severe {
+                    mild_time,
+                    severe_time,
+                },
+                Self::Severe {
+                    mild_time: other_mild_time,
+                    severe_time: other_severe_time,
+                },
+            ) => {
+                mild_time.to_bits() == other_mild_time.to_bits()
+                    && severe_time.to_bits() == other_severe_time.to_bits()
+            }
+            (
+                Self::Critical {
+                    mild_time,
+                    severe_time,
+                    critical_time,
+                },
+                Self::Critical {
+                    mild_time: other_mild_time,
+                    severe_time: other_severe_time,
+                    critical_time: other_critical_time,
+                },
+            ) => {
+                mild_time.to_bits() == other_mild_time.to_bits()
+                    && severe_time.to_bits() == other_severe_time.to_bits()
+                    && critical_time.to_bits() == other_critical_time.to_bits()
+            }
+            (
+                Self::Resolved {
+                    mild_time,
+                    severe_time,
+                    critical_time,
+                    resolved_time,
+                },
+                Self::Resolved {
+                    mild_time: other_mild_time,
+                    severe_time: other_severe_time,
+                    critical_time: other_critical_time,
+                    resolved_time: other_resolved_time,
+                },
+            ) => {
+                mild_time.to_bits() == other_mild_time.to_bits()
+                    && severe_time.as_ref().map(|time| time.to_bits())
+                        == other_severe_time.as_ref().map(|time| time.to_bits())
+                    && critical_time.as_ref().map(|time| time.to_bits())
+                        == other_critical_time.as_ref().map(|time| time.to_bits())
+                    && resolved_time.to_bits() == other_resolved_time.to_bits()
+            }
+            (
+                Self::Dead {
+                    mild_time,
+                    severe_time,
+                    critical_time,
+                    dead_time,
+                },
+                Self::Dead {
+                    mild_time: other_mild_time,
+                    severe_time: other_severe_time,
+                    critical_time: other_critical_time,
+                    dead_time: other_dead_time,
+                },
+            ) => {
+                mild_time.to_bits() == other_mild_time.to_bits()
+                    && severe_time.to_bits() == other_severe_time.to_bits()
+                    && critical_time.to_bits() == other_critical_time.to_bits()
+                    && dead_time.to_bits() == other_dead_time.to_bits()
+            }
+            _ => false,
+        }
+    }
 }
 
-impl_derived_property!(
-    SymptomStatus,
+impl Eq for SymptomData {}
+
+impl Hash for SymptomData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // This makes the hash distinguish between different variants that happen to have the same
+        // data payload.
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::NoSymptoms => {}
+            Self::Mild { mild_time } => {
+                mild_time.to_bits().hash(state);
+            }
+            Self::Severe {
+                mild_time,
+                severe_time,
+            } => {
+                mild_time.to_bits().hash(state);
+                severe_time.to_bits().hash(state);
+            }
+            Self::Critical {
+                mild_time,
+                severe_time,
+                critical_time,
+            } => {
+                mild_time.to_bits().hash(state);
+                severe_time.to_bits().hash(state);
+                critical_time.to_bits().hash(state);
+            }
+            Self::Resolved {
+                mild_time,
+                severe_time,
+                critical_time,
+                resolved_time,
+            } => {
+                mild_time.to_bits().hash(state);
+                severe_time.as_ref().map(|time| time.to_bits()).hash(state);
+                critical_time
+                    .as_ref()
+                    .map(|time| time.to_bits())
+                    .hash(state);
+                resolved_time.to_bits().hash(state);
+            }
+            Self::Dead {
+                mild_time,
+                severe_time,
+                critical_time,
+                dead_time,
+            } => {
+                mild_time.to_bits().hash(state);
+                severe_time.to_bits().hash(state);
+                critical_time.to_bits().hash(state);
+                dead_time.to_bits().hash(state);
+            }
+        }
+    }
+}
+
+impl_property!(SymptomData, Person, default_const = SymptomData::NoSymptoms);
+
+define_derived_property!(
+    enum SymptomStatus {
+        NoSymptoms,
+        Mild,
+        Severe,
+        Critical,
+        Resolved,
+        Dead,
+    },
     Person,
     [SymptomData],
     [],
@@ -88,11 +228,8 @@ impl PartialOrd for SymptomAgeGroup {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq, Copy, Clone)]
-pub struct AgeGroupIndex(pub usize);
-
-impl_derived_property!(
-    AgeGroupIndex,
+define_derived_property!(
+    struct AgeGroupIndex(usize),
     Person,
     [Age],
     [OrderedAgeGroupsParam],
@@ -349,8 +486,8 @@ mod test {
         draw_transition_time, process_symptom_change_event,
     };
     use crate::{Age, Params};
-    use ixa::assert_almost_eq;
     use ixa::prelude::*;
+    use ixa::{HashMap, assert_almost_eq};
 
     #[test]
     fn test_validate_log_norm_params() {
@@ -393,35 +530,35 @@ mod test {
             .unwrap();
 
         // test people who are 0, 17, 18, 49, 50, 64, 65, and 100 years old for correct derived person property
-        let person_id: PersonId = context.add_entity((Age(0),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(0))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(0));
 
-        let person_id: PersonId = context.add_entity((Age(17),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(17))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(0));
 
-        let person_id: PersonId = context.add_entity((Age(18),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(18))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(1));
 
-        let person_id: PersonId = context.add_entity((Age(49),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(49))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(1));
 
-        let person_id: PersonId = context.add_entity((Age(50),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(50))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(2));
 
-        let person_id: PersonId = context.add_entity((Age(64),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(64))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(2));
 
-        let person_id: PersonId = context.add_entity((Age(65),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(65))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(3));
 
-        let person_id: PersonId = context.add_entity((Age(100),)).unwrap();
+        let person_id: PersonId = context.add_entity(with!(Person, Age(100))).unwrap();
         let symptom_age_group_index = context.get_property::<Person, AgeGroupIndex>(person_id);
         assert_eq!(symptom_age_group_index, AgeGroupIndex(3));
     }
@@ -485,7 +622,7 @@ mod test {
                     max: 120,
                 },
             ],
-            probability_severe_given_mild: ixa::HashMap::from_iter([
+            probability_severe_given_mild: HashMap::from_iter([
                 ("Age0To17".to_string(), 0.0),
                 ("Age18To49".to_string(), 1.0),
                 ("Age50To64".to_string(), 1.0),
@@ -499,7 +636,7 @@ mod test {
                 mu: mild_to_resolved_duration.ln(),
                 sigma: 0.0,
             },
-            probability_critical_given_severe: ixa::HashMap::from_iter([
+            probability_critical_given_severe: HashMap::from_iter([
                 ("Age0To17".to_string(), 0.0),
                 ("Age18To49".to_string(), 0.0),
                 ("Age50To64".to_string(), 1.0),
@@ -513,7 +650,7 @@ mod test {
                 mu: severe_to_resolved_duration.ln(),
                 sigma: 0.0,
             },
-            probability_dead_given_critical: ixa::HashMap::from_iter([
+            probability_dead_given_critical: HashMap::from_iter([
                 ("Age0To17".to_string(), 0.0),
                 ("Age18To49".to_string(), 0.0),
                 ("Age50To64".to_string(), 0.0),
@@ -558,10 +695,10 @@ mod test {
         context
             .set_global_property_value(OrderedAgeGroupsParam, ordered_symptom_age_groups)
             .unwrap();
-        let p1 = context.add_entity::<Person, _>((Age(10),)).unwrap();
-        let p2 = context.add_entity::<Person, _>((Age(30),)).unwrap();
-        let p3 = context.add_entity::<Person, _>((Age(60),)).unwrap();
-        let p4 = context.add_entity::<Person, _>((Age(80),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
+        let p2 = context.add_entity(with!(Person, Age(30))).unwrap();
+        let p3 = context.add_entity(with!(Person, Age(60))).unwrap();
+        let p4 = context.add_entity(with!(Person, Age(80))).unwrap();
 
         context.subscribe_to_event(
             move |context, event: PropertyChangeEvent<Person, SymptomData>| {
@@ -639,10 +776,7 @@ mod test {
                 mu: infect_to_mild_duration.ln(),
                 sigma: 0.0,
             },
-            probability_severe_given_mild: ixa::HashMap::from_iter([(
-                "Age0To120".to_string(),
-                0.0,
-            )]),
+            probability_severe_given_mild: HashMap::from_iter([("Age0To120".to_string(), 0.0)]),
             // some probability_severe_given_mild needs to be specified because mild -> severe or mild -> resolved
             // is *scheduled* the moment the person goes from no symptoms to mild, even though
             // the simulation is shut down before the person actually leaves the mild state
@@ -663,7 +797,7 @@ mod test {
             )
             .unwrap();
 
-        let p1 = context.add_entity::<Person, _>((Age(30),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(30))).unwrap();
         init(&mut context).unwrap();
         context.infect_person(p1, None, None);
         context.add_plan_with_phase(
@@ -694,7 +828,7 @@ mod test {
             .set_global_property_value(GlobalParams, parameters.clone())
             .unwrap();
 
-        let p1 = context.add_entity::<Person, _>((Age(30),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(30))).unwrap();
         init(&mut context).unwrap();
         context.infect_person(p1, None, None);
         context.execute();
@@ -719,15 +853,15 @@ mod test {
             let mut context = Context::new();
             let parameters = Params {
                 probability_mild_given_infect,
-                probability_severe_given_mild: ixa::HashMap::from_iter([(
+                probability_severe_given_mild: HashMap::from_iter([(
                     "Age0To120".to_string(),
                     probability_severe_given_mild,
                 )]),
-                probability_critical_given_severe: ixa::HashMap::from_iter([(
+                probability_critical_given_severe: HashMap::from_iter([(
                     "Age0To120".to_string(),
                     probability_critical_given_severe,
                 )]),
-                probability_dead_given_critical: ixa::HashMap::from_iter([(
+                probability_dead_given_critical: HashMap::from_iter([(
                     "Age0To120".to_string(),
                     probability_dead_given_critical,
                 )]),
@@ -749,12 +883,12 @@ mod test {
                 .unwrap();
 
             // Add our person
-            let p1 = context.add_entity::<Person, _>((Age(30),)).unwrap();
+            let p1 = context.add_entity(with!(Person, Age(30))).unwrap();
             // Initialize event subscriptions and plans for symptom status manager
             init(&mut context).unwrap();
             // Infect the person to trigger the symptom status manager
             context.infect_person(p1, None, None);
-            // Add a plan to shutdown after long period once everyone should have progressed to an absorbing state
+            // Add a plan to shut down after long period once everyone should have progressed to an absorbing state
             context.add_plan(1000.0, ixa::Context::shutdown);
 
             context.execute();


### PR DESCRIPTION
This PR updates the codebase for `ixa@2.0.0-beta2.4`.

I also snuck in these:

- An optimization in `calculate_multiplier` that avoids `f64::powf` for the common case of $\alpha\in \{0.0, 1.0\}$.
- Made the `profiling` feature no longer enabled by default.