### PR TITLE
itinerary manager interface with rebase fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +836,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "criterion",
+ "dyn-clone",
  "ixa",
  "memchr",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ zip = { version = "8.5" }
 once_cell = { version = "1" }
 ouroboros = { version = "0.18.5" }
 strum = { version = "0.28.0", features = ["derive"] }
+dyn-clone = "1.0.20"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -1,222 +1,46 @@
 use ixa::prelude::*;
-use serde::Serialize;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
 };
 
-use crate::settings::SETTING_COUNT;
 use crate::{
     population_loader::{Person, PersonId},
-    settings::ItineraryRatios,
+    settings::{ItineraryRatios, SETTING_COUNT},
 };
 
-const TRANSIENT_STATE_COUNT: usize = SETTING_COUNT * 2;
+use dyn_clone::DynClone;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Copy)]
-pub struct ItineraryTransitionMatrix {
-    activity_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
-    location_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
-    absorption_probabilities: Option<[[f64; SETTING_COUNT]; TRANSIENT_STATE_COUNT]>,
+pub trait ItineraryModifierTrait: std::fmt::Debug + DynClone + 'static {
+    fn layer(&mut self, other: Box<dyn ItineraryModifierTrait>) -> Box<dyn ItineraryModifierTrait>;
+    fn apply(&mut self, base_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT];
+    fn as_any(&self) -> &dyn Any;
 }
 
-#[allow(dead_code)]
-#[allow(clippy::needless_range_loop)]
-impl ItineraryTransitionMatrix {
-    pub fn normalize(&mut self) {
-        let normalize_matrix = |matrix: &mut [[f64; SETTING_COUNT]; SETTING_COUNT]| {
-            for i in 0..SETTING_COUNT {
-                let row_sum: f64 = matrix[i].iter().sum();
-                if row_sum > 1.0 {
-                    for j in 0..SETTING_COUNT {
-                        matrix[i][j] /= row_sum;
-                    }
-                }
-            }
-        };
-
-        normalize_matrix(&mut self.activity_matrix);
-        normalize_matrix(&mut self.location_matrix);
-    }
-
-    pub fn build_transient_and_absorbing_matrix(
-        &self,
-    ) -> (
-        [[f64; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT],
-        [[f64; TRANSIENT_STATE_COUNT]; SETTING_COUNT],
-    ) {
-        let mut transient_matrix = [[0.0; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
-        let mut absorbing_matrix = [[0.0; TRANSIENT_STATE_COUNT]; SETTING_COUNT];
-        let activity_row_sums: Vec<f64> = self
-            .activity_matrix
-            .iter()
-            .map(|row| row.iter().sum())
-            .collect();
-        for i in 0..SETTING_COUNT {
-            for j in 0..SETTING_COUNT {
-                transient_matrix[i][j] = self.activity_matrix[i][j];
-                if i != j {
-                    transient_matrix[i + SETTING_COUNT][j + SETTING_COUNT] =
-                        self.location_matrix[i][j];
-                }
-            }
-            transient_matrix[i][i + SETTING_COUNT] = 1.0 - activity_row_sums[i];
-        }
-
-        let transient_row_sums: Vec<f64> = transient_matrix
-            .iter()
-            .map(|row| row.iter().sum())
-            .collect();
-        for i in 0..SETTING_COUNT {
-            absorbing_matrix[i][i + SETTING_COUNT] = 1.0 - transient_row_sums[i + SETTING_COUNT];
-        }
-        (transient_matrix, absorbing_matrix)
-    }
-
-    pub fn layer(
-        &self,
-        itinerary_transition_matrix: &ItineraryTransitionMatrix,
-    ) -> ItineraryTransitionMatrix {
-        let mut layered_activity_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
-        let mut layered_location_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
-
-        for i in 0..SETTING_COUNT {
-            for j in 0..SETTING_COUNT {
-                layered_activity_matrix[i][j] =
-                    self.activity_matrix[i][j] + itinerary_transition_matrix.activity_matrix[i][j];
-                layered_location_matrix[i][j] =
-                    self.location_matrix[i][j] + itinerary_transition_matrix.location_matrix[i][j];
-            }
-        }
-
-        ItineraryTransitionMatrix {
-            activity_matrix: layered_activity_matrix,
-            location_matrix: layered_location_matrix,
-            absorption_probabilities: None,
-        }
-    }
-
-    fn calculate_absorption_probabilities(&mut self) {
-        // Aborbing probabilities are calculated using the
-        // formula N * R, where N is the fundamental matrix (I - Q)^-1, I is the identity matrix,
-        // Q is the transient matrix, and R is the absorbing matrix.
-
-        let (transient_matrix, absorbing_matrix) = self.build_transient_and_absorbing_matrix();
-
-        // Create identity matrix I
-        let mut identity = [[0.0; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
-        for i in 0..TRANSIENT_STATE_COUNT {
-            identity[i][i] = 1.0;
-        }
-
-        // Calculate I - Q (where Q is the transient matrix)
-        let mut i_minus_q = [[0.0; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
-        for i in 0..TRANSIENT_STATE_COUNT {
-            for j in 0..TRANSIENT_STATE_COUNT {
-                i_minus_q[i][j] = identity[i][j] - transient_matrix[i][j];
-            }
-        }
-
-        // Invert (I - Q) to get the fundamental matrix N
-        // Using Gaussian elimination with partial pivoting
-        let n = i_minus_q;
-
-        // Create augmented identity matrix for inversion
-        let mut aug = [[0.0; 2 * TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
-        for i in 0..TRANSIENT_STATE_COUNT {
-            for j in 0..TRANSIENT_STATE_COUNT {
-                aug[i][j] = n[i][j];
-                aug[i][j + TRANSIENT_STATE_COUNT] = if i == j { 1.0 } else { 0.0 };
-            }
-        }
-
-        // Forward elimination with partial pivoting
-        for col in 0..TRANSIENT_STATE_COUNT {
-            // Find pivot
-            let mut pivot_row = col;
-            let mut max_val = aug[col][col].abs();
-            for row in col + 1..TRANSIENT_STATE_COUNT {
-                if aug[row][col].abs() > max_val {
-                    max_val = aug[row][col].abs();
-                    pivot_row = row;
-                }
-            }
-
-            // Swap rows
-            if pivot_row != col {
-                aug.swap(col, pivot_row);
-            }
-
-            // Scale pivot row
-            let pivot = aug[col][col];
-            if pivot.abs() > f64::EPSILON {
-                for j in 0..2 * TRANSIENT_STATE_COUNT {
-                    aug[col][j] /= pivot;
-                }
-
-                // Eliminate column
-                for row in 0..TRANSIENT_STATE_COUNT {
-                    if row != col {
-                        let factor = aug[row][col];
-                        for j in 0..2 * TRANSIENT_STATE_COUNT {
-                            aug[row][j] -= factor * aug[col][j];
-                        }
-                    }
-                }
-            }
-        }
-
-        // Extract inverted matrix and calculate absorption probabilities
-        // N * R where N is the fundamental matrix (I-Q)^-1 and R is the absorbing matrix
-        let mut absorption_probs = [[0.0; SETTING_COUNT]; TRANSIENT_STATE_COUNT];
-        for i in 0..TRANSIENT_STATE_COUNT {
-            for j in 0..SETTING_COUNT {
-                for k in 0..TRANSIENT_STATE_COUNT {
-                    absorption_probs[i][j] +=
-                        aug[i][k + TRANSIENT_STATE_COUNT] * absorbing_matrix[j][k];
-                }
-            }
-        }
-
-        self.absorption_probabilities = Some(absorption_probs);
-    }
-
-    pub fn apply(&mut self, current_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT] {
-        if self.absorption_probabilities.is_none() {
-            self.calculate_absorption_probabilities();
-        }
-        let absorption_probs = self.absorption_probabilities.unwrap();
-        let mut new_itinerary = [0.0; SETTING_COUNT];
-        for j in 0..SETTING_COUNT {
-            for i in 0..SETTING_COUNT {
-                new_itinerary[j] += current_itinerary[i] * absorption_probs[i][j];
-            }
-        }
-        new_itinerary
+// This is implemented for testing
+impl PartialEq for dyn ItineraryModifierTrait {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_any().type_id() == other.as_any().type_id()
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Copy)]
-pub struct ItineraryModifier {
-    modifier_activity: ItineraryTransitionMatrix,
-}
-
-pub trait ItineraryModifierTrait: std::fmt::Debug + Any {
+pub trait ItineraryModifierStorageTrait: std::fmt::Debug + Any {
     fn get_itinerary_modifiers(
         &self,
         context: &Context,
         person_id: PersonId,
-    ) -> Option<Vec<ItineraryModifier>>;
+    ) -> Option<Vec<Box<dyn ItineraryModifierTrait>>>;
     fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 type PersonPropertyItineraryModifier<'a, P> = (
     P,
     // Use fully qualified syntax for the associated type because type aliases do not have type checking
-    HashMap<<P as Property<Person>>::CanonicalValue, Vec<ItineraryModifier>>,
+    HashMap<<P as Property<Person>>::CanonicalValue, Vec<Box<dyn ItineraryModifierTrait>>>,
 );
 
-impl<P> ItineraryModifierTrait for PersonPropertyItineraryModifier<'static, P>
+impl<P> ItineraryModifierStorageTrait for PersonPropertyItineraryModifier<'static, P>
 where
     P: Property<Person> + std::fmt::Debug,
     P::CanonicalValue: std::hash::Hash + Eq + std::fmt::Debug,
@@ -225,20 +49,26 @@ where
         &self,
         context: &Context,
         person_id: PersonId,
-    ) -> Option<Vec<ItineraryModifier>> {
+    ) -> Option<Vec<Box<dyn ItineraryModifierTrait>>> {
         let (_person_property, modifier_map) = self;
         let property_val = context.get_property::<Person, P>(person_id);
-        modifier_map.get(&property_val.make_canonical()).cloned()
+        modifier_map
+            .get(&property_val.make_canonical())
+            .map(|v| v.iter().map(|b| dyn_clone::clone_box(b.as_ref())).collect())
     }
 
     fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 }
 
 #[derive(Default)]
 struct ItineraryModifierContainer {
-    itinerary_modifier_map: HashMap<TypeId, Box<dyn ItineraryModifierTrait>>,
+    itinerary_modifier_map: HashMap<TypeId, Box<dyn ItineraryModifierStorageTrait>>,
 }
 
 define_data_plugin!(
@@ -249,39 +79,37 @@ define_data_plugin!(
 
 pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
     /// Register a generic itinerary modifier.
-    fn register_itinerary_modifier<P: Property<Person> + std::fmt::Debug + 'static>(
+    fn register_itinerary_modifier<
+        P: Property<Person> + std::fmt::Debug + 'static,
+        I: ItineraryModifierTrait,
+    >(
         &mut self,
         person_property: P,
-        itinerary_modifier: ItineraryModifier,
+        itinerary_modifier: I,
     ) where
         P::CanonicalValue: std::hash::Hash + Eq,
     {
         if let Some(modifier_map) = self
             .get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
-            .get(&TypeId::of::<P>())
+            .get_mut(&TypeId::of::<P>())
         {
             if let Some(downcast_modifier_map) = modifier_map
-                .as_any()
-                .downcast_ref::<PersonPropertyItineraryModifier<P>>(
+                .as_any_mut()
+                .downcast_mut::<PersonPropertyItineraryModifier<P>>(
             ) {
-                let mut new_modifier_map = downcast_modifier_map.1.clone();
-                new_modifier_map
+                let (_property, itinerary_modifier_map) = downcast_modifier_map;
+                itinerary_modifier_map
                     .entry(person_property.make_canonical())
                     .or_insert_with(Vec::new)
-                    .push(itinerary_modifier);
-                let new_person_property_modifier: PersonPropertyItineraryModifier<P> =
-                    (downcast_modifier_map.0, new_modifier_map);
-                self.get_data_mut(ItineraryModifierPlugin)
-                    .itinerary_modifier_map
-                    .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
+                    .push(Box::new(itinerary_modifier));
             }
         } else {
             let person_property_modifier: PersonPropertyItineraryModifier<P> = (
                 person_property,
                 HashMap::from_iter([(
                     person_property.make_canonical(),
-                    Vec::from([itinerary_modifier]),
+                    Vec::from([Box::new(itinerary_modifier) as Box<dyn ItineraryModifierTrait>]),
                 )]),
             );
             // Insert the boxed modifier into the itinerary modifier map
@@ -301,31 +129,26 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
         let modifier_map = self
             .get_data_mut(ItineraryModifierPlugin)
             .itinerary_modifier_map
-            .get(&TypeId::of::<P>());
+            .get_mut(&TypeId::of::<P>());
         if let Some(property_modifier_map) = modifier_map
             && let Some(downcast_property_modifier_map) = property_modifier_map
-                .as_any()
-                .downcast_ref::<PersonPropertyItineraryModifier<P>>(
+                .as_any_mut()
+                .downcast_mut::<PersonPropertyItineraryModifier<P>>(
             )
         {
-            let mut new_property_modifier_map = downcast_property_modifier_map.1.clone();
-            new_property_modifier_map.remove(&property_value);
-            let new_person_property_modifier: PersonPropertyItineraryModifier<P> =
-                (downcast_property_modifier_map.0, new_property_modifier_map);
-            self.get_data_mut(ItineraryModifierPlugin)
-                .itinerary_modifier_map
-                .insert(TypeId::of::<P>(), Box::new(new_person_property_modifier));
+            let (_property, itinerary_modifier_map) = downcast_property_modifier_map;
+            itinerary_modifier_map.remove(&property_value);
         }
     }
 
-    fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier>;
+    fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<Box<dyn ItineraryModifierTrait>>;
     fn get_modified_itinerary(&self, person_id: PersonId) -> [f64; SETTING_COUNT];
 }
 impl ContextItineraryModifierExt for Context {
     // This needs to be here to have access to the concrete context type for the get_itinerary trait method
-    fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<ItineraryModifier> {
+    fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<Box<dyn ItineraryModifierTrait>> {
         let itinerary_modifier_container = self.get_data(ItineraryModifierPlugin);
-        let mut modifiers: Vec<ItineraryModifier> = Vec::new();
+        let mut modifiers: Vec<Box<dyn ItineraryModifierTrait>> = Vec::new();
         for modifier in itinerary_modifier_container.itinerary_modifier_map.values() {
             let itinerary_modifier_vec = modifier.get_itinerary_modifiers(self, person_id);
             if let Some(itinerary_modifier_vec) = itinerary_modifier_vec {
@@ -338,15 +161,12 @@ impl ContextItineraryModifierExt for Context {
     fn get_modified_itinerary(&self, person_id: PersonId) -> [f64; SETTING_COUNT] {
         let base_itinerary = self.get_property::<Person, ItineraryRatios>(person_id);
         let modifiers = self.get_itinerary_modifiers(person_id);
-        let mut layered_modifier: Option<ItineraryTransitionMatrix> = None;
+        let mut layered_modifier: Option<Box<dyn ItineraryModifierTrait>> = None;
         for modifier in modifiers {
             layered_modifier = Some(match layered_modifier {
-                Some(existing) => existing.layer(&modifier.modifier_activity),
-                None => modifier.modifier_activity,
+                Some(mut existing) => existing.layer(modifier),
+                None => modifier,
             });
-        }
-        if let Some(ref mut layered_modifier) = layered_modifier {
-            layered_modifier.normalize();
         }
         if let Some(mut layered_modifier) = layered_modifier {
             layered_modifier.apply(&base_itinerary.itinerary_ratios)
@@ -356,28 +176,13 @@ impl ContextItineraryModifierExt for Context {
     }
 }
 
-pub fn define_itinerary_modifier(
-    activity_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
-    location_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
-) -> ItineraryModifier {
-    let itinerary_transition_matrix = ItineraryTransitionMatrix {
-        activity_matrix: activity_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
-        location_matrix: location_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
-        absorption_probabilities: None,
-    };
-    ItineraryModifier {
-        modifier_activity: itinerary_transition_matrix,
-    }
-}
-
-// need method to check communitivity of location modifier matrices
-
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::Age;
+    use crate::itinerary_modifiers::define_itinerary_modifier;
     use crate::parameters::{GlobalParams, Params, SettingProperties};
-    use crate::settings::SettingCategory;
+    use crate::settings::{ItineraryRatios, SettingCategory};
     use ixa::HashMap;
 
     fn setup() -> Context {
@@ -420,16 +225,25 @@ mod test {
         let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None);
 
         context.register_itinerary_modifier(Age(11), weekend_modifier);
-        let p1 = context.add_entity::<Person, _>((Age(10),)).unwrap();
-        let p2 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
+        let p2 = context.add_entity(with!(Person, Age(11))).unwrap();
         let modifiers_p1 = context.get_itinerary_modifiers(p1);
         let modifiers_p2 = context.get_itinerary_modifiers(p2);
         assert_eq!(modifiers_p1.len(), 0);
-        assert_eq!(modifiers_p2, vec![weekend_modifier]);
+        assert_eq!(
+            modifiers_p2,
+            vec![Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>]
+        );
 
         context.register_itinerary_modifier(Age(10), weekend_modifier);
-        assert_eq!(context.get_itinerary_modifiers(p1), vec![weekend_modifier]);
-        assert_eq!(context.get_itinerary_modifiers(p2), vec![weekend_modifier]);
+        assert_eq!(
+            context.get_itinerary_modifiers(p1),
+            vec![Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>]
+        );
+        assert_eq!(
+            context.get_itinerary_modifiers(p2),
+            vec![Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>]
+        );
     }
 
     #[test]
@@ -456,11 +270,15 @@ mod test {
 
         context.register_itinerary_modifier(Age(11), weekend_modifier);
         context.register_itinerary_modifier(Age(11), school_modifier);
-        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         let modifiers = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers.len(), 2);
-        assert!(modifiers.contains(&school_modifier));
-        assert!(modifiers.contains(&weekend_modifier));
+        assert!(
+            modifiers.contains(&(Box::new(school_modifier) as Box<dyn ItineraryModifierTrait>))
+        );
+        assert!(
+            modifiers.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+        );
     }
 
     #[test]
@@ -476,15 +294,19 @@ mod test {
         let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
         context.register_itinerary_modifier(Age(10), weekend_modifier);
         context.register_itinerary_modifier(Age(11), weekend_modifier);
-        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
-        let p2 = context.add_entity::<Person, _>((Age(10),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
+        let p2 = context.add_entity(with!(Person, Age(10))).unwrap();
         let modifiers_p1 = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers_p1.len(), 1);
-        assert!(modifiers_p1.contains(&weekend_modifier));
+        assert!(
+            modifiers_p1.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+        );
 
         let modifiers_p2 = context.get_itinerary_modifiers(p2);
         assert_eq!(modifiers_p2.len(), 1);
-        assert!(modifiers_p2.contains(&weekend_modifier));
+        assert!(
+            modifiers_p2.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+        );
 
         // This would remove all age based itinerary modifiers that is not ideal.
         context.remove_itinerary_modifier_by_property::<Age>(Age(11));
@@ -493,7 +315,9 @@ mod test {
 
         let modifiers_p2 = context.get_itinerary_modifiers(p2);
         assert_eq!(modifiers_p2.len(), 1);
-        assert!(modifiers_p2.contains(&weekend_modifier));
+        assert!(
+            modifiers_p2.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+        );
     }
 
     #[test]
@@ -534,7 +358,7 @@ mod test {
         let sip_modifier =
             define_itinerary_modifier(Some(sip_transient_matrix), Some(sip_location_matrix));
 
-        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
 
         context.set_property(
             p1,
@@ -584,7 +408,7 @@ mod test {
         let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
         let isolation_modifier = define_itinerary_modifier(Some(isolation_matrix), None);
 
-        let p1 = context.add_entity::<Person, _>((Age(11),)).unwrap();
+        let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         context.register_itinerary_modifier(Age(11), weekend_modifier);
         context.register_itinerary_modifier(Age(11), isolation_modifier);
         context.set_property(

--- a/src/itinerary_modifiers.rs
+++ b/src/itinerary_modifiers.rs
@@ -1,0 +1,335 @@
+use serde::Serialize;
+use std::any::Any;
+
+use crate::{itinerary_manager::ItineraryModifierTrait, settings::SETTING_COUNT};
+
+const TRANSIENT_STATE_COUNT: usize = SETTING_COUNT * 2;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Copy)]
+pub struct ItineraryTransitionMatrix {
+    activity_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
+    location_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
+    absorption_probabilities: Option<[[f64; SETTING_COUNT]; TRANSIENT_STATE_COUNT]>,
+}
+
+impl ItineraryModifierTrait for ItineraryTransitionMatrix {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn layer(&mut self, other: Box<dyn ItineraryModifierTrait>) -> Box<dyn ItineraryModifierTrait> {
+        if let Some(other_modifier) = other.as_any().downcast_ref::<ItineraryTransitionMatrix>() {
+            Box::new((*self).layer(other_modifier))
+        } else {
+            panic!("Incompatible modifier types for layering");
+        }
+    }
+    fn apply(&mut self, base_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT] {
+        self.apply(base_itinerary)
+    }
+}
+
+#[allow(dead_code)]
+#[allow(clippy::needless_range_loop)]
+impl ItineraryTransitionMatrix {
+    pub fn normalize(&mut self) {
+        let normalize_matrix = |matrix: &mut [[f64; SETTING_COUNT]; SETTING_COUNT]| {
+            for i in 0..SETTING_COUNT {
+                let row_sum: f64 = matrix[i].iter().sum();
+                if row_sum > 1.0 {
+                    for j in 0..SETTING_COUNT {
+                        matrix[i][j] /= row_sum;
+                    }
+                }
+            }
+        };
+
+        normalize_matrix(&mut self.activity_matrix);
+        normalize_matrix(&mut self.location_matrix);
+    }
+
+    pub fn build_transient_and_absorbing_matrix(
+        &self,
+    ) -> (
+        [[f64; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT],
+        [[f64; TRANSIENT_STATE_COUNT]; SETTING_COUNT],
+    ) {
+        let mut transient_matrix = [[0.0; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
+        let mut absorbing_matrix = [[0.0; TRANSIENT_STATE_COUNT]; SETTING_COUNT];
+        let activity_row_sums: Vec<f64> = self
+            .activity_matrix
+            .iter()
+            .map(|row| row.iter().sum())
+            .collect();
+        for i in 0..SETTING_COUNT {
+            for j in 0..SETTING_COUNT {
+                transient_matrix[i][j] = self.activity_matrix[i][j];
+                if i != j {
+                    transient_matrix[i + SETTING_COUNT][j + SETTING_COUNT] =
+                        self.location_matrix[i][j];
+                }
+            }
+            transient_matrix[i][i + SETTING_COUNT] = 1.0 - activity_row_sums[i];
+        }
+
+        let transient_row_sums: Vec<f64> = transient_matrix
+            .iter()
+            .map(|row| row.iter().sum())
+            .collect();
+        for i in 0..SETTING_COUNT {
+            absorbing_matrix[i][i + SETTING_COUNT] = 1.0 - transient_row_sums[i + SETTING_COUNT];
+        }
+        (transient_matrix, absorbing_matrix)
+    }
+
+    pub fn layer(
+        &self,
+        itinerary_transition_matrix: &ItineraryTransitionMatrix,
+    ) -> ItineraryTransitionMatrix {
+        let mut layered_activity_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+        let mut layered_location_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+
+        for i in 0..SETTING_COUNT {
+            for j in 0..SETTING_COUNT {
+                layered_activity_matrix[i][j] =
+                    self.activity_matrix[i][j] + itinerary_transition_matrix.activity_matrix[i][j];
+                layered_location_matrix[i][j] =
+                    self.location_matrix[i][j] + itinerary_transition_matrix.location_matrix[i][j];
+            }
+        }
+
+        ItineraryTransitionMatrix {
+            activity_matrix: layered_activity_matrix,
+            location_matrix: layered_location_matrix,
+            absorption_probabilities: None,
+        }
+    }
+
+    fn calculate_absorption_probabilities(&mut self) {
+        // Aborbing probabilities are calculated using the
+        // formula N * R, where N is the fundamental matrix (I - Q)^-1, I is the identity matrix,
+        // Q is the transient matrix, and R is the absorbing matrix.
+
+        let (transient_matrix, absorbing_matrix) = self.build_transient_and_absorbing_matrix();
+
+        // Create identity matrix I
+        let mut identity = [[0.0; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
+        for i in 0..TRANSIENT_STATE_COUNT {
+            identity[i][i] = 1.0;
+        }
+
+        // Calculate I - Q (where Q is the transient matrix)
+        let mut i_minus_q = [[0.0; TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
+        for i in 0..TRANSIENT_STATE_COUNT {
+            for j in 0..TRANSIENT_STATE_COUNT {
+                i_minus_q[i][j] = identity[i][j] - transient_matrix[i][j];
+            }
+        }
+
+        // Invert (I - Q) to get the fundamental matrix N
+        // Using Gaussian elimination with partial pivoting
+        let n = i_minus_q;
+
+        // Create augmented identity matrix for inversion
+        let mut aug = [[0.0; 2 * TRANSIENT_STATE_COUNT]; TRANSIENT_STATE_COUNT];
+        for i in 0..TRANSIENT_STATE_COUNT {
+            for j in 0..TRANSIENT_STATE_COUNT {
+                aug[i][j] = n[i][j];
+                aug[i][j + TRANSIENT_STATE_COUNT] = if i == j { 1.0 } else { 0.0 };
+            }
+        }
+
+        // Forward elimination with partial pivoting
+        for col in 0..TRANSIENT_STATE_COUNT {
+            // Find pivot
+            let mut pivot_row = col;
+            let mut max_val = aug[col][col].abs();
+            for row in col + 1..TRANSIENT_STATE_COUNT {
+                if aug[row][col].abs() > max_val {
+                    max_val = aug[row][col].abs();
+                    pivot_row = row;
+                }
+            }
+
+            // Swap rows
+            if pivot_row != col {
+                aug.swap(col, pivot_row);
+            }
+
+            // Scale pivot row
+            let pivot = aug[col][col];
+            if pivot.abs() > f64::EPSILON {
+                for j in 0..2 * TRANSIENT_STATE_COUNT {
+                    aug[col][j] /= pivot;
+                }
+
+                // Eliminate column
+                for row in 0..TRANSIENT_STATE_COUNT {
+                    if row != col {
+                        let factor = aug[row][col];
+                        for j in 0..2 * TRANSIENT_STATE_COUNT {
+                            aug[row][j] -= factor * aug[col][j];
+                        }
+                    }
+                }
+            }
+        }
+
+        // Extract inverted matrix and calculate absorption probabilities
+        // N * R where N is the fundamental matrix (I-Q)^-1 and R is the absorbing matrix
+        let mut absorption_probs = [[0.0; SETTING_COUNT]; TRANSIENT_STATE_COUNT];
+        for i in 0..TRANSIENT_STATE_COUNT {
+            for j in 0..SETTING_COUNT {
+                for k in 0..TRANSIENT_STATE_COUNT {
+                    absorption_probs[i][j] +=
+                        aug[i][k + TRANSIENT_STATE_COUNT] * absorbing_matrix[j][k];
+                }
+            }
+        }
+
+        self.absorption_probabilities = Some(absorption_probs);
+    }
+
+    pub fn apply(&mut self, current_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT] {
+        self.normalize();
+        if self.absorption_probabilities.is_none() {
+            self.calculate_absorption_probabilities();
+        }
+        let absorption_probs = self.absorption_probabilities.unwrap();
+        let mut new_itinerary = [0.0; SETTING_COUNT];
+        for j in 0..SETTING_COUNT {
+            for i in 0..SETTING_COUNT {
+                new_itinerary[j] += current_itinerary[i] * absorption_probs[i][j];
+            }
+        }
+        new_itinerary
+    }
+}
+
+pub fn define_itinerary_modifier(
+    activity_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
+    location_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
+) -> ItineraryTransitionMatrix {
+    ItineraryTransitionMatrix {
+        activity_matrix: activity_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
+        location_matrix: location_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
+        absorption_probabilities: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_define_itinerary_modifier_with_none() {
+        let modifier = define_itinerary_modifier(None, None);
+        assert_eq!(
+            modifier.activity_matrix,
+            [[0.0; SETTING_COUNT]; SETTING_COUNT]
+        );
+        assert_eq!(
+            modifier.location_matrix,
+            [[0.0; SETTING_COUNT]; SETTING_COUNT]
+        );
+        assert_eq!(modifier.absorption_probabilities, None);
+    }
+
+    #[test]
+    fn test_define_itinerary_modifier_with_matrices() {
+        let mut activity = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+        let mut location = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+        activity[0][0] = 0.5;
+        location[0][1] = 0.3;
+
+        let modifier = define_itinerary_modifier(Some(activity), Some(location));
+        assert_eq!(modifier.activity_matrix[0][0], 0.5);
+        assert_eq!(modifier.location_matrix[0][1], 0.3);
+    }
+
+    #[test]
+    fn test_normalize_matrix() {
+        let mut matrix = ItineraryTransitionMatrix {
+            activity_matrix: {
+                let mut m = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+                m[0][0] = 0.4;
+                m[0][1] = 0.6;
+                m
+            },
+            location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
+            absorption_probabilities: None,
+        };
+
+        matrix.normalize();
+        let sum: f64 = matrix.activity_matrix[0].iter().sum();
+        assert!(sum <= 1.0);
+    }
+
+    #[test]
+    fn test_normalize_matrix_unnormalized() {
+        let mut matrix = ItineraryTransitionMatrix {
+            activity_matrix: {
+                let mut m = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+                m[0][0] = 0.6;
+                m[0][1] = 0.8;
+                m
+            },
+            location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
+            absorption_probabilities: None,
+        };
+
+        matrix.normalize();
+        let sum: f64 = matrix.activity_matrix[0].iter().sum();
+        assert!((sum - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_layer_matrices() {
+        let matrix1 = ItineraryTransitionMatrix {
+            activity_matrix: {
+                let mut m = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+                m[0][0] = 0.3;
+                m
+            },
+            location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
+            absorption_probabilities: None,
+        };
+
+        let matrix2 = ItineraryTransitionMatrix {
+            activity_matrix: {
+                let mut m = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+                m[0][0] = 0.2;
+                m
+            },
+            location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
+            absorption_probabilities: None,
+        };
+
+        let layered = matrix1.layer(&matrix2);
+        assert_eq!(layered.activity_matrix[0][0], 0.5);
+        assert_eq!(layered.absorption_probabilities, None);
+    }
+
+    #[test]
+    fn test_build_transient_and_absorbing_matrix() {
+        let matrix = ItineraryTransitionMatrix {
+            activity_matrix: {
+                let mut m = [[0.0; SETTING_COUNT]; SETTING_COUNT];
+                m[0][0] = 0.5;
+                m
+            },
+            location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
+            absorption_probabilities: None,
+        };
+
+        let (transient, absorbing) = matrix.build_transient_and_absorbing_matrix();
+        assert_eq!(transient[0][0], 0.5);
+        assert_eq!(transient[0][SETTING_COUNT], 0.5);
+        assert_eq!(transient[1][SETTING_COUNT + 1], 1.0);
+        assert_eq!(transient[2][SETTING_COUNT + 2], 1.0);
+        assert_eq!(transient[3][SETTING_COUNT + 3], 1.0);
+        assert_eq!(absorbing[0][SETTING_COUNT], 1.0);
+        assert_eq!(absorbing[1][SETTING_COUNT + 1], 1.0);
+        assert_eq!(absorbing[2][SETTING_COUNT + 2], 1.0);
+        assert_eq!(absorbing[3][SETTING_COUNT + 3], 1.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod infection_importation;
 pub mod infection_propagation_loop;
 pub mod infectiousness_manager;
 pub mod itinerary_manager;
+pub mod itinerary_modifiers;
 pub mod model;
 pub mod natural_history_parameter_manager;
 pub mod parameters;


### PR DESCRIPTION
This PR separates the implementation of the itinerary modifier logic from how they are stored in the itinerary modifier manager. A trait ItineraryModifierTrait is implemented which requires a layer() and apply() method which combine itinerary modifiers together and apply them to a default itinerary, respectively. The implementation of these methods on an structure that implements the ItineraryModifierTrait is done in a separate code module. What is now stored in the itinerary manager data structures and passed between methods are `Vec<Box<dyn ItineraryModifierTrait>>>`

This fixes #135 