### PR TITLE
Connecting itinerary manager to settings module

### DIFF
--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -142,7 +142,7 @@ pub trait ContextItineraryModifierExt: PluginContext + ContextEntitiesExt {
     }
 
     fn get_itinerary_modifiers(&self, person_id: PersonId) -> Vec<Box<dyn ItineraryModifierTrait>>;
-    fn get_modified_itinerary(&self, person_id: PersonId) -> [f64; SETTING_COUNT];
+    fn get_itinerary(&self, person_id: PersonId) -> [f64; SETTING_COUNT];
 }
 impl ContextItineraryModifierExt for Context {
     // This needs to be here to have access to the concrete context type for the get_itinerary trait method
@@ -158,7 +158,7 @@ impl ContextItineraryModifierExt for Context {
         modifiers
     }
 
-    fn get_modified_itinerary(&self, person_id: PersonId) -> [f64; SETTING_COUNT] {
+    fn get_itinerary(&self, person_id: PersonId) -> [f64; SETTING_COUNT] {
         let base_itinerary = self.get_property::<Person, ItineraryRatios>(person_id);
         let modifiers = self.get_itinerary_modifiers(person_id);
         let mut layered_modifier: Option<Box<dyn ItineraryModifierTrait>> = None;
@@ -369,12 +369,12 @@ mod test {
 
         context.register_itinerary_modifier(Age(11), weekend_modifier);
 
-        let modified_itinerary = context.get_modified_itinerary(p1);
+        let modified_itinerary = context.get_itinerary(p1);
         assert_eq!(modified_itinerary, [0.55, 0.0, 0.0, 0.45]);
 
         context.register_itinerary_modifier(Age(11), sip_modifier);
 
-        let modified_itinerary = context.get_modified_itinerary(p1);
+        let modified_itinerary = context.get_itinerary(p1);
         assert_eq!(modified_itinerary, [0.775, 0.0, 0.0, 0.225]);
     }
 
@@ -418,7 +418,7 @@ mod test {
             },
         );
 
-        let modified_itinerary = context.get_modified_itinerary(p1);
+        let modified_itinerary = context.get_itinerary(p1);
         assert_eq!(modified_itinerary, [1.0, 0.0, 0.0, 0.0]);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,7 @@ use std::{
 };
 use strum::{EnumCount as EnumCountMacro, EnumIter, IntoEnumIterator};
 
+use crate::itinerary_manager::ContextItineraryModifierExt;
 pub(crate) use crate::{
     ContextParametersExt, Params,
     error::ModelError,
@@ -126,7 +127,11 @@ impl ContextSettingExtPrivate for Context {}
 
 #[allow(private_bounds)]
 pub trait ContextSettingExt:
-    PluginContext + ContextEntitiesExt + ContextSettingExtPrivate + ContextParametersExt
+    PluginContext
+    + ContextEntitiesExt
+    + ContextSettingExtPrivate
+    + ContextParametersExt
+    + ContextItineraryModifierExt
 {
     fn register_setting_global_properties(&mut self) {
         let Params {
@@ -179,13 +184,15 @@ pub trait ContextSettingExt:
     ) -> Result<Vec<(SettingCode, f64, f64)>, ModelError> {
         let mut active_settings = Vec::new();
         let setting_ids = self.get_property::<Person, SettingIds>(person_id);
-        let itinerary_ratios = self.get_property::<Person, ItineraryRatios>(person_id);
+        let itinerary_ratios = self.get_modified_itinerary(person_id);
 
         for category in SettingCategory::iter() {
             if let Some(id) = setting_ids.setting_ids[category] {
-                let ratio = itinerary_ratios.itinerary_ratios[category];
-                let multiplier = self.calculate_multiplier(id)?;
-                active_settings.push((id, ratio, multiplier));
+                let ratio = itinerary_ratios[category];
+                if ratio > 0.0 {
+                    let multiplier = self.calculate_multiplier(id)?;
+                    active_settings.push((id, ratio, multiplier));
+                }
             }
         }
         Ok(active_settings)
@@ -330,6 +337,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::itinerary_manager::define_itinerary_modifier;
     use crate::population_loader::{CommunityId, HomeId, SchoolId, WorkId};
     use crate::{
         Age, Params,
@@ -637,5 +645,64 @@ mod test {
         assert_eq!(itinerary_ratios[SettingCategory::Work], 0.0);
         assert_eq!(itinerary_ratios[SettingCategory::School], 0.0);
         assert_eq!(itinerary_ratios[SettingCategory::Community], 0.0);
+    }
+
+    #[test]
+    fn test_active_settings_with_itinerary_modifiers() {
+        let mut context = setup_test_context(0.0);
+        let person_id = context.add_entity::<Person, _>((Age(20),)).unwrap();
+        context.add_person_to_settings(
+            person_id,
+            Some(make_home_id(b"160379602000011")),
+            Some(make_workplace_id(b"1603796020001332")),
+            Some(make_school_id(b"1603796020001443")),
+            Some(make_community_id(b"160379602000011")),
+        );
+        let active_settings = context.get_active_settings_for_person(person_id).unwrap();
+        let setting_codes: Vec<SettingCode> = active_settings.iter().map(|s| s.0).collect();
+        let itinerary_ratios: Vec<f64> = active_settings.iter().map(|s| s.1).collect();
+        let multipliers: Vec<f64> = active_settings.iter().map(|s| s.2).collect();
+
+        let expected_setting_codes = vec![
+            make_home_id(b"160379602000011"),
+            make_workplace_id(b"1603796020001332"),
+            make_school_id(b"1603796020001443"),
+            make_community_id(b"160379602000011"),
+        ];
+
+        let expected_itinerary_ratios = vec![0.25, 0.25, 0.25, 0.25];
+
+        let expected_multipliers = vec![1.0, 1.0, 1.0, 1.0]; // alpha is set to 0.0 so all multipliers are 1 regardless of size
+
+        assert_eq!(setting_codes, expected_setting_codes);
+        assert_eq!(itinerary_ratios, expected_itinerary_ratios);
+        assert_eq!(multipliers, expected_multipliers);
+
+        let weekend_matrix = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0, 0.5],
+            [0.5, 0.0, 0.0, 0.5],
+            [0.0, 0.0, 0.0, 0.0],
+        ];
+
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
+
+        context.register_itinerary_modifier(Age(20), weekend_modifier);
+
+        let active_settings = context.get_active_settings_for_person(person_id).unwrap();
+        let setting_codes: Vec<SettingCode> = active_settings.iter().map(|s| s.0).collect();
+        let itinerary_ratios: Vec<f64> = active_settings.iter().map(|s| s.1).collect();
+        let multipliers: Vec<f64> = active_settings.iter().map(|s| s.2).collect();
+
+        let expected_setting_codes = vec![
+            make_home_id(b"160379602000011"),
+            make_community_id(b"160379602000011"),
+        ];
+        let expected_itinerary_ratios = vec![0.5, 0.5];
+        let expected_multipliers = vec![1.0, 1.0]; // alpha is set to 0.0 so all multipliers are 1 regardless of size
+
+        assert_eq!(setting_codes, expected_setting_codes);
+        assert_eq!(itinerary_ratios, expected_itinerary_ratios);
+        assert_eq!(multipliers, expected_multipliers);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -184,7 +184,7 @@ pub trait ContextSettingExt:
     ) -> Result<Vec<(SettingCode, f64, f64)>, ModelError> {
         let mut active_settings = Vec::new();
         let setting_ids = self.get_property::<Person, SettingIds>(person_id);
-        let itinerary_ratios = self.get_modified_itinerary(person_id);
+        let itinerary_ratios = self.get_itinerary(person_id);
 
         for category in SettingCategory::iter() {
             if let Some(id) = setting_ids.setting_ids[category] {
@@ -337,7 +337,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::itinerary_manager::define_itinerary_modifier;
+    use crate::itinerary_modifiers::define_itinerary_modifier;
     use crate::population_loader::{CommunityId, HomeId, SchoolId, WorkId};
     use crate::{
         Age, Params,


### PR DESCRIPTION
This PR connects the itinerary manager module to the settings module. In the setting module method `get_active_settings_for_person` rather than a person's itinerary ratios being accessed via `get_property` the itinerary manager method `get_modified_itinerary` is called. If the returned ratio of a setting is 0, the setting is not included in the set of active settings.