### PR TITLE
Acceptance functions for itinerary modifiers and weekends implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,9 +757,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixa"
+<<<<<<< HEAD
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28adace56d30d4e3c5a5fb067eb4e58c12b3035646d8aeaba950bc523d4511bf"
+=======
+version = "2.0.0"
+source = "git+https://github.com/CDCgov/ixa?branch=RobertJacobsonCDC_944_triggers#25770a23ef3649ad86e3d5e0d0613d21345b5998"
+>>>>>>> 2f18dea (work in progress)
 dependencies = [
  "approx",
  "bytesize",
@@ -794,8 +799,12 @@ dependencies = [
 [[package]]
 name = "ixa-derive"
 version = "2.0.0"
+<<<<<<< HEAD
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67327babaf3a484300b8b6e85a3f12ddefa48ba076875d5c92b3804aa24131f9"
+=======
+source = "git+https://github.com/CDCgov/ixa?branch=RobertJacobsonCDC_944_triggers#25770a23ef3649ad86e3d5e0d0613d21345b5998"
+>>>>>>> 2f18dea (work in progress)
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
+ "cpubits",
  "cpufeatures",
 ]
 
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -125,39 +125,40 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -184,15 +185,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "bzip2"
@@ -211,9 +212,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -229,9 +230,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -267,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "crypto-common",
  "inout",
@@ -277,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -299,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -316,10 +317,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -334,10 +347,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -388,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -398,18 +417,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -419,12 +438,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -450,11 +468,20 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
+checksum = "fb22e947478ccf9dc44d8922042c677a63fbb88f2cb468521d1145816e5087cb"
 dependencies = [
  "linktime-proc-macro",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -479,9 +506,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -507,13 +531,15 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -524,9 +550,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -546,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fern"
@@ -582,19 +608,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "futures-task"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "typenum",
- "version_check",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -611,16 +645,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -637,24 +669,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -670,18 +687,27 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -708,30 +734,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -757,14 +775,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixa"
-<<<<<<< HEAD
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28adace56d30d4e3c5a5fb067eb4e58c12b3035646d8aeaba950bc523d4511bf"
-=======
-version = "2.0.0"
-source = "git+https://github.com/CDCgov/ixa?branch=RobertJacobsonCDC_944_triggers#25770a23ef3649ad86e3d5e0d0613d21345b5998"
->>>>>>> 2f18dea (work in progress)
 dependencies = [
  "approx",
  "bytesize",
@@ -799,12 +812,8 @@ dependencies = [
 [[package]]
 name = "ixa-derive"
 version = "2.0.0"
-<<<<<<< HEAD
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67327babaf3a484300b8b6e85a3f12ddefa48ba076875d5c92b3804aa24131f9"
-=======
-source = "git+https://github.com/CDCgov/ixa?branch=RobertJacobsonCDC_944_triggers#25770a23ef3649ad86e3d5e0d0613d21345b5998"
->>>>>>> 2f18dea (work in progress)
 dependencies = [
  "quote",
  "syn",
@@ -833,41 +842,36 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -877,9 +881,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -889,9 +893,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "log-mdc"
@@ -922,18 +926,18 @@ dependencies = [
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.2"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
 dependencies = [
  "sha2",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -947,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "mock_instant"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+checksum = "9bb517913cfcfb9eeda59f36020269075a152701a01606c612f547e4890be399"
 
 [[package]]
 name = "munge"
@@ -982,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1075,19 +1079,25 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest",
  "hmac",
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
+name = "pin-project-lite"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -1139,16 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1213,18 +1213,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1261,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1304,28 +1304,28 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -1338,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -1440,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1464,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -1492,6 +1492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallbox"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,9 +1505,9 @@ checksum = "aca054fd9f8c2ebe8557a2433f307e038c0716124efd045daa0388afa5172189"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "static_assertions"
@@ -1537,16 +1543,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1574,7 +1574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
@@ -1626,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinytemplate"
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1663,9 +1663,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1675,9 +1675,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -1693,9 +1693,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1719,27 +1719,18 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1750,9 +1741,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1760,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1773,52 +1764,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1976,97 +1933,15 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yansi"
@@ -2076,18 +1951,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2096,15 +1971,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zip"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2726508a48f38dceb22b35ecbbd2430efe34ff05c62bd3285f965d7911b33464"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes",
  "bzip2",
@@ -2112,7 +1987,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hmac",
  "indexmap",
  "lzma-rust2",
@@ -2129,15 +2004,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/input/input.json
+++ b/input/input.json
@@ -54,6 +54,11 @@
                             "School": {"alpha": 0.0},
                             "Community": {"alpha": 0.0}},
         "itinerary_ratios": {"Home": 0.25, "Work": 0.25, "School": 0.25, "Community": 0.25},
+        "weekends": {
+            "delay": 3.0,
+            "prop_school_time_to_home": 0.5,
+            "prop_school_time_to_comm": 0.5
+        },
         "prevalence_report": {
             "write": true,
             "filename": "person_property_count.csv",

--- a/input/input.json
+++ b/input/input.json
@@ -54,11 +54,21 @@
                             "School": {"alpha": 0.0},
                             "Community": {"alpha": 0.0}},
         "itinerary_ratios": {"Home": 0.25, "Work": 0.25, "School": 0.25, "Community": 0.25},
-        "weekends": {
-            "delay": 3.0,
-            "prop_school_time_to_home": 0.5,
-            "prop_school_time_to_comm": 0.5
-        },
+        "school_calendar": [
+            {
+                "modifier": "Weekend",
+                "start_time": 3.0,
+                "prop_school_time_to_home": 0.5,
+                "prop_school_time_to_comm": 0.5
+            },
+            {
+                "modifier": "SummerBreak",
+                "start_time": 151.0,
+                "end_time": 226.0,
+                "prop_school_time_to_home": 0.5,
+                "prop_school_time_to_comm": 0.5
+            }
+        ],
         "prevalence_report": {
             "write": true,
             "filename": "person_property_count.csv",

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -160,13 +160,19 @@ impl ContextItineraryModifierExt for Context {
         for modifier in modifiers {
             layered_modifier = Some(match layered_modifier {
                 Some(mut existing) => {
-                    if modifier.accept(self, person_id){
+                    if modifier.accept(self, person_id) {
                         existing.layer(modifier)
                     } else {
                         existing
                     }
-                },
-                None => modifier,
+                }
+                None => {
+                    if modifier.accept(self, person_id) {
+                        modifier
+                    } else {
+                        continue;
+                    }
+                }
             });
         }
         if let Some(mut layered_modifier) = layered_modifier {
@@ -179,12 +185,14 @@ impl ContextItineraryModifierExt for Context {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use super::*;
     use crate::Age;
-    use crate::itinerary_modifiers::define_itinerary_modifier;
+    use crate::itinerary_modifiers::{AcceptanceFunction, define_itinerary_modifier};
     use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::settings::{Itinerary, SettingCategory};
-    use ixa::HashMap;
+    use ixa::{ExecutionPhase, HashMap};
 
     fn setup() -> Context {
         let mut context = Context::new();
@@ -223,7 +231,8 @@ mod test {
             [0.5, 0.0, 0.0, 0.5],
             [0.0, 0.0, 0.0, 0.0],
         ];
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
+        let weekend_modifier =
+            define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
 
         context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
@@ -258,7 +267,8 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
+        let weekend_modifier =
+            define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
         let school_transient_matrix = [
             [0.0, 0.0, 0.0, 0.0],
             [0.75, 0.0, 0.0, 0.25],
@@ -273,10 +283,12 @@ mod test {
         let modifiers = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers.len(), 2);
         assert!(
-            modifiers.contains(&(Box::new(school_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
+            modifiers
+                .contains(&(Box::new(school_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
         assert!(
-            modifiers.contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
+            modifiers
+                .contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
     }
 
@@ -298,13 +310,15 @@ mod test {
         let modifiers_p1 = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers_p1.len(), 1);
         assert!(
-            modifiers_p1.contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
+            modifiers_p1
+                .contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
 
         let modifiers_p2 = context.get_itinerary_modifiers(p2);
         assert_eq!(modifiers_p2.len(), 1);
         assert!(
-            modifiers_p2.contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
+            modifiers_p2
+                .contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
 
         // This would remove all age based itinerary modifiers that is not ideal.
@@ -421,5 +435,85 @@ mod test {
 
         let modified_itinerary = context.get_itinerary(p1);
         assert_eq!(modified_itinerary, [1.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_single_itinerary_modifier_with_acceptance_function() {
+        let mut context = setup();
+        let modifier_matrix = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0, 0.5],
+            [0.5, 0.0, 0.0, 0.5],
+            [0.0, 0.0, 0.0, 0.0],
+        ];
+        let acceptance: AcceptanceFunction =
+            Arc::new(move |context, _person| context.get_current_time() > 5.0);
+        let modifier = define_itinerary_modifier(Some(modifier_matrix), None, Some(acceptance));
+        context.register_itinerary_modifier(Age(11), modifier);
+        let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
+        context.set_property(
+            p1,
+            Itinerary {
+                setting_ids: [None, None, None, None],
+                itinerary_ratios: [0.3, 0.0, 0.5, 0.2],
+            },
+        );
+
+        assert_eq!(context.get_itinerary(p1), [0.3, 0.0, 0.5, 0.2]);
+        context.add_plan_with_phase(10.0, ixa::Context::shutdown, ExecutionPhase::Last);
+        context.execute();
+        assert_eq!(context.get_itinerary(p1), [0.55, 0.0, 0.0, 0.45]);
+    }
+
+    #[test]
+    fn test_two_itinerary_modifiers_with_acceptance_function() {
+        let mut context = setup();
+        let modifier_one_matrix = [
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ];
+        let acceptance: AcceptanceFunction =
+            Arc::new(move |context, _person| context.get_current_time() > 5.0);
+        let modifier_one =
+            define_itinerary_modifier(Some(modifier_one_matrix), None, Some(acceptance));
+        context.register_itinerary_modifier(Age(11), modifier_one);
+
+        let modifier_two_matrix = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ];
+        let acceptance_two: AcceptanceFunction = Arc::new(move |context, _person| {
+            context.get_current_time() < 10.0 && context.get_current_time() > 7.0
+        });
+        let modifier_two =
+            define_itinerary_modifier(Some(modifier_two_matrix), None, Some(acceptance_two));
+        context.register_itinerary_modifier(Age(11), modifier_two);
+
+        let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
+        context.set_property(
+            p1,
+            Itinerary {
+                setting_ids: [None, None, None, None],
+                itinerary_ratios: [0.3, 0.2, 0.4, 0.1],
+            },
+        );
+
+        assert_eq!(context.get_itinerary(p1), [0.3, 0.2, 0.4, 0.1]);
+
+        context.add_plan(6.0, move |context| {
+            assert_eq!(context.get_itinerary(p1), [0.5, 0.0, 0.4, 0.1]);
+        });
+
+        context.add_plan(8.0, move |context| {
+            assert_eq!(context.get_itinerary(p1), [0.5, 0.0, 0.0, 0.5]);
+        });
+
+        context.add_plan_with_phase(20.0, ixa::Context::shutdown, ExecutionPhase::Last);
+        context.execute();
+        assert_eq!(context.get_itinerary(p1), [0.5, 0.0, 0.4, 0.1]);
     }
 }

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -185,14 +185,13 @@ impl ContextItineraryModifierExt for Context {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
     use super::*;
     use crate::Age;
-    use crate::itinerary_modifiers::{AcceptanceFunction, define_itinerary_modifier};
+    use crate::itinerary_modifiers::{AcceptanceFunction, create_itinerary_transition_matrix};
     use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::settings::{Itinerary, SettingCategory};
     use ixa::{ExecutionPhase, HashMap};
+    use std::rc::Rc;
 
     fn setup() -> Context {
         let mut context = Context::new();
@@ -232,7 +231,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
         let weekend_modifier =
-            define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
+            create_itinerary_transition_matrix(Some(weekend_transient_matrix), None, None);
 
         context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
@@ -268,7 +267,7 @@ mod test {
         ];
 
         let weekend_modifier =
-            define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
+            create_itinerary_transition_matrix(Some(weekend_transient_matrix), None, None);
         let school_transient_matrix = [
             [0.0, 0.0, 0.0, 0.0],
             [0.75, 0.0, 0.0, 0.25],
@@ -276,7 +275,8 @@ mod test {
             [0.75, 0.0, 0.0, 0.25],
         ];
 
-        let school_modifier = define_itinerary_modifier(Some(school_transient_matrix), None, None);
+        let school_modifier =
+            create_itinerary_transition_matrix(Some(school_transient_matrix), None, None);
         context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
         context.register_itinerary_modifier(Age(11), school_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
@@ -302,7 +302,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
+        let weekend_modifier = create_itinerary_transition_matrix(Some(weekend_matrix), None, None);
         context.register_itinerary_modifier(Age(10), weekend_modifier.clone());
         context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
@@ -353,7 +353,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
+        let weekend_modifier = create_itinerary_transition_matrix(Some(weekend_matrix), None, None);
 
         let sip_transient_matrix = [
             [0.0, 0.0, 0.0, 0.0],
@@ -368,8 +368,11 @@ mod test {
             [0.0, 0.0, 1.0, 0.0],
             [0.0, 0.0, 0.0, 1.0],
         ];
-        let sip_modifier =
-            define_itinerary_modifier(Some(sip_transient_matrix), Some(sip_location_matrix), None);
+        let sip_modifier = create_itinerary_transition_matrix(
+            Some(sip_transient_matrix),
+            Some(sip_location_matrix),
+            None,
+        );
 
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
 
@@ -419,8 +422,9 @@ mod test {
             [1.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
-        let isolation_modifier = define_itinerary_modifier(Some(isolation_matrix), None, None);
+        let weekend_modifier = create_itinerary_transition_matrix(Some(weekend_matrix), None, None);
+        let isolation_modifier =
+            create_itinerary_transition_matrix(Some(isolation_matrix), None, None);
 
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         context.register_itinerary_modifier(Age(11), weekend_modifier);
@@ -447,8 +451,9 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
         let acceptance: AcceptanceFunction =
-            Arc::new(move |context, _person| context.get_current_time() > 5.0);
-        let modifier = define_itinerary_modifier(Some(modifier_matrix), None, Some(acceptance));
+            Rc::new(move |context, _person| context.get_current_time() > 5.0);
+        let modifier =
+            create_itinerary_transition_matrix(Some(modifier_matrix), None, Some(acceptance));
         context.register_itinerary_modifier(Age(11), modifier);
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         context.set_property(
@@ -475,9 +480,9 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
         let acceptance: AcceptanceFunction =
-            Arc::new(move |context, _person| context.get_current_time() > 5.0);
+            Rc::new(move |context, _person| context.get_current_time() > 5.0);
         let modifier_one =
-            define_itinerary_modifier(Some(modifier_one_matrix), None, Some(acceptance));
+            create_itinerary_transition_matrix(Some(modifier_one_matrix), None, Some(acceptance));
         context.register_itinerary_modifier(Age(11), modifier_one);
 
         let modifier_two_matrix = [
@@ -486,11 +491,14 @@ mod test {
             [0.0, 0.0, 0.0, 1.0],
             [0.0, 0.0, 0.0, 0.0],
         ];
-        let acceptance_two: AcceptanceFunction = Arc::new(move |context, _person| {
+        let acceptance_two: AcceptanceFunction = Rc::new(move |context, _person| {
             context.get_current_time() < 10.0 && context.get_current_time() > 7.0
         });
-        let modifier_two =
-            define_itinerary_modifier(Some(modifier_two_matrix), None, Some(acceptance_two));
+        let modifier_two = create_itinerary_transition_matrix(
+            Some(modifier_two_matrix),
+            None,
+            Some(acceptance_two),
+        );
         context.register_itinerary_modifier(Age(11), modifier_two);
 
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();

--- a/src/itinerary_manager.rs
+++ b/src/itinerary_manager.rs
@@ -15,6 +15,7 @@ pub trait ItineraryModifierTrait: std::fmt::Debug + DynClone + 'static {
     fn layer(&mut self, other: Box<dyn ItineraryModifierTrait>) -> Box<dyn ItineraryModifierTrait>;
     fn apply(&mut self, base_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT];
     fn as_any(&self) -> &dyn Any;
+    fn accept(&self, context: &Context, person_id: PersonId) -> bool;
 }
 
 // This is implemented for testing
@@ -158,7 +159,13 @@ impl ContextItineraryModifierExt for Context {
         let mut layered_modifier: Option<Box<dyn ItineraryModifierTrait>> = None;
         for modifier in modifiers {
             layered_modifier = Some(match layered_modifier {
-                Some(mut existing) => existing.layer(modifier),
+                Some(mut existing) => {
+                    if modifier.accept(self, person_id){
+                        existing.layer(modifier)
+                    } else {
+                        existing
+                    }
+                },
                 None => modifier,
             });
         }
@@ -216,9 +223,9 @@ mod test {
             [0.5, 0.0, 0.0, 0.5],
             [0.0, 0.0, 0.0, 0.0],
         ];
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None);
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
 
-        context.register_itinerary_modifier(Age(11), weekend_modifier);
+        context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
         let p2 = context.add_entity(with!(Person, Age(11))).unwrap();
         let modifiers_p1 = context.get_itinerary_modifiers(p1);
@@ -226,17 +233,17 @@ mod test {
         assert_eq!(modifiers_p1.len(), 0);
         assert_eq!(
             modifiers_p2,
-            vec![Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>]
+            vec![Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>]
         );
 
-        context.register_itinerary_modifier(Age(10), weekend_modifier);
+        context.register_itinerary_modifier(Age(10), weekend_modifier.clone());
         assert_eq!(
             context.get_itinerary_modifiers(p1),
-            vec![Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>]
+            vec![Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>]
         );
         assert_eq!(
             context.get_itinerary_modifiers(p2),
-            vec![Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>]
+            vec![Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>]
         );
     }
 
@@ -251,8 +258,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None);
-
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_transient_matrix), None, None);
         let school_transient_matrix = [
             [0.0, 0.0, 0.0, 0.0],
             [0.75, 0.0, 0.0, 0.25],
@@ -260,18 +266,17 @@ mod test {
             [0.75, 0.0, 0.0, 0.25],
         ];
 
-        let school_modifier = define_itinerary_modifier(Some(school_transient_matrix), None);
-
-        context.register_itinerary_modifier(Age(11), weekend_modifier);
-        context.register_itinerary_modifier(Age(11), school_modifier);
+        let school_modifier = define_itinerary_modifier(Some(school_transient_matrix), None, None);
+        context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
+        context.register_itinerary_modifier(Age(11), school_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         let modifiers = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers.len(), 2);
         assert!(
-            modifiers.contains(&(Box::new(school_modifier) as Box<dyn ItineraryModifierTrait>))
+            modifiers.contains(&(Box::new(school_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
         assert!(
-            modifiers.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+            modifiers.contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
     }
 
@@ -285,21 +290,21 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
-        context.register_itinerary_modifier(Age(10), weekend_modifier);
-        context.register_itinerary_modifier(Age(11), weekend_modifier);
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
+        context.register_itinerary_modifier(Age(10), weekend_modifier.clone());
+        context.register_itinerary_modifier(Age(11), weekend_modifier.clone());
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         let p2 = context.add_entity(with!(Person, Age(10))).unwrap();
         let modifiers_p1 = context.get_itinerary_modifiers(p1);
         assert_eq!(modifiers_p1.len(), 1);
         assert!(
-            modifiers_p1.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+            modifiers_p1.contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
 
         let modifiers_p2 = context.get_itinerary_modifiers(p2);
         assert_eq!(modifiers_p2.len(), 1);
         assert!(
-            modifiers_p2.contains(&(Box::new(weekend_modifier) as Box<dyn ItineraryModifierTrait>))
+            modifiers_p2.contains(&(Box::new(weekend_modifier.clone()) as Box<dyn ItineraryModifierTrait>))
         );
 
         // This would remove all age based itinerary modifiers that is not ideal.
@@ -334,7 +339,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
 
         let sip_transient_matrix = [
             [0.0, 0.0, 0.0, 0.0],
@@ -350,7 +355,7 @@ mod test {
             [0.0, 0.0, 0.0, 1.0],
         ];
         let sip_modifier =
-            define_itinerary_modifier(Some(sip_transient_matrix), Some(sip_location_matrix));
+            define_itinerary_modifier(Some(sip_transient_matrix), Some(sip_location_matrix), None);
 
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
 
@@ -400,8 +405,8 @@ mod test {
             [1.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
-        let isolation_modifier = define_itinerary_modifier(Some(isolation_matrix), None);
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
+        let isolation_modifier = define_itinerary_modifier(Some(isolation_matrix), None, None);
 
         let p1 = context.add_entity(with!(Person, Age(11))).unwrap();
         context.register_itinerary_modifier(Age(11), weekend_modifier);

--- a/src/itinerary_modifiers.rs
+++ b/src/itinerary_modifiers.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::any::Any;
 
 use crate::{itinerary_manager::ItineraryModifierTrait, settings::SETTING_COUNT};
 
 const TRANSIENT_STATE_COUNT: usize = SETTING_COUNT * 2;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Copy)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Copy)]
 pub struct ItineraryTransitionMatrix {
     activity_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
     location_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],

--- a/src/itinerary_modifiers.rs
+++ b/src/itinerary_modifiers.rs
@@ -1,6 +1,6 @@
 use ixa::Context;
 use serde::{Deserialize, Serialize};
-use std::{any::Any, sync::Arc};
+use std::{any::Any, rc::Rc};
 
 use crate::{
     itinerary_manager::ItineraryModifierTrait,
@@ -9,7 +9,7 @@ use crate::{
 
 const TRANSIENT_STATE_COUNT: usize = SETTING_COUNT * 2;
 
-pub type AcceptanceFunction = Arc<dyn Fn(&Context, PersonId) -> bool + Send + Sync + 'static>;
+pub type AcceptanceFunction = Rc<dyn Fn(&Context, PersonId) -> bool>;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ItineraryTransitionMatrix {
@@ -235,7 +235,7 @@ impl ItineraryTransitionMatrix {
     }
 }
 
-pub fn define_itinerary_modifier(
+pub fn create_itinerary_transition_matrix(
     activity_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
     location_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
     acceptance_function: Option<AcceptanceFunction>,
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_define_itinerary_modifier_with_none() {
-        let modifier = define_itinerary_modifier(None, None, None);
+        let modifier = create_itinerary_transition_matrix(None, None, None);
         assert_eq!(
             modifier.activity_matrix,
             [[0.0; SETTING_COUNT]; SETTING_COUNT]
@@ -273,7 +273,7 @@ mod tests {
         activity[0][0] = 0.5;
         location[0][1] = 0.3;
 
-        let modifier = define_itinerary_modifier(Some(activity), Some(location), None);
+        let modifier = create_itinerary_transition_matrix(Some(activity), Some(location), None);
         assert_eq!(modifier.activity_matrix[0][0], 0.5);
         assert_eq!(modifier.location_matrix[0][1], 0.3);
     }

--- a/src/itinerary_modifiers.rs
+++ b/src/itinerary_modifiers.rs
@@ -1,15 +1,37 @@
+use ixa::Context;
 use serde::{Deserialize, Serialize};
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 
-use crate::{itinerary_manager::ItineraryModifierTrait, settings::SETTING_COUNT};
+use crate::{itinerary_manager::ItineraryModifierTrait, settings::{PersonId, SETTING_COUNT}};
 
 const TRANSIENT_STATE_COUNT: usize = SETTING_COUNT * 2;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Copy)]
+type AcceptanceFunction = Arc<dyn Fn(&Context, PersonId) -> bool + Send + Sync + 'static>;
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ItineraryTransitionMatrix {
     activity_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
     location_matrix: [[f64; SETTING_COUNT]; SETTING_COUNT],
     absorption_probabilities: Option<[[f64; SETTING_COUNT]; TRANSIENT_STATE_COUNT]>,
+    #[serde(skip, default)]
+    acceptance_function: Option<AcceptanceFunction>,
+}
+
+impl std::fmt::Debug for ItineraryTransitionMatrix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ItineraryTransitionMatrix")
+            .field("activity_matrix", &self.activity_matrix)
+            .field("location_matrix", &self.location_matrix)
+            .field(
+                "absorption_probabilities",
+                &self.absorption_probabilities,
+            )
+            .field(
+                "has_acceptance_function",
+                &self.acceptance_function.is_some(),
+            )
+            .finish()
+    }
 }
 
 impl ItineraryModifierTrait for ItineraryTransitionMatrix {
@@ -25,6 +47,15 @@ impl ItineraryModifierTrait for ItineraryTransitionMatrix {
     }
     fn apply(&mut self, base_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT] {
         self.apply(base_itinerary)
+    }
+    fn accept(
+        &self,
+        context: &Context,
+        person_id: PersonId,
+    ) -> bool {
+        self.acceptance_function
+            .as_ref()
+            .map_or(true, |acceptance| acceptance(context, person_id))
     }
 }
 
@@ -85,6 +116,7 @@ impl ItineraryTransitionMatrix {
         &self,
         itinerary_transition_matrix: &ItineraryTransitionMatrix,
     ) -> ItineraryTransitionMatrix {
+
         let mut layered_activity_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
         let mut layered_location_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
 
@@ -96,11 +128,14 @@ impl ItineraryTransitionMatrix {
                     self.location_matrix[i][j] + itinerary_transition_matrix.location_matrix[i][j];
             }
         }
-
+        
+        // WARNING: You need to evaluated the acceptance function before they are layered.
+        // If both modifiers have acceptance functions, the layered modifier will not have an acceptance function.
         ItineraryTransitionMatrix {
             activity_matrix: layered_activity_matrix,
             location_matrix: layered_location_matrix,
             absorption_probabilities: None,
+            acceptance_function: None
         }
     }
 
@@ -208,11 +243,13 @@ impl ItineraryTransitionMatrix {
 pub fn define_itinerary_modifier(
     activity_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
     location_matrix: Option<[[f64; SETTING_COUNT]; SETTING_COUNT]>,
+    acceptance_function: Option<AcceptanceFunction>,
 ) -> ItineraryTransitionMatrix {
     ItineraryTransitionMatrix {
         activity_matrix: activity_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
         location_matrix: location_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
         absorption_probabilities: None,
+        acceptance_function
     }
 }
 
@@ -222,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_define_itinerary_modifier_with_none() {
-        let modifier = define_itinerary_modifier(None, None);
+        let modifier = define_itinerary_modifier(None, None, None);
         assert_eq!(
             modifier.activity_matrix,
             [[0.0; SETTING_COUNT]; SETTING_COUNT]
@@ -241,7 +278,7 @@ mod tests {
         activity[0][0] = 0.5;
         location[0][1] = 0.3;
 
-        let modifier = define_itinerary_modifier(Some(activity), Some(location));
+        let modifier = define_itinerary_modifier(Some(activity), Some(location), None);
         assert_eq!(modifier.activity_matrix[0][0], 0.5);
         assert_eq!(modifier.location_matrix[0][1], 0.3);
     }
@@ -257,6 +294,7 @@ mod tests {
             },
             location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
             absorption_probabilities: None,
+            acceptance_function: None,
         };
 
         matrix.normalize();
@@ -275,6 +313,7 @@ mod tests {
             },
             location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
             absorption_probabilities: None,
+            acceptance_function: None,
         };
 
         matrix.normalize();
@@ -292,6 +331,7 @@ mod tests {
             },
             location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
             absorption_probabilities: None,
+            acceptance_function: None,
         };
 
         let matrix2 = ItineraryTransitionMatrix {
@@ -302,6 +342,7 @@ mod tests {
             },
             location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
             absorption_probabilities: None,
+            acceptance_function: None,
         };
 
         let layered = matrix1.layer(&matrix2);
@@ -319,6 +360,7 @@ mod tests {
             },
             location_matrix: [[0.0; SETTING_COUNT]; SETTING_COUNT],
             absorption_probabilities: None,
+            acceptance_function: None,
         };
 
         let (transient, absorbing) = matrix.build_transient_and_absorbing_matrix();

--- a/src/itinerary_modifiers.rs
+++ b/src/itinerary_modifiers.rs
@@ -2,11 +2,14 @@ use ixa::Context;
 use serde::{Deserialize, Serialize};
 use std::{any::Any, sync::Arc};
 
-use crate::{itinerary_manager::ItineraryModifierTrait, settings::{PersonId, SETTING_COUNT}};
+use crate::{
+    itinerary_manager::ItineraryModifierTrait,
+    settings::{PersonId, SETTING_COUNT},
+};
 
 const TRANSIENT_STATE_COUNT: usize = SETTING_COUNT * 2;
 
-type AcceptanceFunction = Arc<dyn Fn(&Context, PersonId) -> bool + Send + Sync + 'static>;
+pub type AcceptanceFunction = Arc<dyn Fn(&Context, PersonId) -> bool + Send + Sync + 'static>;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ItineraryTransitionMatrix {
@@ -22,10 +25,7 @@ impl std::fmt::Debug for ItineraryTransitionMatrix {
         f.debug_struct("ItineraryTransitionMatrix")
             .field("activity_matrix", &self.activity_matrix)
             .field("location_matrix", &self.location_matrix)
-            .field(
-                "absorption_probabilities",
-                &self.absorption_probabilities,
-            )
+            .field("absorption_probabilities", &self.absorption_probabilities)
             .field(
                 "has_acceptance_function",
                 &self.acceptance_function.is_some(),
@@ -48,14 +48,10 @@ impl ItineraryModifierTrait for ItineraryTransitionMatrix {
     fn apply(&mut self, base_itinerary: &[f64; SETTING_COUNT]) -> [f64; SETTING_COUNT] {
         self.apply(base_itinerary)
     }
-    fn accept(
-        &self,
-        context: &Context,
-        person_id: PersonId,
-    ) -> bool {
+    fn accept(&self, context: &Context, person_id: PersonId) -> bool {
         self.acceptance_function
             .as_ref()
-            .map_or(true, |acceptance| acceptance(context, person_id))
+            .is_none_or(|acceptance| acceptance(context, person_id))
     }
 }
 
@@ -116,7 +112,6 @@ impl ItineraryTransitionMatrix {
         &self,
         itinerary_transition_matrix: &ItineraryTransitionMatrix,
     ) -> ItineraryTransitionMatrix {
-
         let mut layered_activity_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
         let mut layered_location_matrix = [[0.0; SETTING_COUNT]; SETTING_COUNT];
 
@@ -128,14 +123,14 @@ impl ItineraryTransitionMatrix {
                     self.location_matrix[i][j] + itinerary_transition_matrix.location_matrix[i][j];
             }
         }
-        
+
         // WARNING: You need to evaluated the acceptance function before they are layered.
         // If both modifiers have acceptance functions, the layered modifier will not have an acceptance function.
         ItineraryTransitionMatrix {
             activity_matrix: layered_activity_matrix,
             location_matrix: layered_location_matrix,
             absorption_probabilities: None,
-            acceptance_function: None
+            acceptance_function: None,
         }
     }
 
@@ -249,7 +244,7 @@ pub fn define_itinerary_modifier(
         activity_matrix: activity_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
         location_matrix: location_matrix.unwrap_or([[0.0; SETTING_COUNT]; SETTING_COUNT]),
         absorption_probabilities: None,
-        acceptance_function
+        acceptance_function,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod pop_reader;
 pub mod population_loader;
 pub mod rate_fns;
 pub mod reports;
+pub mod school_calendar;
 mod setting_code;
 pub mod settings;
 pub mod symptom_status_manager;

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,7 +4,7 @@ use ixa::{ExecutionPhase, prelude::*};
 
 use crate::{
     abort_run, error::ModelError, infection_importation, infection_propagation_loop, parameters,
-    population_loader, reports, settings, symptom_status_manager,
+    population_loader, reports, school_calendar, settings, symptom_status_manager,
 };
 
 pub fn initialize_model(
@@ -37,6 +37,8 @@ pub fn initialize_model(
     info!("Infection propagation loop initialized");
     infection_importation::init(context)?;
     info!("Infection importation initialized");
+    school_calendar::init(context);
+    info!("School calendar initialized");
     reports::init(context)?;
     info!("Reports initialized");
     abort_run::init(context);

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -4,6 +4,7 @@ use std::{fmt::Debug, path::PathBuf};
 
 use crate::error::ModelError;
 use crate::infection_importation::ImportCasesFromFile;
+use crate::itinerary_modifiers::ItineraryTransitionMatrix;
 use crate::reports::ReportParams;
 use crate::settings::SettingCategory;
 use crate::symptom_status_manager::{SymptomAgeGroup, SymptomDelayDistLogNormParams};
@@ -23,6 +24,11 @@ pub enum RateFnType {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct SettingProperties {
     pub alpha: f64,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub struct Weekends {
+    pub itinerary_modifier: Option<ItineraryTransitionMatrix>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -68,6 +74,8 @@ pub struct Params {
     pub settings_properties: HashMap<SettingCategory, SettingProperties>,
     /// ratios used to initialize individuals itineraries by setting type.
     pub itinerary_ratios: HashMap<SettingCategory, f64>,
+    /// itinerary modifier for weekends
+    pub weekends: Weekends,
     /// Prevalence report with a period and name required
     pub prevalence_report: ReportParams,
     /// Incidence report with a period and name required
@@ -356,6 +364,9 @@ impl Default for Params {
             },
             settings_properties: HashMap::new(),
             itinerary_ratios: HashMap::new(),
+            weekends: Weekends {
+                itinerary_modifier: None,
+            },
             prevalence_report: ReportParams {
                 write: false,
                 filename: None,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -4,7 +4,6 @@ use std::{fmt::Debug, path::PathBuf};
 
 use crate::error::ModelError;
 use crate::infection_importation::ImportCasesFromFile;
-use crate::itinerary_modifiers::ItineraryTransitionMatrix;
 use crate::reports::ReportParams;
 use crate::settings::SettingCategory;
 use crate::symptom_status_manager::{SymptomAgeGroup, SymptomDelayDistLogNormParams};
@@ -28,7 +27,9 @@ pub struct SettingProperties {
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct Weekends {
-    pub itinerary_modifier: Option<ItineraryTransitionMatrix>,
+    pub delay: Option<f64>,
+    pub prop_school_time_to_home: Option<f64>,
+    pub prop_school_time_to_comm: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -285,6 +286,33 @@ fn validate_inputs(parameters: &Params) -> Result<(), Box<dyn std::error::Error 
         )));
     }
 
+    // Validate weekends parameter
+    if let Some(delay) = parameters.weekends.delay
+        && delay <= 0.0
+    {
+        return Err(Box::new(ModelError::ModelError(
+            "The delay for weekends must be greater than zero.".to_string(),
+        )));
+    }
+
+    if let (Some(proportion_home), Some(proportion_community)) = (
+        parameters.weekends.prop_school_time_to_home,
+        parameters.weekends.prop_school_time_to_comm,
+    ) {
+        if proportion_home <= 0.0 || proportion_community <= 0.0 {
+            return Err(Box::new(ModelError::ModelError(
+                "The proportions moved to home and community must be greater than zero."
+                    .to_string(),
+            )));
+        }
+        if (proportion_home + proportion_community - 1.0).abs() > f64::EPSILON {
+            return Err(Box::new(ModelError::ModelError(
+                "The sum of proportions moved to home and community must be equal to one."
+                    .to_string(),
+            )));
+        }
+    }
+
     Ok(())
 }
 
@@ -365,7 +393,9 @@ impl Default for Params {
             settings_properties: HashMap::new(),
             itinerary_ratios: HashMap::new(),
             weekends: Weekends {
-                itinerary_modifier: None,
+                delay: None,
+                prop_school_time_to_home: None,
+                prop_school_time_to_comm: None,
             },
             prevalence_report: ReportParams {
                 write: false,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -5,6 +5,7 @@ use std::{fmt::Debug, path::PathBuf};
 use crate::error::ModelError;
 use crate::infection_importation::ImportCasesFromFile;
 use crate::reports::ReportParams;
+use crate::school_calendar::{SchoolCalendarModifier, SchoolCalendarModifierType};
 use crate::settings::SettingCategory;
 use crate::symptom_status_manager::{SymptomAgeGroup, SymptomDelayDistLogNormParams};
 
@@ -23,13 +24,6 @@ pub enum RateFnType {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct SettingProperties {
     pub alpha: f64,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
-pub struct Weekends {
-    pub delay: Option<f64>,
-    pub prop_school_time_to_home: Option<f64>,
-    pub prop_school_time_to_comm: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -76,7 +70,7 @@ pub struct Params {
     /// ratios used to initialize individuals itineraries by setting type.
     pub itinerary_ratios: HashMap<SettingCategory, f64>,
     /// itinerary modifier for weekends
-    pub weekends: Weekends,
+    pub school_calendar: Vec<SchoolCalendarModifier>,
     /// Prevalence report with a period and name required
     pub prevalence_report: ReportParams,
     /// Incidence report with a period and name required
@@ -286,33 +280,34 @@ fn validate_inputs(parameters: &Params) -> Result<(), Box<dyn std::error::Error 
         )));
     }
 
-    // Validate weekends parameter
-    if let Some(delay) = parameters.weekends.delay
-        && delay < 0.0
-    {
-        return Err(Box::new(ModelError::ModelError(
-            "The delay for weekends must be non-negative.".to_string(),
-        )));
-    }
-
-    if let (Some(proportion_home), Some(proportion_community)) = (
-        parameters.weekends.prop_school_time_to_home,
-        parameters.weekends.prop_school_time_to_comm,
-    ) {
-        if proportion_home <= 0.0 || proportion_community <= 0.0 {
-            return Err(Box::new(ModelError::ModelError(
-                "The proportions moved to home and community must be greater than zero."
-                    .to_string(),
-            )));
+    let mut unique_school_calendar_modifiers: Vec<SchoolCalendarModifier> = Vec::new();
+    for school_calendar_modifier in &parameters.school_calendar {
+        let modifier_params = school_calendar_modifier.clone();
+        modifier_params.validate()?;
+        for unique_modifier in &unique_school_calendar_modifiers {
+            if school_calendar_modifier == unique_modifier {
+                return Err(Box::new(ModelError::ModelError(
+                    "Duplicate school calendar modifiers are not allowed.".to_string(),
+                )));
+            }
+            if school_calendar_modifier.modifier == SchoolCalendarModifierType::Weekend
+                && unique_modifier.modifier == SchoolCalendarModifierType::Weekend
+            {
+                return Err(Box::new(ModelError::ModelError(
+                    "Only one weekend modifier is allowed.".to_string(),
+                )));
+            }
+            if school_calendar_modifier.modifier != SchoolCalendarModifierType::Weekend
+                && modifier_params.end_time.is_none()
+            {
+                return Err(Box::new(ModelError::ModelError(
+                    "end_time must be specified for non-weekend school calendar modifiers"
+                        .to_string(),
+                )));
+            }
         }
-        if (proportion_home + proportion_community - 1.0).abs() > f64::EPSILON {
-            return Err(Box::new(ModelError::ModelError(
-                "The sum of proportions moved to home and community must be equal to one."
-                    .to_string(),
-            )));
-        }
+        unique_school_calendar_modifiers.push(school_calendar_modifier.clone());
     }
-
     Ok(())
 }
 
@@ -392,11 +387,7 @@ impl Default for Params {
             },
             settings_properties: HashMap::new(),
             itinerary_ratios: HashMap::new(),
-            weekends: Weekends {
-                delay: None,
-                prop_school_time_to_home: None,
-                prop_school_time_to_comm: None,
-            },
+            school_calendar: Vec::new(),
             prevalence_report: ReportParams {
                 write: false,
                 filename: None,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -288,10 +288,10 @@ fn validate_inputs(parameters: &Params) -> Result<(), Box<dyn std::error::Error 
 
     // Validate weekends parameter
     if let Some(delay) = parameters.weekends.delay
-        && delay <= 0.0
+        && delay < 0.0
     {
         return Err(Box::new(ModelError::ModelError(
-            "The delay for weekends must be greater than zero.".to_string(),
+            "The delay for weekends must be non-negative.".to_string(),
         )));
     }
 

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -1,13 +1,14 @@
 use ixa::{
-    ExecutionPhase, impl_derived_property,
+    ExecutionPhase, IxaEvent, impl_derived_property,
     prelude::*,
-    triggers::{PeriodicTimeTrigger, TriggerCriterion},
+    triggers::{ContextTriggersExt, PeriodicTimeTrigger, TriggerCriterion},
 };
 use serde::Serialize;
 
 use crate::{
     ContextParametersExt, Params,
-    itinerary_modifiers::ItineraryTransitionMatrix,
+    itinerary_manager::ContextItineraryModifierExt,
+    itinerary_modifiers::{ItineraryTransitionMatrix, define_itinerary_modifier},
     settings::{Itinerary, Person, SettingCategory},
 };
 
@@ -18,25 +19,179 @@ impl_derived_property!(GoesToSchool, Person, [Itinerary], [], |itinerary| {
     GoesToSchool(itinerary.setting_ids[SettingCategory::School].is_some())
 });
 
-pub trait ContextCalendarExt: PluginContext + ContextEntitiesExt + ContextParametersExt {
-    fn add_weekends(
-        &mut self,
-        weekend_itinerary_modifier: ItineraryTransitionMatrix,
-        max_time: f64,
-    ) {
-        let trigger = PeriodicTimeTrigger::every(7.0)
+#[derive(IxaEvent)]
+struct Weekend {
+    active: bool,
+}
+
+pub trait ContextCalendarExt:
+    PluginContext + ContextEntitiesExt + ContextParametersExt + ContextTriggersExt
+{
+    fn setup_weekend_triggers(&mut self, delay: f64) {
+        let weekend_start_trigger = PeriodicTimeTrigger::every(7.0)
             .with_phase(ExecutionPhase::Last)
-            .start_with_delay(3.0)
-            .emit_value(Weekend);
+            .start_with_delay(delay)
+            .emit_value(Weekend { active: true });
+        let weekend_end_trigger = PeriodicTimeTrigger::every(7.0)
+            .with_phase(ExecutionPhase::Last)
+            .start_with_delay(delay + 2.0)
+            .emit_value(Weekend { active: false });
+        self.register_trigger(weekend_start_trigger);
+        self.register_trigger(weekend_end_trigger);
+    }
+    fn setup_weekend_itinerary_modification(
+        &mut self,
+        itinerary_modifier: ItineraryTransitionMatrix,
+    ) {
+        self.subscribe_to_event(move |context, event: Weekend| {
+            if event.active {
+                context.register_itinerary_modifier(GoesToSchool(true), itinerary_modifier);
+            } else {
+                context.remove_itinerary_modifier_by_property(GoesToSchool(true));
+            }
+        });
     }
 }
 impl ContextCalendarExt for Context {}
 
 pub fn init(context: &mut Context) {
-    let Params {
-        max_time, weekends, ..
-    } = context.get_params().clone();
-    if let Some(weekends_itinerary_modifier) = weekends.itinerary_modifier {
-        context.add_weekends(weekends_itinerary_modifier, max_time);
+    let Params { weekends, .. } = context.get_params().clone();
+    if let (Some(delay), Some(prop_school_time_to_home), Some(prop_school_time_to_comm)) = (
+        weekends.delay,
+        weekends.prop_school_time_to_home,
+        weekends.prop_school_time_to_comm,
+    ) {
+        context.setup_weekend_triggers(delay);
+        let weekend_modifier =
+            define_weekend_itinerary_modifier(prop_school_time_to_home, prop_school_time_to_comm);
+        context.setup_weekend_itinerary_modification(weekend_modifier);
+    }
+}
+
+fn define_weekend_itinerary_modifier(
+    prop_school_time_to_home: f64,
+    prop_school_time_to_comm: f64,
+) -> ItineraryTransitionMatrix {
+    let weekend_matrix = [
+        [0.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 0.0],
+        [prop_school_time_to_home, 0.0, 0.0, prop_school_time_to_comm],
+        [0.0, 0.0, 0.0, 0.0],
+    ];
+
+    define_itinerary_modifier(Some(weekend_matrix), None)
+}
+
+#[cfg(test)]
+mod test {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::Age;
+    use crate::parameters::{GlobalParams, Params, SettingProperties};
+    use crate::pop_reader::parser::parse_fips_school_id;
+    use crate::setting_code::SettingCode;
+    use crate::settings::SettingCategory;
+    use ixa::HashMap;
+
+    fn make_school_id(school_id: &[u8]) -> SettingCode {
+        SettingCode(parse_fips_school_id(school_id).unwrap().1)
+    }
+
+    fn setup() -> Context {
+        let mut context = Context::new();
+        let parameters = Params {
+            // We need to specify an itinerary split here even though we don't draw people from
+            // itineraries because `load_synth_population` calls `create_itinerary` for each person,
+            // and that function requires an itinerary write function to be set.
+            settings_properties: HashMap::from_iter(
+                [
+                    (SettingCategory::Home, SettingProperties { alpha: 0.0 }),
+                    (SettingCategory::School, SettingProperties { alpha: 0.0 }),
+                    (SettingCategory::Work, SettingProperties { alpha: 0.0 }),
+                    (SettingCategory::Community, SettingProperties { alpha: 0.0 }),
+                ]
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+            ),
+            itinerary_ratios: HashMap::from_iter([
+                (SettingCategory::Home, 0.25),
+                (SettingCategory::School, 0.25),
+                (SettingCategory::Work, 0.25),
+                (SettingCategory::Community, 0.25),
+            ]),
+            ..Default::default()
+        };
+        context
+            .set_global_property_value(GlobalParams, parameters)
+            .unwrap();
+        crate::settings::init(&mut context).unwrap();
+        context
+    }
+
+    #[test]
+    fn test_weekend_triggers() {
+        let mut context = setup();
+        let weekend_starts = Rc::new(RefCell::new(0));
+        let weekend_starts_clone: Rc<RefCell<usize>> = Rc::clone(&weekend_starts);
+        let weekend_ends = Rc::new(RefCell::new(0));
+        let weekend_ends_clone: Rc<RefCell<usize>> = Rc::clone(&weekend_ends);
+        context.setup_weekend_triggers(3.0);
+        context.subscribe_to_event(move |cxt, event: Weekend| {
+            if event.active {
+                assert_eq!(cxt.get_current_time() % 7.0, 3.0);
+                *weekend_starts_clone.borrow_mut() += 1;
+            } else {
+                assert_eq!(cxt.get_current_time() % 7.0, 5.0);
+                *weekend_ends_clone.borrow_mut() += 1;
+            }
+        });
+        context.add_plan_with_phase(18.0, ixa::Context::shutdown, ExecutionPhase::Last);
+        context.execute();
+        #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+        let observed_weekend_starts = *weekend_starts.borrow();
+        let observed_weekend_ends = *weekend_ends.borrow();
+        // weekend starts on day 3, 10, and 17
+        // weekend ends on day 5, 12, and 19
+        assert_eq!(observed_weekend_starts, 3);
+        assert_eq!(observed_weekend_ends, 2);
+    }
+
+    #[test]
+    fn test_itinerary_modification_registration() {
+        let mut context = setup();
+        let weekend_modifier = define_weekend_itinerary_modifier(0.5, 0.5);
+        let school_code = make_school_id(b"16037960200002");
+        let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
+        // context.register_itinerary_modifier(GoesToSchool(true), weekend_modifier);
+        context.setup_weekend_itinerary_modification(weekend_modifier);
+        context.set_property(
+            p1,
+            Itinerary {
+                setting_ids: [None, None, Some(school_code), None],
+                itinerary_ratios: [0.3, 0.0, 0.5, 0.2],
+            },
+        );
+        context.add_plan(1.0, move |context| {
+            context.emit_event(Weekend { active: true });
+        });
+        context.add_plan(2.0, move |context| {
+            context.emit_event(Weekend { active: false });
+        });
+
+        context.add_plan(0.0, move |context| {
+            let itinerary = context.get_itinerary(p1);
+            assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
+        });
+        context.add_plan(1.5, move |context| {
+            let itinerary = context.get_itinerary(p1);
+            assert_eq!(itinerary, [0.55, 0.0, 0.0, 0.45]);
+        });
+        context.add_plan(3.0, move |context| {
+            let itinerary = context.get_itinerary(p1);
+            assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
+        });
+        context.execute();
     }
 }

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -141,41 +141,4 @@ mod test {
         assert_eq!(observed_weekend, 9);
         assert_eq!(observed_weekday, 11);
     }
-
-    // #[test]
-    // fn test_itinerary_modification_registration() {
-    //     let mut context = setup();
-    //     let weekend_modifier = define_weekend_itinerary_modifier(0.5, 0.5);
-    //     let school_code = make_school_id(b"16037960200002");
-    //     let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
-    //     // context.register_itinerary_modifier(GoesToSchool(true), weekend_modifier);
-    //     context.setup_weekend_itinerary_modification(weekend_modifier);
-    //     context.set_property(
-    //         p1,
-    //         Itinerary {
-    //             setting_ids: [None, None, Some(school_code), None],
-    //             itinerary_ratios: [0.3, 0.0, 0.5, 0.2],
-    //         },
-    //     );
-    //     context.add_plan(1.0, move |context| {
-    //         context.emit_event(Weekend { active: true });
-    //     });
-    //     context.add_plan(2.0, move |context| {
-    //         context.emit_event(Weekend { active: false });
-    //     });
-
-    //     context.add_plan(0.0, move |context| {
-    //         let itinerary = context.get_itinerary(p1);
-    //         assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
-    //     });
-    //     context.add_plan(1.5, move |context| {
-    //         let itinerary = context.get_itinerary(p1);
-    //         assert_eq!(itinerary, [0.55, 0.0, 0.0, 0.45]);
-    //     });
-    //     context.add_plan(3.0, move |context| {
-    //         let itinerary = context.get_itinerary(p1);
-    //         assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
-    //     });
-    //     context.execute();
-    // }
 }

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -1,15 +1,16 @@
-use ixa::{impl_derived_property, prelude::*};
-use serde::Serialize;
-use std::rc::Rc;
+use std::{hash::Hash, rc::Rc};
 
 use crate::{
     ContextParametersExt, Params,
+    error::ModelError,
     itinerary_manager::ContextItineraryModifierExt,
     itinerary_modifiers::{
         AcceptanceFunction, ItineraryTransitionMatrix, create_itinerary_transition_matrix,
     },
     settings::{Itinerary, Person, SettingCategory},
 };
+use ixa::{impl_derived_property, prelude::*};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
 pub struct Student(pub bool);
@@ -18,37 +19,131 @@ impl_derived_property!(Student, Person, [Itinerary], [], |itinerary| {
     Student(itinerary.setting_ids[SettingCategory::School].is_some())
 });
 
-pub fn init(context: &mut Context) {
-    let Params { weekends, .. } = context.get_params().clone();
-    if let (Some(delay), Some(prop_school_time_to_home), Some(prop_school_time_to_comm)) = (
-        weekends.delay,
-        weekends.prop_school_time_to_home,
-        weekends.prop_school_time_to_comm,
-    ) {
-        let weekend_modifier = define_weekend_itinerary_modifier(
-            prop_school_time_to_home,
-            prop_school_time_to_comm,
-            delay,
-        );
-        context.register_itinerary_modifier(Student(true), weekend_modifier);
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SchoolCalendarModifierType {
+    Weekend,
+    SummerBreak,
+    HolidayBreak,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SchoolCalendarModifier {
+    pub modifier: SchoolCalendarModifierType,
+    pub start_time: f64,
+    pub prop_school_time_to_home: f64,
+    pub prop_school_time_to_comm: f64,
+    pub end_time: Option<f64>,
+}
+
+impl SchoolCalendarModifier {
+    pub fn validate(&self) -> Result<(), ModelError> {
+        if self.start_time < 0.0 {
+            return Err(ModelError::ModelError(
+                "start_time must be >= 0.0".to_string(),
+            ));
+        }
+        if let Some(end_time) = self.end_time
+            && end_time < self.start_time
+        {
+            return Err(ModelError::ModelError(
+                "end_time must be >= start_time".to_string(),
+            ));
+        }
+        if self.prop_school_time_to_home < 0.0 || self.prop_school_time_to_home > 1.0 {
+            return Err(ModelError::ModelError(
+                "prop_school_time_to_home must be in [0.0, 1.0]".to_string(),
+            ));
+        }
+        if self.prop_school_time_to_comm < 0.0 || self.prop_school_time_to_comm > 1.0 {
+            return Err(ModelError::ModelError(
+                "prop_school_time_to_comm must be in [0.0, 1.0]".to_string(),
+            ));
+        }
+        if self.prop_school_time_to_home + self.prop_school_time_to_comm > 1.0 {
+            return Err(ModelError::ModelError(
+                "prop_school_time_to_home + prop_school_time_to_comm must be <= 1.0".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
-fn define_weekend_itinerary_modifier(
-    prop_school_time_to_home: f64,
-    prop_school_time_to_comm: f64,
-    delay: f64,
-) -> ItineraryTransitionMatrix {
-    let weekend_matrix = [
+impl PartialEq for SchoolCalendarModifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.start_time.to_bits() == other.start_time.to_bits()
+            && self.prop_school_time_to_home.to_bits() == other.prop_school_time_to_home.to_bits()
+            && self.prop_school_time_to_comm.to_bits() == other.prop_school_time_to_comm.to_bits()
+            && match (self.end_time, other.end_time) {
+                (Some(a), Some(b)) => a.to_bits() == b.to_bits(),
+                (None, None) => true,
+                _ => false,
+            }
+            && self.modifier == other.modifier
+    }
+}
+
+impl Eq for SchoolCalendarModifier {}
+
+pub fn init(context: &mut Context) {
+    let Params {
+        school_calendar, ..
+    } = context.get_params().clone();
+    for modifier in school_calendar {
+        let itinerary_modifier = define_school_calendar_itinerary_modifier(&modifier).unwrap();
+        context.register_itinerary_modifier(Student(true), itinerary_modifier);
+    }
+}
+
+fn define_school_calendar_itinerary_modifier(
+    school_calendar_modifier: &SchoolCalendarModifier,
+) -> Result<ItineraryTransitionMatrix, ModelError> {
+    let params = school_calendar_modifier.clone();
+    let matrix = [
         [0.0, 0.0, 0.0, 0.0],
         [0.0, 0.0, 0.0, 0.0],
-        [prop_school_time_to_home, 0.0, 0.0, prop_school_time_to_comm],
+        [
+            params.prop_school_time_to_home,
+            0.0,
+            0.0,
+            params.prop_school_time_to_comm,
+        ],
         [0.0, 0.0, 0.0, 0.0],
     ];
-    let acceptance: AcceptanceFunction = Rc::new(move |context, _person| {
-        context.get_current_time() % 7.0 >= delay && context.get_current_time() % 7.0 <= delay + 2.0
-    });
-    create_itinerary_transition_matrix(Some(weekend_matrix), None, Some(acceptance))
+
+    match params.modifier {
+        SchoolCalendarModifierType::Weekend => {
+            let start_time = params.start_time;
+            let acceptance: AcceptanceFunction = Rc::new(move |context, _person_id| {
+                context.get_current_time() % 7.0 >= start_time
+                    && context.get_current_time() % 7.0 <= start_time + 2.0
+            });
+            Ok(create_itinerary_transition_matrix(
+                Some(matrix),
+                None,
+                Some(acceptance),
+            ))
+        }
+        _ => {
+            let start_time = params.start_time;
+            let end_time = params.end_time;
+            if let Some(end_time) = end_time {
+                let acceptance: AcceptanceFunction = Rc::new(move |context, _person_id| {
+                    context.get_current_time() >= start_time
+                        && context.get_current_time() <= end_time
+                });
+                Ok(create_itinerary_transition_matrix(
+                    Some(matrix),
+                    None,
+                    Some(acceptance),
+                ))
+            } else {
+                Err(ModelError::ModelError(
+                    "end_time must be specified for non-weekend school calendar modifiers"
+                        .to_string(),
+                ))
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -58,7 +153,7 @@ mod test {
 
     use super::*;
     use crate::Age;
-    use crate::parameters::{GlobalParams, Params, SettingProperties, Weekends};
+    use crate::parameters::{GlobalParams, Params, SettingProperties};
     use crate::pop_reader::parser::parse_fips_school_id;
     use crate::setting_code::SettingCode;
     use crate::settings::SettingCategory;
@@ -68,7 +163,7 @@ mod test {
         SettingCode(parse_fips_school_id(school_id).unwrap().1)
     }
 
-    fn setup() -> Context {
+    fn setup(school_calendar_modifier: Vec<SchoolCalendarModifier>) -> Context {
         let mut context = Context::new();
         let parameters = Params {
             // We need to specify an itinerary split here even though we don't draw people from
@@ -90,11 +185,7 @@ mod test {
                 (SettingCategory::Work, 0.25),
                 (SettingCategory::Community, 0.25),
             ]),
-            weekends: Weekends {
-                delay: Some(3.0),
-                prop_school_time_to_home: Some(0.5),
-                prop_school_time_to_comm: Some(0.5),
-            },
+            school_calendar: school_calendar_modifier.clone(),
             ..Default::default()
         };
         context
@@ -105,9 +196,17 @@ mod test {
         context
     }
 
+
+
     #[test]
     fn test_weekend_conditions() {
-        let mut context = setup();
+        let mut context = setup(vec![SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::Weekend,
+            start_time: 3.0,
+            prop_school_time_to_home: 0.5,
+            prop_school_time_to_comm: 0.5,
+            end_time: None,
+        }]);
         let weekend = Rc::new(RefCell::new(0));
         let weekday = Rc::new(RefCell::new(0));
         let school_code = make_school_id(b"16037960200002");
@@ -140,5 +239,110 @@ mod test {
         // weekend ends on day 5, 12, and 19
         assert_eq!(observed_weekend, 9);
         assert_eq!(observed_weekday, 11);
+    }
+
+    #[test]
+    fn test_non_weekend_conditions() {
+        let mut context = setup(vec![SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::SummerBreak,
+            start_time: 3.0,
+            prop_school_time_to_home: 0.5,
+            prop_school_time_to_comm: 0.5,
+            end_time: Some(5.0),
+        }]);
+        let summer_break = Rc::new(RefCell::new(0));
+        let school_days = Rc::new(RefCell::new(0));
+        let school_code = make_school_id(b"16037960200002");
+        let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
+        context.set_property(
+            p1,
+            Itinerary {
+                setting_ids: [None, None, Some(school_code), None],
+                itinerary_ratios: [0.3, 0.0, 0.5, 0.2],
+            },
+        );
+        for i in 0..20 {
+            let summer_break_clone: Rc<RefCell<usize>> = Rc::clone(&summer_break);
+            let school_days_clone: Rc<RefCell<usize>> = Rc::clone(&school_days);
+            context.add_plan(i as f64, move |context| {
+                let itinerary = context.get_itinerary(p1);
+                if itinerary == [0.3, 0.0, 0.5, 0.2] {
+                    *school_days_clone.borrow_mut() += 1;
+                } else if itinerary == [0.55, 0.0, 0.0, 0.45] {
+                    *summer_break_clone.borrow_mut() += 1;
+                }
+            });
+        }
+        context.add_plan_with_phase(20.0, ixa::Context::shutdown, ExecutionPhase::Last);
+        context.execute();
+        #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+        let observed_summer_break = *summer_break.borrow();
+        let observed_school_days = *school_days.borrow();
+        // summer break starts on day 3 and ends on day 5
+        assert_eq!(observed_summer_break, 3);
+        assert_eq!(observed_school_days, 17);
+    }
+
+    #[test]
+    fn test_school_calendar_modifier_validation() {
+        // Test valid modifier
+        let valid_modifier = SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::Weekend,
+            start_time: 1.0,
+            prop_school_time_to_home: 0.5,
+            prop_school_time_to_comm: 0.3,
+            end_time: Some(2.0),
+        };
+        assert!(valid_modifier.validate().is_ok());
+
+        // Test negative start_time
+        let neg_start = SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::Weekend,
+            start_time: -1.0,
+            prop_school_time_to_home: 0.5,
+            prop_school_time_to_comm: 0.3,
+            end_time: None,
+        };
+        assert!(neg_start.validate().is_err());
+
+        // Test end_time < start_time
+        let invalid_end = SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::SummerBreak,
+            start_time: 5.0,
+            prop_school_time_to_home: 0.5,
+            prop_school_time_to_comm: 0.3,
+            end_time: Some(2.0),
+        };
+        assert!(invalid_end.validate().is_err());
+
+        // Test prop_school_time_to_home > 1.0
+        let high_home = SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::HolidayBreak,
+            start_time: 1.0,
+            prop_school_time_to_home: 1.5,
+            prop_school_time_to_comm: 0.3,
+            end_time: None,
+        };
+        assert!(high_home.validate().is_err());
+
+        // Test prop_school_time_to_comm < 0.0
+        let neg_comm = SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::Weekend,
+            start_time: 1.0,
+            prop_school_time_to_home: 0.5,
+            prop_school_time_to_comm: -0.1,
+            end_time: None,
+        };
+        assert!(neg_comm.validate().is_err());
+
+        // Test sum of proportions > 1.0
+        let sum_too_high = SchoolCalendarModifier {
+            modifier: SchoolCalendarModifierType::SummerBreak,
+            start_time: 1.0,
+            prop_school_time_to_home: 0.7,
+            prop_school_time_to_comm: 0.5,
+            end_time: None,
+        };
+        assert!(sum_too_high.validate().is_err());
     }
 }

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -1,12 +1,12 @@
 use ixa::{impl_derived_property, prelude::*};
 use serde::Serialize;
-use std::sync::Arc;
+use std::rc::Rc;
 
 use crate::{
     ContextParametersExt, Params,
     itinerary_manager::ContextItineraryModifierExt,
     itinerary_modifiers::{
-        AcceptanceFunction, ItineraryTransitionMatrix, define_itinerary_modifier,
+        AcceptanceFunction, ItineraryTransitionMatrix, create_itinerary_transition_matrix,
     },
     settings::{Itinerary, Person, SettingCategory},
 };
@@ -45,10 +45,10 @@ fn define_weekend_itinerary_modifier(
         [prop_school_time_to_home, 0.0, 0.0, prop_school_time_to_comm],
         [0.0, 0.0, 0.0, 0.0],
     ];
-    let acceptance: AcceptanceFunction = Arc::new(move |context, _person| {
+    let acceptance: AcceptanceFunction = Rc::new(move |context, _person| {
         context.get_current_time() % 7.0 >= delay && context.get_current_time() % 7.0 <= delay + 2.0
     });
-    define_itinerary_modifier(Some(weekend_matrix), None, Some(acceptance))
+    create_itinerary_transition_matrix(Some(weekend_matrix), None, Some(acceptance))
 }
 
 #[cfg(test)]

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -45,7 +45,7 @@ pub trait ContextCalendarExt:
     ) {
         self.subscribe_to_event(move |context, event: Weekend| {
             if event.active {
-                context.register_itinerary_modifier(GoesToSchool(true), itinerary_modifier);
+                context.register_itinerary_modifier(GoesToSchool(true), itinerary_modifier.clone());
             } else {
                 context.remove_itinerary_modifier_by_property(GoesToSchool(true));
             }
@@ -79,7 +79,7 @@ fn define_weekend_itinerary_modifier(
         [0.0, 0.0, 0.0, 0.0],
     ];
 
-    define_itinerary_modifier(Some(weekend_matrix), None)
+    define_itinerary_modifier(Some(weekend_matrix), None, None)
 }
 
 #[cfg(test)]

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -1,0 +1,42 @@
+use ixa::{
+    ExecutionPhase, impl_derived_property,
+    prelude::*,
+    triggers::{PeriodicTimeTrigger, TriggerCriterion},
+};
+use serde::Serialize;
+
+use crate::{
+    ContextParametersExt, Params,
+    itinerary_modifiers::ItineraryTransitionMatrix,
+    settings::{Itinerary, Person, SettingCategory},
+};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
+pub struct GoesToSchool(pub bool);
+
+impl_derived_property!(GoesToSchool, Person, [Itinerary], [], |itinerary| {
+    GoesToSchool(itinerary.setting_ids[SettingCategory::School].is_some())
+});
+
+pub trait ContextCalendarExt: PluginContext + ContextEntitiesExt + ContextParametersExt {
+    fn add_weekends(
+        &mut self,
+        weekend_itinerary_modifier: ItineraryTransitionMatrix,
+        max_time: f64,
+    ) {
+        let trigger = PeriodicTimeTrigger::every(7.0)
+            .with_phase(ExecutionPhase::Last)
+            .start_with_delay(3.0)
+            .emit_value(Weekend);
+    }
+}
+impl ContextCalendarExt for Context {}
+
+pub fn init(context: &mut Context) {
+    let Params {
+        max_time, weekends, ..
+    } = context.get_params().clone();
+    if let Some(weekends_itinerary_modifier) = weekends.itinerary_modifier {
+        context.add_weekends(weekends_itinerary_modifier, max_time);
+    }
+}

--- a/src/school_calendar.rs
+++ b/src/school_calendar.rs
@@ -1,58 +1,22 @@
-use ixa::{
-    ExecutionPhase, IxaEvent, impl_derived_property,
-    prelude::*,
-    triggers::{ContextTriggersExt, PeriodicTimeTrigger, TriggerCriterion},
-};
+use ixa::{impl_derived_property, prelude::*};
 use serde::Serialize;
+use std::sync::Arc;
 
 use crate::{
     ContextParametersExt, Params,
     itinerary_manager::ContextItineraryModifierExt,
-    itinerary_modifiers::{ItineraryTransitionMatrix, define_itinerary_modifier},
+    itinerary_modifiers::{
+        AcceptanceFunction, ItineraryTransitionMatrix, define_itinerary_modifier,
+    },
     settings::{Itinerary, Person, SettingCategory},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Hash)]
-pub struct GoesToSchool(pub bool);
+pub struct Student(pub bool);
 
-impl_derived_property!(GoesToSchool, Person, [Itinerary], [], |itinerary| {
-    GoesToSchool(itinerary.setting_ids[SettingCategory::School].is_some())
+impl_derived_property!(Student, Person, [Itinerary], [], |itinerary| {
+    Student(itinerary.setting_ids[SettingCategory::School].is_some())
 });
-
-#[derive(IxaEvent)]
-struct Weekend {
-    active: bool,
-}
-
-pub trait ContextCalendarExt:
-    PluginContext + ContextEntitiesExt + ContextParametersExt + ContextTriggersExt
-{
-    fn setup_weekend_triggers(&mut self, delay: f64) {
-        let weekend_start_trigger = PeriodicTimeTrigger::every(7.0)
-            .with_phase(ExecutionPhase::Last)
-            .start_with_delay(delay)
-            .emit_value(Weekend { active: true });
-        let weekend_end_trigger = PeriodicTimeTrigger::every(7.0)
-            .with_phase(ExecutionPhase::Last)
-            .start_with_delay(delay + 2.0)
-            .emit_value(Weekend { active: false });
-        self.register_trigger(weekend_start_trigger);
-        self.register_trigger(weekend_end_trigger);
-    }
-    fn setup_weekend_itinerary_modification(
-        &mut self,
-        itinerary_modifier: ItineraryTransitionMatrix,
-    ) {
-        self.subscribe_to_event(move |context, event: Weekend| {
-            if event.active {
-                context.register_itinerary_modifier(GoesToSchool(true), itinerary_modifier.clone());
-            } else {
-                context.remove_itinerary_modifier_by_property(GoesToSchool(true));
-            }
-        });
-    }
-}
-impl ContextCalendarExt for Context {}
 
 pub fn init(context: &mut Context) {
     let Params { weekends, .. } = context.get_params().clone();
@@ -61,16 +25,19 @@ pub fn init(context: &mut Context) {
         weekends.prop_school_time_to_home,
         weekends.prop_school_time_to_comm,
     ) {
-        context.setup_weekend_triggers(delay);
-        let weekend_modifier =
-            define_weekend_itinerary_modifier(prop_school_time_to_home, prop_school_time_to_comm);
-        context.setup_weekend_itinerary_modification(weekend_modifier);
+        let weekend_modifier = define_weekend_itinerary_modifier(
+            prop_school_time_to_home,
+            prop_school_time_to_comm,
+            delay,
+        );
+        context.register_itinerary_modifier(Student(true), weekend_modifier);
     }
 }
 
 fn define_weekend_itinerary_modifier(
     prop_school_time_to_home: f64,
     prop_school_time_to_comm: f64,
+    delay: f64,
 ) -> ItineraryTransitionMatrix {
     let weekend_matrix = [
         [0.0, 0.0, 0.0, 0.0],
@@ -78,8 +45,10 @@ fn define_weekend_itinerary_modifier(
         [prop_school_time_to_home, 0.0, 0.0, prop_school_time_to_comm],
         [0.0, 0.0, 0.0, 0.0],
     ];
-
-    define_itinerary_modifier(Some(weekend_matrix), None, None)
+    let acceptance: AcceptanceFunction = Arc::new(move |context, _person| {
+        context.get_current_time() % 7.0 >= delay && context.get_current_time() % 7.0 <= delay + 2.0
+    });
+    define_itinerary_modifier(Some(weekend_matrix), None, Some(acceptance))
 }
 
 #[cfg(test)]
@@ -89,11 +58,11 @@ mod test {
 
     use super::*;
     use crate::Age;
-    use crate::parameters::{GlobalParams, Params, SettingProperties};
+    use crate::parameters::{GlobalParams, Params, SettingProperties, Weekends};
     use crate::pop_reader::parser::parse_fips_school_id;
     use crate::setting_code::SettingCode;
     use crate::settings::SettingCategory;
-    use ixa::HashMap;
+    use ixa::{ExecutionPhase, HashMap};
 
     fn make_school_id(school_id: &[u8]) -> SettingCode {
         SettingCode(parse_fips_school_id(school_id).unwrap().1)
@@ -121,51 +90,28 @@ mod test {
                 (SettingCategory::Work, 0.25),
                 (SettingCategory::Community, 0.25),
             ]),
+            weekends: Weekends {
+                delay: Some(3.0),
+                prop_school_time_to_home: Some(0.5),
+                prop_school_time_to_comm: Some(0.5),
+            },
             ..Default::default()
         };
         context
             .set_global_property_value(GlobalParams, parameters)
             .unwrap();
         crate::settings::init(&mut context).unwrap();
+        crate::school_calendar::init(&mut context);
         context
     }
 
     #[test]
-    fn test_weekend_triggers() {
+    fn test_weekend_conditions() {
         let mut context = setup();
-        let weekend_starts = Rc::new(RefCell::new(0));
-        let weekend_starts_clone: Rc<RefCell<usize>> = Rc::clone(&weekend_starts);
-        let weekend_ends = Rc::new(RefCell::new(0));
-        let weekend_ends_clone: Rc<RefCell<usize>> = Rc::clone(&weekend_ends);
-        context.setup_weekend_triggers(3.0);
-        context.subscribe_to_event(move |cxt, event: Weekend| {
-            if event.active {
-                assert_eq!(cxt.get_current_time() % 7.0, 3.0);
-                *weekend_starts_clone.borrow_mut() += 1;
-            } else {
-                assert_eq!(cxt.get_current_time() % 7.0, 5.0);
-                *weekend_ends_clone.borrow_mut() += 1;
-            }
-        });
-        context.add_plan_with_phase(18.0, ixa::Context::shutdown, ExecutionPhase::Last);
-        context.execute();
-        #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
-        let observed_weekend_starts = *weekend_starts.borrow();
-        let observed_weekend_ends = *weekend_ends.borrow();
-        // weekend starts on day 3, 10, and 17
-        // weekend ends on day 5, 12, and 19
-        assert_eq!(observed_weekend_starts, 3);
-        assert_eq!(observed_weekend_ends, 2);
-    }
-
-    #[test]
-    fn test_itinerary_modification_registration() {
-        let mut context = setup();
-        let weekend_modifier = define_weekend_itinerary_modifier(0.5, 0.5);
+        let weekend = Rc::new(RefCell::new(0));
+        let weekday = Rc::new(RefCell::new(0));
         let school_code = make_school_id(b"16037960200002");
         let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
-        // context.register_itinerary_modifier(GoesToSchool(true), weekend_modifier);
-        context.setup_weekend_itinerary_modification(weekend_modifier);
         context.set_property(
             p1,
             Itinerary {
@@ -173,25 +119,63 @@ mod test {
                 itinerary_ratios: [0.3, 0.0, 0.5, 0.2],
             },
         );
-        context.add_plan(1.0, move |context| {
-            context.emit_event(Weekend { active: true });
-        });
-        context.add_plan(2.0, move |context| {
-            context.emit_event(Weekend { active: false });
-        });
-
-        context.add_plan(0.0, move |context| {
-            let itinerary = context.get_itinerary(p1);
-            assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
-        });
-        context.add_plan(1.5, move |context| {
-            let itinerary = context.get_itinerary(p1);
-            assert_eq!(itinerary, [0.55, 0.0, 0.0, 0.45]);
-        });
-        context.add_plan(3.0, move |context| {
-            let itinerary = context.get_itinerary(p1);
-            assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
-        });
+        for i in 0..20 {
+            let weekend_clone: Rc<RefCell<usize>> = Rc::clone(&weekend);
+            let weekday_clone: Rc<RefCell<usize>> = Rc::clone(&weekday);
+            context.add_plan(i as f64, move |context| {
+                let itinerary = context.get_itinerary(p1);
+                if itinerary == [0.3, 0.0, 0.5, 0.2] {
+                    *weekday_clone.borrow_mut() += 1;
+                } else if itinerary == [0.55, 0.0, 0.0, 0.45] {
+                    *weekend_clone.borrow_mut() += 1;
+                }
+            });
+        }
+        context.add_plan_with_phase(20.0, ixa::Context::shutdown, ExecutionPhase::Last);
         context.execute();
+        #[allow(clippy::cast_precision_loss, clippy::cast_lossless)]
+        let observed_weekend = *weekend.borrow();
+        let observed_weekday = *weekday.borrow();
+        // weekend starts on day 3, 10, and 17
+        // weekend ends on day 5, 12, and 19
+        assert_eq!(observed_weekend, 9);
+        assert_eq!(observed_weekday, 11);
     }
+
+    // #[test]
+    // fn test_itinerary_modification_registration() {
+    //     let mut context = setup();
+    //     let weekend_modifier = define_weekend_itinerary_modifier(0.5, 0.5);
+    //     let school_code = make_school_id(b"16037960200002");
+    //     let p1 = context.add_entity(with!(Person, Age(10))).unwrap();
+    //     // context.register_itinerary_modifier(GoesToSchool(true), weekend_modifier);
+    //     context.setup_weekend_itinerary_modification(weekend_modifier);
+    //     context.set_property(
+    //         p1,
+    //         Itinerary {
+    //             setting_ids: [None, None, Some(school_code), None],
+    //             itinerary_ratios: [0.3, 0.0, 0.5, 0.2],
+    //         },
+    //     );
+    //     context.add_plan(1.0, move |context| {
+    //         context.emit_event(Weekend { active: true });
+    //     });
+    //     context.add_plan(2.0, move |context| {
+    //         context.emit_event(Weekend { active: false });
+    //     });
+
+    //     context.add_plan(0.0, move |context| {
+    //         let itinerary = context.get_itinerary(p1);
+    //         assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
+    //     });
+    //     context.add_plan(1.5, move |context| {
+    //         let itinerary = context.get_itinerary(p1);
+    //         assert_eq!(itinerary, [0.55, 0.0, 0.0, 0.45]);
+    //     });
+    //     context.add_plan(3.0, move |context| {
+    //         let itinerary = context.get_itinerary(p1);
+    //         assert_eq!(itinerary, [0.3, 0.0, 0.5, 0.2]);
+    //     });
+    //     context.execute();
+    // }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -353,7 +353,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::itinerary_modifiers::define_itinerary_modifier;
+    use crate::itinerary_modifiers::create_itinerary_transition_matrix;
     use crate::population_loader::{CommunityId, HomeId, SchoolId, WorkId};
     use crate::{
         Age, Params,
@@ -700,7 +700,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
+        let weekend_modifier = create_itinerary_transition_matrix(Some(weekend_matrix), None, None);
 
         context.register_itinerary_modifier(Age(20), weekend_modifier);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -700,7 +700,7 @@ mod test {
             [0.0, 0.0, 0.0, 0.0],
         ];
 
-        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None);
+        let weekend_modifier = define_itinerary_modifier(Some(weekend_matrix), None, None);
 
         context.register_itinerary_modifier(Age(20), weekend_modifier);
 


### PR DESCRIPTION
This PR extends itinerary modifiers to only be applied based on the context and person id. Itinerary modifiers are still stored in a hash map with person property values, but now there is an additional way to filter which ones should be applied. The alleviates potentially complicated processes for registering and deregistering them. 
 
This PR adds a new optional field, `acceptance_function` to the `ItineraryTransitionMatrix`. This field is of type `pub type AcceptanceFunction = Rc<dyn Fn(&Context, PersonId) -> bool>;`. So this function has arguments of `context` and `person_id` and returns a Boolean.  The function is evaluated at the point when itinerary modifier is applied to a base itinerary. If true, the itinerary modifier is applied to the base itinerary. If false, the itinerary modifier is not applied to the base itinerary. 

This new feature is used to implement weekends for students, in the school calendar module.   